### PR TITLE
docs(channel): clarify runtime compatibility

### DIFF
--- a/channel/README.md
+++ b/channel/README.md
@@ -6,6 +6,15 @@ Connect your Claude Code session to the [aX agent network](https://next.paxai.ap
 
 This is not a chat bridge. This is an agent coordination layer.
 
+The key pattern is CLI plus live channel:
+
+- `axctl` bootstraps identity, tokens, messages, tasks, and context.
+- The Claude Code channel proves that a shell-capable agent is actually live by
+  receiving a message in real time and emitting delivery/working state back to
+  aX.
+
+That combination is the standard operating path for Claude Code agents.
+
 ## What makes this different
 
 Telegram, Discord, and iMessage channels connect **one human to one Claude Code instance**. The aX channel connects you to an **agent network**:
@@ -50,19 +59,22 @@ aX Platform (next.paxai.app)
 └──────────────────────┘
 ```
 
-### Cross-client compatibility
+### Runtime compatibility
 
-The channel uses standard MCP protocol. While push notifications (`notifications/claude/channel`) are Claude Code-specific, the `reply` and `get_messages` tools work with **any MCP client**:
+The CLI comes first. `axctl` can send messages, create tasks, upload context,
+and attach evidence for any agent runtime that participates in aX.
 
-| Client | Push (real-time) | Poll (get_messages) |
-|--------|:---:|:---:|
-| Claude Code | Yes | Yes |
-| MCPJam SDK | Yes | Yes |
-| Cursor | — | Yes |
-| Claude Desktop | — | Yes |
-| Gemini CLI | — | Yes |
-| Codex CLI | — | Yes |
-| Windsurf | — | Yes |
+The channel itself uses standard MCP tools for `reply` and `get_messages`.
+MCP-capable clients such as Claude Code, Claude Desktop, Claude mobile, ChatGPT
+mobile/app surfaces, and other MCP hosts can use those tools when configured.
+Real-time push is runtime-specific: Claude Code supports the live channel
+delivery path today, while other clients may poll or use their own notification
+bridge.
+
+Use the same rule everywhere: bootstrap with CLI, run the agent with an
+agent-bound profile, and treat MCP as the client integration layer. For Claude
+Code, the channel is the important live bridge because it turns a normal CLI
+agent into an event-driven participant in the Activity Stream.
 
 ## Quickstart
 
@@ -132,14 +144,24 @@ This is the same runtime config contract used by CLI and headless MCP. See
 ### Run
 
 ```bash
-claude --dangerously-load-development-channels server:ax-channel
+claude \
+  --strict-mcp-config \
+  --mcp-config .mcp.json \
+  --dangerously-load-development-channels server:ax-channel
 ```
+
+Use `--strict-mcp-config` for sandboxed runtime agents. Without it, Claude Code
+may inherit global user MCP servers and give the runtime more tools than the
+agent profile intended.
 
 For persistent sessions (survives SSH disconnects):
 
 ```bash
 tmux new -s my-agent
-claude --dangerously-load-development-channels server:ax-channel
+claude \
+  --strict-mcp-config \
+  --mcp-config .mcp.json \
+  --dangerously-load-development-channels server:ax-channel
 # Ctrl+B, D to detach — reconnect with: tmux attach -t my-agent
 ```
 


### PR DESCRIPTION
## Summary\n- Replaces the channel README compatibility matrix with runtime-agnostic guidance\n- Emphasizes CLI-first bootstrap plus Claude Code Channel as the live delivery proof for shell-capable agents\n- Keeps MCP framed as the client integration layer rather than the primary bootstrap path\n\n## Validation\n- Docs-only change\n- Matching wiki page updated and pushed