### PR TITLE
feat(channel): forward attachment metadata in notifications

### DIFF
--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -39,6 +39,7 @@ class MentionEvent:
     raw_content: str
     created_at: str | None
     space_id: str
+    attachments: list[dict[str, Any]] | None = None
 
 
 class ChannelBridge:
@@ -114,21 +115,24 @@ class ChannelBridge:
                 self.log("emit_mentions: initialized done, sending notification")
 
                 self._last_message_id = event.message_id
+                meta: dict[str, Any] = {
+                    "chat_id": event.space_id,
+                    "message_id": event.message_id,
+                    "parent_id": event.parent_id,
+                    "user": event.author,
+                    "sender": event.author,
+                    "source": "ax",
+                    "space_id": event.space_id,
+                    "ts": event.created_at,
+                    "raw_content": event.raw_content,
+                }
+                if event.attachments:
+                    meta["attachments"] = event.attachments
                 await self.send_notification(
                     "notifications/claude/channel",
                     {
                         "content": event.prompt,
-                        "meta": {
-                            "chat_id": event.space_id,
-                            "message_id": event.message_id,
-                            "parent_id": event.parent_id,
-                            "user": event.author,
-                            "sender": event.author,
-                            "source": "ax",
-                            "space_id": event.space_id,
-                            "ts": event.created_at,
-                            "raw_content": event.raw_content,
-                        },
+                        "meta": meta,
                     },
                 )
                 self.log(f"delivered mention {event.message_id} from {event.author}")
@@ -361,6 +365,22 @@ def _sse_loop(bridge: ChannelBridge) -> None:
                             or data.get("sender_name")
                             or (author_raw if isinstance(author_raw, str) else "unknown")
                         )
+
+                    # Extract attachment metadata from the message.
+                    # The backend includes attachments in metadata.attachments
+                    # (and sometimes at the top level for SSE events).
+                    attachments = None
+                    msg_metadata = data.get("metadata") or {}
+                    if isinstance(msg_metadata, dict):
+                        raw_attachments = msg_metadata.get("attachments") or msg_metadata.get("accepted_attachments")
+                        if raw_attachments and isinstance(raw_attachments, list):
+                            attachments = raw_attachments
+                    # Fallback: some SSE event shapes put attachments at top level
+                    if not attachments:
+                        raw_top = data.get("attachments")
+                        if raw_top and isinstance(raw_top, list):
+                            attachments = raw_top
+
                     bridge.enqueue_from_thread(
                         MentionEvent(
                             message_id=message_id,
@@ -370,6 +390,7 @@ def _sse_loop(bridge: ChannelBridge) -> None:
                             raw_content=data.get("content", ""),
                             created_at=data.get("created_at"),
                             space_id=bridge.space_id,
+                            attachments=attachments,
                         )
                     )
         except (httpx.ConnectError, httpx.ReadTimeout, ConnectionError) as exc:


### PR DESCRIPTION
## Summary
- Channel bridge now extracts attachment metadata from SSE message events and includes it in `notifications/claude/channel` as `meta.attachments`
- Agents receiving messages via the channel bridge can now see when images/files are attached and retrieve them via `ax context download <context_key>`
- Extracts from `metadata.attachments`, `metadata.accepted_attachments`, or top-level `attachments` field (covers all SSE event shapes)

## What this enables
When a user sends `@orion check this screenshot` with an image attached, the channel notification now includes:
```json
{
  "meta": {
    "attachments": [
      {
        "id": "...",
        "filename": "image.png",
        "content_type": "image/png",
        "size_bytes": 223522,
        "url": "/api/v1/uploads/files/...",
        "context_key": "upload:..."
      }
    ]
  }
}
```

Previously the bridge only forwarded text content — attachments were silently dropped.

## Test plan
- [ ] Send a message with image attachment via the frontend while channel bridge is running
- [ ] Verify the notification includes `meta.attachments` with correct metadata
- [ ] Verify `ax context download <context_key>` retrieves the file
- [ ] Verify messages without attachments still work (no `meta.attachments` field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)