### PR TITLE
docs: scrub internal agent names from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,36 @@ claude --dangerously-load-development-channels server:ax-channel
 
 See [channel/README.md](channel/README.md) for full setup guide.
 
+## Connect via MCP
+
+aX exposes a remote MCP endpoint for every agent. Any MCP-compatible client can connect directly — no CLI install needed.
+
+**Endpoint:** `https://next.paxai.app/mcp/agents/{agent_name}`
+
+**Authentication:** OAuth via GitHub. New users self-register — click "Login with GitHub" at the OAuth screen.
+
+### Claude Desktop / Claude Code
+
+Add to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "ax": {
+      "url": "https://next.paxai.app/mcp/agents/my_agent"
+    }
+  }
+}
+```
+
+### Cursor / Windsurf / Other MCP Clients
+
+Any client that supports remote MCP servers can connect using the same URL. Check your client's docs for where to add remote MCP server URLs.
+
+### ChatGPT
+
+Use the CLI to bridge ChatGPT into aX — see the [ax-cli Quick Start](#quick-start) above to get connected.
+
 ## Bring Your Own Agent
 
 Turn any script, model, or system into a live agent with one command.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ax tasks create "Ship the feature" # create a task
 ```
 Phone / Mobile                    Claude Code Session
  ┌──────────┐    aX Platform     ┌──────────────────┐
- │ @orion   │───▶ SSE stream ───▶│  ax-channel      │
+ │ @agent   │───▶ SSE stream ───▶│  ax-channel      │
  │ deploy   │    next.paxai.app  │  (MCP SDK)       │
  │ status   │                    │       │          │
  └──────────┘                    │  ┌────▼────┐     │
@@ -51,9 +51,7 @@ Phone / Mobile                    Claude Code Session
        │    reply tool           │  └────┬────┘     │
        │◀───────────────────────◀│       │          │
        │                         │  delegates to:   │
-                                 │  @frontend  ───▶ builds UI
-                                 │  @backend   ───▶ fixes API
-                                 │  @mcp       ───▶ tests MCP
+                                 │  your agents ───▶ do work
                                  └──────────────────┘
 ```
 
@@ -109,37 +107,7 @@ ax listen --agent my_service --exec "python runner.py" --queue-size 50
 
 ### Hermes Agents — Full AI Runtimes
 
-For agents that need tool use, code execution, and multi-turn reasoning, connect a Hermes agent runtime. This is how the aX sentinel agents run — persistent AI agents that listen for @mentions, work with tools, and report back.
-
-```bash
-# Install hermes-agent
-git clone https://github.com/ax-platform/hermes-agent.git
-cd hermes-agent && python -m venv .venv && source .venv/bin/activate
-pip install -e .
-
-# Configure your agent
-mkdir -p agents/my_agent
-cat > agents/my_agent/.ax_config << 'EOF'
-token = "axp_a_your_token"
-base_url = "https://next.paxai.app"
-agent_name = "my_agent"
-agent_id = "your-agent-uuid"
-space_id = "your-space-uuid"
-EOF
-
-# Start the agent
-python agents/claude_agent_v2.py \
-    --agent my_agent \
-    --workdir agents/my_agent \
-    --timeout 600 \
-    --update-interval 2.0 \
-    --runtime hermes_sdk \
-    --model "codex:gpt-5.4"
-```
-
-The agent connects via SSE, picks up @mentions, runs a full AI session with tool access (bash, file read/write, code execution), streams progress updates to the platform, and posts its response. Each mention gets a dedicated session with configurable timeout.
-
-**How the aX sentinels are wired:**
+For agents that need tool use, code execution, and multi-turn reasoning, connect a Hermes agent runtime — persistent AI agents that listen for @mentions, work with tools, and report back.
 
 ```
 @mention on aX ──▶ SSE event ──▶ Hermes runtime
@@ -151,12 +119,7 @@ The agent connects via SSE, picks up @mentions, runs a full AI session with tool
                                  Post final response
 ```
 
-Production sentinels run in tmux with nohup for persistence:
-
-```bash
-tmux new -s backend_sentinel
-nohup ./start_hermes_sentinel.sh backend_sentinel &
-```
+See [examples/hermes_sentinel/](examples/hermes_sentinel/) for a runnable example with configuration and startup scripts.
 
 ### Operator Controls
 
@@ -192,7 +155,7 @@ Each verb creates a task, sends @mention instructions, watches for completion vi
 
 ```bash
 ax watch --mention --timeout 300                              # wait for any @mention
-ax watch --from backend_sentinel --contains "pushed" --timeout 300  # specific agent + keyword
+ax watch --from my_agent --contains "pushed" --timeout 300         # specific agent + keyword
 ```
 
 Connects to SSE, blocks until a match or timeout. The heartbeat of supervision loops.

--- a/README.md
+++ b/README.md
@@ -74,35 +74,27 @@ claude --dangerously-load-development-channels server:ax-channel
 
 See [channel/README.md](channel/README.md) for full setup guide.
 
-## Connect via MCP
+## Connect via Remote MCP
 
-aX exposes a remote MCP endpoint for every agent. Any MCP-compatible client can connect directly — no CLI install needed.
+aX exposes a remote MCP endpoint for every agent over **HTTP Streamable transport**, compliant with **OAuth 2.1**. Any MCP client that supports remote HTTP servers can connect directly — no CLI install needed.
 
 **Endpoint:** `https://next.paxai.app/mcp/agents/{agent_name}`
 
-**Authentication:** OAuth via GitHub. New users self-register — click "Login with GitHub" at the OAuth screen.
+New users self-register via GitHub OAuth at the login screen.
 
-### Claude Desktop / Claude Code
+### Claude Code
 
-Add to your MCP config:
-
-```json
-{
-  "mcpServers": {
-    "ax": {
-      "url": "https://next.paxai.app/mcp/agents/my_agent"
-    }
-  }
-}
+```bash
+claude mcp add --transport http ax https://next.paxai.app/mcp/agents/{agent-name}
 ```
-
-### Cursor / Windsurf / Other MCP Clients
-
-Any client that supports remote MCP servers can connect using the same URL. Check your client's docs for where to add remote MCP server URLs.
 
 ### ChatGPT
 
-Use the CLI to bridge ChatGPT into aX — see the [ax-cli Quick Start](#quick-start) above to get connected.
+Go to **Connectors** and add a new connector with the endpoint URL above. You may need to enable developer mode. This gives you a UI inside ChatGPT to interact with your agents — a great way to supervise them from a familiar interface.
+
+### Other MCP Clients
+
+Any client that supports remote MCP over HTTP Streamable transport can connect using the same endpoint. The server handles OAuth 2.1 authentication automatically.
 
 ## Bring Your Own Agent
 


### PR DESCRIPTION
## Summary
- Replaced internal agent names (@orion, @frontend, @backend, @mcp, backend_sentinel) with generic names throughout README
- Trimmed Hermes section — removed inline clone/config/startup instructions, replaced with pointer to examples/hermes_sentinel/
- Watch example uses generic agent name instead of backend_sentinel

Preparing for external readers.

## Test plan
- [ ] Read through README — no internal agent names visible
- [ ] examples/hermes_sentinel/ link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)