### PR TITLE
fix(auth): require agent-bound tokens for channel replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ This is not a chat bridge. Every other channel (Telegram, Discord, iMessage) con
 # Install
 cd channel && bun install
 
-# Configure
-echo "AX_TOKEN=axp_u_..." > ~/.claude/channels/ax-channel/.env
+# Configure with an agent-bound PAT. User PATs are bootstrap credentials only.
+echo "AX_TOKEN=axp_a_..." > ~/.claude/channels/ax-channel/.env
+echo "AX_AGENT_ID=<agent-uuid>" >> ~/.claude/channels/ax-channel/.env
 
 # Run
 claude --dangerously-load-development-channels server:ax-channel

--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -535,6 +535,7 @@ class AxClient:
     def create_key(self, name: str, *, allowed_agent_ids: list[str] | None = None) -> dict:
         body: dict = {"name": name}
         if allowed_agent_ids:
+            body["agent_scope"] = "agents"
             body["allowed_agent_ids"] = allowed_agent_ids
         r = self._http.post("/api/v1/keys", json=body)
         r.raise_for_status()

--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -657,7 +657,8 @@ class AxClient:
         if space_id:
             params["space_id"] = space_id
         return self._http.stream(
-            "GET", "/api/sse/messages",
+            "GET",
+            "/api/sse/messages",
             params=params,
             timeout=timeout or httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0),
         )

--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -191,25 +191,43 @@ class ChannelBridge:
         if not reply_to:
             await self.send_error(request_id, -32602, "reply_to is required until at least one aX message has arrived")
             return
+        if getattr(self.client, "_use_exchange", False) and not str(getattr(self.client, "token", "")).startswith("axp_a_"):
+            await self.send_response(
+                request_id,
+                {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "reply failed: ax channel requires an agent-bound PAT (axp_a_). "
+                                "User PATs may create agent PATs but cannot speak as an agent."
+                            ),
+                        }
+                    ],
+                    "isError": True,
+                },
+            )
+            return
+        if not self.agent_id:
+            await self.send_response(
+                request_id,
+                {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "reply failed: channel agent_id is required for agent runtime replies.",
+                        }
+                    ],
+                    "isError": True,
+                },
+            )
+            return
 
         try:
 
             def _send_as_agent():
-                """Send message as agent, adding X-Agent-Id header for user tokens."""
-                body = {
-                    "content": text,
-                    "space_id": self.space_id,
-                    "channel": "main",
-                    "message_type": "text",
-                    "parent_id": reply_to,
-                }
-                # Build auth headers, then add agent identity
-                headers = self.client._auth_headers()
-                if self.agent_id:
-                    headers["X-Agent-Id"] = self.agent_id
-                r = self.client._http.post("/api/v1/messages", json=body, headers=headers)
-                r.raise_for_status()
-                return self.client._parse_json(r)
+                """Send using the agent_access JWT produced by the agent-bound PAT."""
+                return self.client.send_message(self.space_id, text, parent_id=reply_to)
 
             data = await asyncio.to_thread(_send_as_agent)
             message = data.get("message", data)
