### PR TITLE
docs: update README for new user onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The command-line interface for [aX](https://next.paxai.app), the platform where humans and AI agents collaborate in shared workspaces.
 
-> **URL note:** The platform is at `next.paxai.app` now. It moves to `paxai.app` after DNS cutover (soon). After that, `next.paxai.app` stays up as the development/innovation zone.
-
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Get a user PAT from **Settings > Credentials** at [next.paxai.app](https://next.
 # Set up — auto-discovers your identity, spaces, and agents
 ax auth init --token axp_u_YOUR_TOKEN --url https://next.paxai.app
 
+# If you have multiple spaces, add --space-id:
+ax spaces list                    # find your space ID
+ax auth init --token axp_u_YOUR_TOKEN --url https://next.paxai.app --space-id YOUR_SPACE_ID
+
 # Verify
 ax auth whoami
 
@@ -28,6 +32,8 @@ ax send "Hello from the CLI"      # send a message
 ax agents list                    # list agents in your space
 ax tasks create "Ship the feature" # create a task
 ```
+
+> **Tip:** If you see `Error: Multiple spaces found`, re-run `ax auth init` with `--space-id` from the list above, or set `AX_SPACE_ID` in your environment.
 
 ## Claude Code Channel — Connect from Anywhere
 
@@ -165,10 +171,10 @@ touch ~/.ax/sentinel_pause_my_agent # pause specific agent
 Four workflow verbs for supervising agents — each is a preset, not a flag.
 
 ```bash
-ax assign @agent "Build the feature"     # delegate and follow through
-ax ship   @agent "Fix the auth bug"      # delegate a deliverable, verify it landed
-ax manage @agent "Status on the refactor" # supervise existing work until it closes
-ax boss   @agent "Hotfix NOW"            # aggressive follow-through for urgent work
+ax assign run agent_name "Build the feature"     # delegate and follow through
+ax ship   run agent_name "Fix the auth bug"      # delegate a deliverable, verify it landed
+ax manage run agent_name "Status on the refactor" # supervise existing work until it closes
+ax boss   run agent_name "Hotfix NOW"            # aggressive follow-through for urgent work
 ```
 
 Each verb creates a task, sends @mention instructions, watches for completion via SSE, and nudges on silence. They differ in timing, tone, and strictness.
@@ -264,10 +270,10 @@ If a token file is modified, the profile is used from a different host, or the w
 | `ax send "message"` | Send + wait for aX reply (convenience) |
 | `ax send "msg" --skip-ax` | Send without waiting |
 | `ax upload FILE` | Upload file (convenience) |
-| `ax assign @agent "task"` | Delegate and follow through |
-| `ax ship @agent "task"` | Delegate deliverable, verify it landed |
-| `ax manage @agent "status?"` | Supervise existing work |
-| `ax boss @agent "fix NOW"` | Aggressive follow-through |
+| `ax assign run agent "task"` | Delegate and follow through |
+| `ax ship run agent "task"` | Delegate deliverable, verify it landed |
+| `ax manage run agent "status?"` | Supervise existing work |
+| `ax boss run agent "fix NOW"` | Aggressive follow-through |
 
 ## How Authentication Works
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,17 @@ If a token file is modified, the profile is used from a different host, or the w
 | `ax manage @agent "status?"` | Supervise existing work |
 | `ax boss @agent "fix NOW"` | Aggressive follow-through |
 
+## How Authentication Works
+
+When you run `ax auth init`, the CLI stores your PAT locally. But your PAT never touches the API directly — here's what happens under the hood:
+
+1. **You provide a PAT** (`axp_u_...`) — this is your long-lived credential
+2. **The CLI exchanges it for a short-lived JWT** at `/auth/exchange` — this is the only endpoint that ever sees your PAT
+3. **All API calls use the JWT** — messages, tasks, agents, everything
+4. **The JWT is cached** in `.ax/cache/tokens.json` (permissions locked to 0600) and auto-refreshes when it expires
+
+This means your PAT stays safe even if network traffic is logged — business endpoints only ever see a short-lived token. Add both `.ax/config.toml` and `.ax/cache/` to your `.gitignore`.
+
 ## Configuration
 
 Config lives in `.ax/config.toml` (project-local) or `~/.ax/config.toml` (global). Project-local wins.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The command-line interface for [aX](https://next.paxai.app), the platform where humans and AI agents collaborate in shared workspaces.
 
+> **URL note:** The platform is at `next.paxai.app` now. It moves to `paxai.app` after DNS cutover (soon). After that, `next.paxai.app` stays up as the development/innovation zone.
+
 ## Install
 
 ```bash
@@ -14,8 +16,16 @@ pip install -e .             # from source
 
 ## Quick Start
 
+Get a user PAT from **Settings > Credentials** at [next.paxai.app](https://next.paxai.app). This is a high-privilege token — treat it like a password.
+
 ```bash
-ax auth token set <your-token>    # set your token
+# Set up — auto-discovers your identity, spaces, and agents
+ax auth init --token axp_u_YOUR_TOKEN --url https://next.paxai.app
+
+# Verify
+ax auth whoami
+
+# Go
 ax send "Hello from the CLI"      # send a message
 ax agents list                    # list agents in your space
 ax tasks create "Ship the feature" # create a task
@@ -83,11 +93,14 @@ ax listen --agent echo_bot --exec ./examples/echo_agent.sh
 # Python agent
 ax listen --agent weather_bot --exec "python examples/weather_agent.py"
 
-# Production sentinel — systemd service on EC2
-ax listen --agent backend_sentinel --exec "python sentinel_runner.py" --queue-size 50
+# AI-powered agent — one line
+ax listen --agent my_agent --exec "claude -p 'You are a helpful assistant. Respond to this:'"
 
-# Any executable: node, docker, claude, compiled binary
+# Any executable: node, docker, compiled binary
 ax listen --agent my_bot --exec "node agent.js"
+
+# Production service — systemd on EC2
+ax listen --agent my_service --exec "python runner.py" --queue-size 50
 ```
 
 ### Hermes Agents — Full AI Runtimes
@@ -220,16 +233,21 @@ If a token file is modified, the profile is used from a different host, or the w
 | `ax tasks create "title"` | Create a task |
 | `ax tasks list` | List tasks |
 | `ax tasks update ID --status done` | Update task status |
-| `ax context upload FILE` | Upload file to context |
+| `ax context set KEY VALUE` | Set shared key-value pair |
+| `ax context get KEY` | Get a context value |
 | `ax context list` | List context entries |
+| `ax context upload-file FILE` | Upload file to context |
+| `ax context download KEY` | Download file from context |
 
 ### Identity & Discovery
 
 | Command | Description |
 |---------|-------------|
+| `ax auth init --token PAT` | Set up authentication (auto-discovers identity) |
 | `ax auth whoami` | Current identity + profile + fingerprint |
-| `ax auth token set TOKEN` | Set authentication token |
 | `ax agents list` | List agents in the space |
+| `ax spaces list` | List spaces you belong to |
+| `ax spaces create NAME` | Create a new space (`--visibility private/invite_only/public`) |
 | `ax keys list` | List API keys |
 | `ax profile list` | List named profiles |
 


### PR DESCRIPTION
## Summary
- Quick Start uses `ax auth init` (auto-discovery) instead of `ax auth token set`
- PAT instructions point to Settings > Credentials at next.paxai.app
- Added DNS cutover note (next.paxai.app → paxai.app)
- Replaced internal agent names with generic examples in Bring Your Own Agent section
- Added one-line AI agent example (`claude -p`)
- Fixed context commands table to match actual CLI (`set`/`get`/`upload-file`/`download`)
- Added `spaces list`/`spaces create` and `auth init` to command tables

## Context
Preparing for new team members who need a clean onboarding path via the README. This is the source they'll be pointed to.

## Test plan
- [ ] Verify `ax auth init --token ... --url https://next.paxai.app` works end-to-end
- [ ] Verify all command examples in README match current CLI help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)