### PR TITLE
fix(listen): trust backend mentions array instead of content regex

### DIFF
--- a/ax_cli/commands/listen.py
+++ b/ax_cli/commands/listen.py
@@ -58,7 +58,21 @@ def _iter_sse(response: httpx.Response):
 
 
 def _should_respond(data: dict, agent_name: str, agent_id: str | None) -> bool:
-    """Return True if this message is an @mention for our agent."""
+    """Return True if this message is an @mention for our agent.
+
+    Trusts the backend's authoritative `mentions` array in the event
+    payload. If the backend says this agent is NOT in the mentions list,
+    we do not respond — even if the content text contains "@<agent_name>".
+    That matters because the backend filters disabled / break'd agents
+    out of the mentions list at broadcast time (see AgentControlService
+    enforcement in ax-backend messages_notifications.broadcast_sse), so
+    trusting the list is how this client respects the universal kill
+    switch without duplicating the check. Enforcement belongs at the
+    API boundary; this function's job is to trust what the API publishes.
+
+    Falls back to a content regex only if `mentions` is completely
+    absent from the payload (legacy / non-standard event shapes).
+    """
     if not isinstance(data, dict):
         return False
     content = data.get("content", "")
@@ -79,11 +93,33 @@ def _should_respond(data: dict, agent_name: str, agent_id: str | None) -> bool:
         )
         sender_id = data.get("agent_id") or ""
 
+    # Self-filter: never respond to our own messages, regardless of content.
     if sender.lower() == agent_name.lower():
         return False
     if agent_id and sender_id == agent_id:
         return False
 
+    # Primary path: trust the backend's authoritative mentions list.
+    # An empty list is MEANINGFUL — it means "no active mentions for
+    # this message," which covers the kill-switch filter case where
+    # disabled agents have been removed server-side. Do NOT fall back
+    # to content regex if mentions is present but empty.
+    mentions = data.get("mentions")
+    if mentions is not None and isinstance(mentions, list):
+        agent_name_lower = agent_name.lower()
+        for m in mentions:
+            handle = ""
+            if isinstance(m, str):
+                handle = m
+            elif isinstance(m, dict):
+                handle = m.get("agent_name") or m.get("handle") or m.get("name") or ""
+            if handle.lower().lstrip("@").strip() == agent_name_lower:
+                return True
+        return False
+
+    # Fallback: `mentions` field absent entirely (legacy / non-standard
+    # event shape). Use content regex so we don't silently stop reacting
+    # to payloads that predate the current mentions contract.
     return f"@{agent_name}" in content
 
 


### PR DESCRIPTION
## Summary

Removes a latent bug in \`ax listen\` where \`_should_respond\` matched @mentions via content regex instead of trusting the event payload's \`mentions\` array. That bug had no consequence until ax-backend started filtering disabled agents out of the mentions list at broadcast time (see ax-backend \`d6fb390\` \"feat(notifications): enforce kill switch at mention broadcast boundary\"). Now the regex path bypasses the server-side filter and lets \`ax listen\` respond to messages the backend has explicitly excluded.

This is **not** a kill switch implementation. It removes client-side re-inference in favor of trusting the backend's authoritative list. Enforcement still lives at the API (ax-backend \`broadcast_sse\` → \`AgentControlService\`). This change stops the client from disagreeing with it.

## What changed

\`_should_respond(data, agent_name, agent_id)\`:
- **Primary path:** read \`mentions\` from event data. If present (even as an empty list), trust it absolutely. An empty list means \"no active mentions\" — do not fall back to regex.
- **Fallback:** only if \`mentions\` is completely absent (legacy / non-standard event shapes), use content regex so we don't regress on payloads predating the current mentions contract.
- **Self-filter preserved:** sender check runs before mentions lookup.
- Handles both string and dict entries in the mentions array, strips leading \`@\`, case-insensitive.

## Test plan

- [x] 8 unit tests covering: filtered empty mentions, list with us, list without us, legacy fallback, self-mention, mention-event shape, dict entries, \`@\` prefix stripping — all pass
- [ ] Live E2E after merge: restart \`ping_bot\` with this code, click Break in UI, send \`@ping_bot test\`, verify \`ping_bot\` does NOT reply and backend log shows \`KILL SWITCH FILTER\` line. Then re-enable, send again, verify \`pong\` reply.

## Context

This is the second half of the kill-switch-enforcement-at-the-API fix. First half is ax-backend \`d6fb390\` which makes the backend filter disabled agents out of the mentions list universally. Second half (this PR) is the client trusting that list. Together: one enforcement point at the API, all clients that trust the mentions contract respect it automatically.

Reverted PR #29 added a client-side kill switch check to \`ax listen\`. That was the wrong shape. This PR is the correct shape: fix a client bug that was bypassing the server's authoritative routing.