@@ -399,7 +417,9 @@ def channel(
         raise typer.Exit(1)
 
     sid = resolve_space_id(client, explicit=space_id)
-    agent_id = _resolve_agent_id(client, agent_name)
+    agent_id = client.agent_id or _resolve_agent_id(client, agent_name)
+    if agent_id and not client.agent_id:
+        client.agent_id = agent_id
     bridge = ChannelBridge(
         client=client,
         agent_name=agent_name,

--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -191,7 +191,9 @@ class ChannelBridge:
         if not reply_to:
             await self.send_error(request_id, -32602, "reply_to is required until at least one aX message has arrived")
             return
-        if getattr(self.client, "_use_exchange", False) and not str(getattr(self.client, "token", "")).startswith("axp_a_"):
+        if getattr(self.client, "_use_exchange", False) and not str(getattr(self.client, "token", "")).startswith(
+            "axp_a_"
+        ):
             await self.send_response(
                 request_id,
                 {

--- a/ax_cli/commands/context.py
+++ b/ax_cli/commands/context.py
@@ -1,7 +1,7 @@
 """ax context — shared context and file upload operations."""
 
-import tempfile
 import os
+import tempfile
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urljoin

--- a/docs/agent-authentication.md
+++ b/docs/agent-authentication.md
@@ -14,7 +14,7 @@ Most users start with Path 1. If you're running multiple agents or using Claude 
 
 ### Step 1: Get your token
 
-Your admin creates a PAT scoped to your agent on the aX platform (Settings > Credentials > Create PAT). They'll give you a token that looks like `axp_u_...`.
+Your admin creates a PAT scoped to your agent on the aX platform (Settings > Credentials > Create PAT). They'll give you a token that looks like `axp_a_...`.
 
 ### Step 2: Install and configure
 
@@ -37,7 +37,7 @@ Profiles add security — token fingerprinting, host binding, workdir verificati
 
 ```bash
 # Save your token to a file
-echo -n 'axp_u_...' > ~/.ax/my_token && chmod 600 ~/.ax/my_token
+echo -n 'axp_a_...' > ~/.ax/my_token && chmod 600 ~/.ax/my_token
 
 # Create a profile
 ax profile add my-agent \
@@ -56,12 +56,11 @@ Now `ax` commands use your profiled identity with fingerprint protection.
 
 ## Path 2: Set Up an Agent Swarm
 
-You have a **user PAT** (sometimes called a swarm token) — a token with `agent_scope: all` that can act as any agent and create new tokens. This is the operator token.
+You have a **user PAT** (sometimes called a bootstrap token) that can create scoped tokens for agents you own or administer. It must not be used as an agent runtime credential.
 
 ### What the user token can do
 
 - Create agent-scoped PATs for individual agents
-- Send messages as any agent you own
 - List and manage all agents in your space
 - View credentials, violations, and platform settings
 
@@ -75,7 +74,7 @@ You have a **user PAT** (sometimes called a swarm token) — a token with `agent
 ### The flow
 
 ```
-User PAT (swarm token)
+User PAT (bootstrap token)
   │
   ├── POST /api/v1/keys → creates agent-scoped PAT for @backend_sentinel
   ├── POST /api/v1/keys → creates agent-scoped PAT for @frontend_sentinel
@@ -146,9 +145,9 @@ ax assign @frontend_sentinel "Add the upload button"
 
 ## Using with Claude Code
 
-If you're using Claude Code to manage your agent swarm, give it the user PAT and point it at the ax-control-plane skill:
+If you're using Claude Code to manage your agent swarm, use the user PAT only for bootstrap work: creating scoped PATs, profiles, and verification. Claude Code channel sessions that speak as an agent must run with that agent's `axp_a_` PAT.
 
-1. Set the token: `ax auth token set <your-swarm-token>`
+1. Set the bootstrap token only for setup: `ax auth token set <your-bootstrap-token>`
 2. Tell Claude Code: "Read the ax-control-plane skill and set up my agent profiles"
 3. Claude Code will use the swarm token to create scoped PATs, set up profiles, and verify everything
 
@@ -162,9 +161,19 @@ The ax-control-plane skill knows how to:
 
 | Type | Scope | Use For | Risk |
 |------|-------|---------|------|
-| **User PAT** (swarm) | All agents | Operator bootstrap, creating scoped tokens | High — full user access |
+| **User PAT** (bootstrap) | User management authority | Operator bootstrap, creating scoped tokens | High — full user access |
 | **Agent-scoped PAT** | One agent | Runtime agent operations | Medium — limited to one agent |
 | **Home agent PAT** | User settings (read) | Platform monitoring (future) | Low — read-only |
+
+## User Experience Tokens
+
+The browser user JWT is the user's experience token. It powers user-owned UI actions:
+
+- Quick-action widgets and panels.
+- Explicit human-in-the-loop approvals.
+- User-approved artifact changes such as creating agents, updating agents, or creating spaces.
+
+It is not an agent runtime credential. Agents use their own agent PAT or agent access JWT. The user experience token can approve an action, but it should not be silently reused by an agent or channel process to speak as that agent.
 
 ## Security Model
 

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,0 +1,68 @@
+"""Tests for the Claude Code channel bridge identity boundary."""
+
+import asyncio
+
+from ax_cli.commands.channel import ChannelBridge
+
+
+class FakeClient:
+    def __init__(self, token: str = "axp_a_AgentKey.Secret", *, agent_id: str = "agent-123"):
+        self.token = token
+        self.agent_id = agent_id
+        self._use_exchange = token.startswith("axp_")
+        self.sent = []
+
+    def send_message(self, space_id, content, *, parent_id=None, **kwargs):
+        self.sent.append({"space_id": space_id, "content": content, "parent_id": parent_id, **kwargs})
+        return {"message": {"id": "msg-123"}}
+
+
+class CaptureBridge(ChannelBridge):
+    def __init__(self, client, *, agent_id="agent-123"):
+        super().__init__(
+            client=client,
+            agent_name="anvil",
+            agent_id=agent_id,
+            space_id="space-123",
+            queue_size=10,
+            debug=False,
+        )
+        self.writes = []
+
+    async def write_message(self, payload):
+        self.writes.append(payload)
+
+
+def test_channel_rejects_user_pat_for_agent_reply():
+    client = FakeClient("axp_u_UserKey.Secret")
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "hello"}},
+        )
+    )
+
+    assert client.sent == []
+    result = bridge.writes[0]["result"]
+    assert result["isError"] is True
+    assert "agent-bound PAT" in result["content"][0]["text"]
+
+
+def test_channel_sends_with_agent_bound_pat():
+    client = FakeClient("axp_a_AgentKey.Secret")
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "hello"}},
+        )
+    )
+
+    assert client.sent == [{"space_id": "space-123", "content": "hello", "parent_id": "incoming-123"}]
+    result = bridge.writes[0]["result"]
+    assert result["content"][0]["text"] == "sent reply to incoming-123 (msg-123)"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -69,6 +69,21 @@ class TestTokenClassSelection:
 class TestCredentialManagement:
     """Verify credential management request payloads."""
 
+    def test_create_key_with_allowed_agents_sets_agent_scope(self):
+        client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")
+        response = httpx.Response(
+            201,
+            json={"ok": True},
+            request=httpx.Request("POST", "https://example.com/api/v1/keys"),
+        )
+        client._http.post = MagicMock(return_value=response)
+
+        client.create_key("agent-key", allowed_agent_ids=["agent-123"])
+
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["agent_scope"] == "agents"
+        assert body["allowed_agent_ids"] == ["agent-123"]
+
     def test_issue_agent_pat_sends_requested_audience(self):
         client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")
         client._admin_headers = MagicMock(return_value={"Authorization": "Bearer admin"})


### PR DESCRIPTION
## Summary
- Send `agent_scope=agents` when creating agent-scoped keys through `ax keys create --scope-to-agent`
- Make `ax channel` reject user PATs for agent runtime replies instead of adding an agent header to a user-auth request
- Update docs to separate user bootstrap tokens, agent runtime PATs, and browser user experience tokens

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_client.py tests/test_channel.py -q`

## Notes
- User PATs remain valid for bootstrap/management: creating agent PATs and profiles.
- Runtime agent sends now require an agent-bound `axp_a_` PAT / agent access JWT.