### PR TITLE
Fix credential audience option

### DIFF
--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -582,9 +582,16 @@ class AxClient:
         r.raise_for_status()
         return self._parse_json(r)
 
-    def mgmt_issue_agent_pat(self, agent_id: str, *, name: str | None = None, expires_in_days: int = 90) -> dict:
+    def mgmt_issue_agent_pat(
+        self,
+        agent_id: str,
+        *,
+        name: str | None = None,
+        expires_in_days: int = 90,
+        audience: str = "cli",
+    ) -> dict:
         """POST /credentials/agent-pat — requires user_admin + credentials.issue.agent."""
-        body = {"agent_id": agent_id, "expires_in_days": expires_in_days}
+        body = {"agent_id": agent_id, "expires_in_days": expires_in_days, "audience": audience}
         if name:
             body["name"] = name
         r = self._http.post(
@@ -593,9 +600,15 @@ class AxClient:
         r.raise_for_status()
         return self._parse_json(r)
 
-    def mgmt_issue_enrollment(self, *, name: str | None = None, expires_in_hours: int = 1) -> dict:
+    def mgmt_issue_enrollment(
+        self,
+        *,
+        name: str | None = None,
+        expires_in_hours: int = 1,
+        audience: str = "cli",
+    ) -> dict:
         """POST /credentials/enrollment — requires user_admin + credentials.issue.agent."""
-        body = {"expires_in_hours": expires_in_hours}
+        body = {"expires_in_hours": expires_in_hours, "audience": audience}
         if name:
             body["name"] = name
         r = self._http.post(

--- a/ax_cli/commands/credentials.py
+++ b/ax_cli/commands/credentials.py
@@ -49,7 +49,12 @@ def issue_agent_pat(
             handle_error(e)
 
     try:
-        data = client.mgmt_issue_agent_pat(agent_id, name=name, expires_in_days=expires_days)
+        data = client.mgmt_issue_agent_pat(
+            agent_id,
+            name=name,
+            expires_in_days=expires_days,
+            audience=audience,
+        )
     except httpx.HTTPStatusError as e:
         handle_error(e)
 
@@ -80,7 +85,11 @@ def issue_enrollment(
     """
     client = get_client()
     try:
-        data = client.mgmt_issue_enrollment(name=name, expires_in_hours=expires_hours)
+        data = client.mgmt_issue_enrollment(
+            name=name,
+            expires_in_hours=expires_hours,
+            audience=audience,
+        )
     except httpx.HTTPStatusError as e:
         handle_error(e)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 """Tests for AxClient auth and token class selection."""
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from ax_cli.client import AxClient
@@ -63,6 +64,40 @@ class TestTokenClassSelection:
 
         call_body = mock_post.call_args[1]["json"]
         assert call_body["requested_token_class"] == "user_access"
+
+
+class TestCredentialManagement:
+    """Verify credential management request payloads."""
+
+    def test_issue_agent_pat_sends_requested_audience(self):
+        client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")
+        client._admin_headers = MagicMock(return_value={"Authorization": "Bearer admin"})
+        response = httpx.Response(
+            201,
+            json={"ok": True},
+            request=httpx.Request("POST", "https://example.com/credentials/agent-pat"),
+        )
+        client._http.post = MagicMock(return_value=response)
+
+        client.mgmt_issue_agent_pat("agent-123", audience="mcp")
+
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["audience"] == "mcp"
+
+    def test_issue_enrollment_sends_requested_audience(self):
+        client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")
+        client._admin_headers = MagicMock(return_value={"Authorization": "Bearer admin"})
+        response = httpx.Response(
+            201,
+            json={"ok": True},
+            request=httpx.Request("POST", "https://example.com/credentials/enrollment"),
+        )
+        client._http.post = MagicMock(return_value=response)
+
+        client.mgmt_issue_enrollment(audience="both")
+
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["audience"] == "both"
 
     def test_agent_pat_without_agent_id_uses_user_access(self, tmp_path, monkeypatch, mock_exchange):
         """Agent PAT without agent_id falls back to user_access."""


### PR DESCRIPTION
## Summary
- send `--audience` from `ax credentials issue-agent-pat` to `/credentials/agent-pat`
- send `--audience` from `ax credentials issue-enrollment` to `/credentials/enrollment`
- add client tests for both request payloads

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_client.py`

## Context
The CLI exposed `--audience cli|mcp|both`, but the value was not included in the backend request body. This made MCP agent PAT provisioning look successful while creating CLI-only PATs.