### PR TITLE
agents: avatar-day bundle — set via PUT, --avatar-url/-file, config line

### DIFF
--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -68,6 +68,7 @@ def _check_avatar_url_length(avatar_url: str) -> None:
         )
         raise typer.Exit(1)
 
+
 app = typer.Typer(name="agents", help="Agent management", no_args_is_help=True)
 
 
@@ -473,8 +474,7 @@ def update_agent(
     avatar_file: str = typer.Option(
         None,
         "--avatar-file",
-        help="Read avatar from a file (svg/png/jpg/gif/webp) and set it. "
-        "Mutually exclusive with --avatar-url.",
+        help="Read avatar from a file (svg/png/jpg/gif/webp) and set it. Mutually exclusive with --avatar-url.",
     ),
     as_json: bool = JSON_OPTION,
 ):
@@ -519,8 +519,7 @@ def update_agent(
 
     if not fields:
         typer.echo(
-            "Nothing to update. Use --type, --model, --bio, --description, "
-            "--status, --avatar-url, --avatar-file, etc.",
+            "Nothing to update. Use --type, --model, --bio, --description, --status, --avatar-url, --avatar-file, etc.",
             err=True,
         )
         raise typer.Exit(1)

--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -17,7 +17,7 @@ from ..config import (
     resolve_base_url,
     resolve_space_id,
 )
-from ..output import JSON_OPTION, console, handle_error, print_json, print_kv, print_table
+from ..output import JSON_OPTION, console, err_console, handle_error, print_json, print_kv, print_table
 from .handoff import _wait_for_handoff_reply
 
 # Backend caps avatar_url at 512 chars (see ax-backend app/api/v1/agents.py
@@ -29,16 +29,23 @@ AVATAR_URL_MAX_LENGTH = 512
 def _effective_config_line() -> str:
     """One-liner describing the resolved environment, for mutating commands.
 
-    Printed to stderr before any write so operators can eyeball that they're
-    targeting the right environment. Addresses the common footgun where
-    ~/.ax/users/.active silently overrides AX_BASE_URL (see
-    shared/state/axctl-friction-2026-04-17.md §2).
+    Returned as a string so tests can assert on the format. Callers should
+    emit it via :func:`_print_effective_config_line` (which routes to
+    stderr) so the preamble never contaminates ``--json`` stdout or any
+    piped consumer of the command's output. See
+    shared/state/axctl-friction-2026-04-17.md §2.
     """
     base_url = resolve_base_url()
     user_env = _resolve_user_env() or "default"
     user_cfg_path = _user_config_path()
     source = str(user_cfg_path) if user_cfg_path.exists() else "(none)"
     return f"[dim]base_url={base_url}  user_env={user_env}  source={source}[/dim]"
+
+
+def _print_effective_config_line() -> None:
+    """Print the effective-config preamble to **stderr** so stdout stays
+    clean for ``--json`` parsers and pipe consumers."""
+    err_console.print(_effective_config_line())
 
 
 def _build_avatar_data_uri_from_file(path: str) -> str:
@@ -496,7 +503,7 @@ def update_agent(
     if avatar_url is not None:
         _check_avatar_url_length(avatar_url)
 
-    console.print(_effective_config_line())
+    _print_effective_config_line()
 
     client = get_client()
     fields = {}
@@ -623,7 +630,7 @@ def avatar(
         client = get_client()
         data_uri = avatar_data_uri(agent, agent_type, size)
         _check_avatar_url_length(data_uri)
-        console.print(_effective_config_line())
+        _print_effective_config_line()
         try:
             # Find the agent by name
             agents_data = client.list_agents()

--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -1,15 +1,72 @@
 """ax agents — agent listing, creation, and management."""
 
+import base64
 import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import (
+    _resolve_user_env,
+    _user_config_path,
+    get_client,
+    resolve_agent_name,
+    resolve_base_url,
+    resolve_space_id,
+)
 from ..output import JSON_OPTION, console, handle_error, print_json, print_kv, print_table
 from .handoff import _wait_for_handoff_reply
+
+# Backend caps avatar_url at 512 chars (see ax-backend app/api/v1/agents.py
+# `AgentCreate.avatar_url: Field(max_length=512)`). Anything longer is silently
+# rejected as a 500, so the CLI fails fast with a helpful message instead.
+AVATAR_URL_MAX_LENGTH = 512
+
+
+def _effective_config_line() -> str:
+    """One-liner describing the resolved environment, for mutating commands.
+
+    Printed to stderr before any write so operators can eyeball that they're
+    targeting the right environment. Addresses the common footgun where
+    ~/.ax/users/.active silently overrides AX_BASE_URL (see
+    shared/state/axctl-friction-2026-04-17.md §2).
+    """
+    base_url = resolve_base_url()
+    user_env = _resolve_user_env() or "default"
+    user_cfg_path = _user_config_path()
+    source = str(user_cfg_path) if user_cfg_path.exists() else "(none)"
+    return f"[dim]base_url={base_url}  user_env={user_env}  source={source}[/dim]"
+
+
+def _build_avatar_data_uri_from_file(path: str) -> str:
+    """Read an SVG/image file and return a base64 data URI."""
+    data = Path(path).read_bytes()
+    suffix = Path(path).suffix.lower().lstrip(".")
+    mime_map = {
+        "svg": "image/svg+xml",
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "webp": "image/webp",
+    }
+    mime = mime_map.get(suffix, "application/octet-stream")
+    return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+
+def _check_avatar_url_length(avatar_url: str) -> None:
+    """Fail fast with a helpful message if avatar_url exceeds the backend cap."""
+    if len(avatar_url) > AVATAR_URL_MAX_LENGTH:
+        console.print(
+            f"[red]avatar_url is {len(avatar_url)} chars; backend caps at "
+            f"{AVATAR_URL_MAX_LENGTH}.[/red] Shrink the SVG or host it and pass "
+            f"an https:// URL. A raw base64 SVG must be ≤ "
+            f"~{int(AVATAR_URL_MAX_LENGTH * 0.7)} bytes before encoding."
+        )
+        raise typer.Exit(1)
 
 app = typer.Typer(name="agents", help="Agent management", no_args_is_help=True)
 
@@ -408,6 +465,17 @@ def update_agent(
     bio: str = typer.Option(None, "--bio", "-b", help="Short bio"),
     specialization: str = typer.Option(None, "--specialization", "-s", help="Specialization area"),
     status: str = typer.Option(None, "--status", help="active or inactive"),
+    avatar_url: str = typer.Option(
+        None,
+        "--avatar-url",
+        help="Set agent avatar (data URI or https URL). ≤ 512 chars.",
+    ),
+    avatar_file: str = typer.Option(
+        None,
+        "--avatar-file",
+        help="Read avatar from a file (svg/png/jpg/gif/webp) and set it. "
+        "Mutually exclusive with --avatar-url.",
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Update an agent's metadata.
@@ -415,7 +483,21 @@ def update_agent(
     Examples:
         ax agents update backend_sentinel --type sentinel --model claude-sonnet-4-6
         ax agents update anvil --bio "Infra and ops" --specialization "server management"
+        ax agents update axolotl --avatar-file notes/axolotl.svg
+        ax agents update axolotl --avatar-url "data:image/svg+xml;base64,..."
     """
+    if avatar_url is not None and avatar_file is not None:
+        console.print("[red]--avatar-url and --avatar-file are mutually exclusive.[/red]")
+        raise typer.Exit(1)
+
+    if avatar_file is not None:
+        avatar_url = _build_avatar_data_uri_from_file(avatar_file)
+
+    if avatar_url is not None:
+        _check_avatar_url_length(avatar_url)
+
+    console.print(_effective_config_line())
+
     client = get_client()
     fields = {}
     if description is not None:
@@ -432,9 +514,15 @@ def update_agent(
         fields["specialization"] = specialization
     if status is not None:
         fields["status"] = status
+    if avatar_url is not None:
+        fields["avatar_url"] = avatar_url
 
     if not fields:
-        typer.echo("Nothing to update. Use --type, --model, --bio, --description, --status, etc.", err=True)
+        typer.echo(
+            "Nothing to update. Use --type, --model, --bio, --description, "
+            "--status, --avatar-url, --avatar-file, etc.",
+            err=True,
+        )
         raise typer.Exit(1)
 
     try:
@@ -535,6 +623,8 @@ def avatar(
     elif set_avatar:
         client = get_client()
         data_uri = avatar_data_uri(agent, agent_type, size)
+        _check_avatar_url_length(data_uri)
+        console.print(_effective_config_line())
         try:
             # Find the agent by name
             agents_data = client.list_agents()
@@ -543,8 +633,10 @@ def avatar(
             if not target:
                 console.print(f"[red]Agent '{agent}' not found[/red]")
                 raise typer.Exit(1)
-            # Update avatar_url
-            r = client._http.patch(f"/api/v1/agents/{target['id']}", json={"avatar_url": data_uri})
+            # Update avatar_url. Use PUT — the ALB on prod proxies PUT/GET/POST
+            # but not PATCH on /api/v1/agents/{id} (see friction-2026-04-17 §7).
+            # The backend PUT handler accepts avatar_url the same way PATCH does.
+            r = client._http.put(f"/api/v1/agents/{target['id']}", json={"avatar_url": data_uri})
             r.raise_for_status()
             console.print(f"[green]Avatar set for @{agent}[/green]")
         except httpx.HTTPStatusError as e:

--- a/ax_cli/output.py
+++ b/ax_cli/output.py
@@ -8,6 +8,9 @@ from rich.console import Console
 from rich.table import Table
 
 console = Console()
+# Dedicated stderr console for status/log lines that mustn't pollute stdout
+# (e.g. when the caller parses --json output or pipes the command).
+err_console = Console(stderr=True)
 
 JSON_OPTION = typer.Option(False, "--json", help="Output as JSON")
 SPACE_OPTION = typer.Option(None, "--space-id", help="Override default space")

--- a/tests/test_avatar_day.py
+++ b/tests/test_avatar_day.py
@@ -154,9 +154,7 @@ def test_update_avatar_file_rejected_over_cap(monkeypatch, tmp_path):
 
 
 def test_avatar_set_uses_put_not_patch(monkeypatch):
-    http = _RecordingHttp(
-        status_code=200, response_json={"id": "agent-1", "name": "axolotl"}
-    )
+    http = _RecordingHttp(status_code=200, response_json={"id": "agent-1", "name": "axolotl"})
     fake = _FakeClient(http)
     monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
 
@@ -189,14 +187,10 @@ def test_avatar_set_rejects_oversized_uri(monkeypatch):
     fake = _FakeClient(http)
     monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
 
-    monkeypatch.setattr(
-        "ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>"
-    )
+    monkeypatch.setattr("ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>")
     # Intentionally produce an over-cap data URI
     oversized = "data:image/svg+xml;base64," + ("A" * (AVATAR_URL_MAX_LENGTH + 1))
-    monkeypatch.setattr(
-        "ax_cli.avatar.avatar_data_uri", lambda *a, **k: oversized
-    )
+    monkeypatch.setattr("ax_cli.avatar.avatar_data_uri", lambda *a, **k: oversized)
 
     result = runner.invoke(app, ["agents", "avatar", "axolotl", "--set"])
     assert result.exit_code == 1, result.output
@@ -226,14 +220,10 @@ def test_update_prints_effective_config(monkeypatch):
 
 
 def test_avatar_set_prints_effective_config(monkeypatch):
-    http = _RecordingHttp(
-        status_code=200, response_json={"id": "agent-1", "name": "axolotl"}
-    )
+    http = _RecordingHttp(status_code=200, response_json={"id": "agent-1", "name": "axolotl"})
     fake = _FakeClient(http)
     monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
-    monkeypatch.setattr(
-        "ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>"
-    )
+    monkeypatch.setattr("ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>")
     small = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
     monkeypatch.setattr("ax_cli.avatar.avatar_data_uri", lambda *a, **k: small)
 

--- a/tests/test_avatar_day.py
+++ b/tests/test_avatar_day.py
@@ -19,7 +19,11 @@ from ax_cli.commands.agents import (
 )
 from ax_cli.main import app
 
+# Click 8.3+ always separates stdout/stderr on CliRunner.Result. We assert
+# on result.stderr for the effective-config-line tests so the preamble
+# is proved to NOT leak into stdout (which --json consumers / pipes read).
 runner = CliRunner()
+split_runner = runner
 
 
 # ── helpers ─────────────────────────────────────────────────────────────────
@@ -209,17 +213,23 @@ def test_effective_config_line_format():
     assert "source=" in line
 
 
-def test_update_prints_effective_config(monkeypatch):
+def test_update_prints_effective_config_to_stderr(monkeypatch):
+    """The config preamble MUST land on stderr so --json consumers and
+    pipes don't see it. See friction §2 + PR #65 review."""
     fake = _FakeClient(_RecordingHttp())
     monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
 
-    result = runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi"])
-    assert result.exit_code == 0, result.output
-    assert "base_url=" in result.output
-    assert "user_env=" in result.output
+    result = split_runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi"])
+    assert result.exit_code == 0, result.stderr
+    assert "base_url=" in result.stderr
+    assert "user_env=" in result.stderr
+    # Critical: the preamble must NOT leak into stdout
+    assert "base_url=" not in result.stdout
+    assert "user_env=" not in result.stdout
 
 
-def test_avatar_set_prints_effective_config(monkeypatch):
+def test_avatar_set_prints_effective_config_to_stderr(monkeypatch):
+    """Same stderr invariant for `ax agents avatar --set`."""
     http = _RecordingHttp(status_code=200, response_json={"id": "agent-1", "name": "axolotl"})
     fake = _FakeClient(http)
     monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
@@ -227,6 +237,24 @@ def test_avatar_set_prints_effective_config(monkeypatch):
     small = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
     monkeypatch.setattr("ax_cli.avatar.avatar_data_uri", lambda *a, **k: small)
 
-    result = runner.invoke(app, ["agents", "avatar", "axolotl", "--set"])
-    assert result.exit_code == 0, result.output
-    assert "base_url=" in result.output
+    result = split_runner.invoke(app, ["agents", "avatar", "axolotl", "--set"])
+    assert result.exit_code == 0, result.stderr
+    assert "base_url=" in result.stderr
+    assert "base_url=" not in result.stdout
+
+
+def test_update_json_stdout_is_clean_of_config_preamble(monkeypatch):
+    """With --json, stdout must be parseable as JSON alone — the preamble
+    must stay on stderr."""
+    import json as _json
+
+    fake = _FakeClient(_RecordingHttp())
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    result = split_runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi", "--json"])
+    assert result.exit_code == 0, result.stderr
+    # stdout should be parseable as JSON with no preamble contamination
+    parsed = _json.loads(result.stdout)
+    assert parsed["name"] == "axolotl"
+    assert parsed["bio"] == "hi"
+    assert "base_url=" in result.stderr

--- a/tests/test_avatar_day.py
+++ b/tests/test_avatar_day.py
@@ -1,0 +1,242 @@
+"""Tests for the 'avatar day' fixes — see shared/state/axctl-friction-2026-04-17.md
+sections 7, 9, 10, 11, and 2 (effective-config printer)."""
+
+from __future__ import annotations
+
+import base64
+
+import click
+import httpx
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from ax_cli.commands import agents as agents_cmd
+from ax_cli.commands.agents import (
+    AVATAR_URL_MAX_LENGTH,
+    _build_avatar_data_uri_from_file,
+    _check_avatar_url_length,
+)
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+class _RecordingHttp:
+    """Minimal httpx.Client stand-in that records method+url+json."""
+
+    def __init__(self, status_code: int = 200, response_json: dict | None = None):
+        self.calls: list[dict] = []
+        self._status_code = status_code
+        self._response_json = response_json or {}
+
+    def _make_response(self) -> httpx.Response:
+        request = httpx.Request("PUT", "http://test.local/")
+        return httpx.Response(self._status_code, json=self._response_json, request=request)
+
+    def put(self, url: str, json=None, **kwargs):
+        self.calls.append({"method": "PUT", "url": url, "json": json})
+        return self._make_response()
+
+    def patch(self, url: str, json=None, **kwargs):
+        self.calls.append({"method": "PATCH", "url": url, "json": json})
+        return self._make_response()
+
+
+class _FakeClient:
+    def __init__(self, http: _RecordingHttp):
+        self._http = http
+        self.updated = None
+
+    def list_agents(self, *, space_id=None, limit=None):
+        return {"agents": [{"id": "agent-1", "name": "axolotl"}]}
+
+    def update_agent(self, identifier, **fields):
+        self.updated = {"identifier": identifier, **fields}
+        return {"id": "agent-1", "name": identifier, **fields}
+
+
+# ── #9 — avatar_url length cap is enforced client-side ─────────────────────
+
+
+def test_avatar_url_length_ok_under_cap():
+    # Should not raise for a URL at exactly the cap
+    _check_avatar_url_length("x" * AVATAR_URL_MAX_LENGTH)
+
+
+def test_avatar_url_length_rejected_over_cap():
+    long = "x" * (AVATAR_URL_MAX_LENGTH + 1)
+    with pytest.raises((typer.Exit, click.exceptions.Exit)) as exc:
+        _check_avatar_url_length(long)
+    # Both typer.Exit and click.exceptions.Exit expose .exit_code
+    assert getattr(exc.value, "exit_code", getattr(exc.value, "code", None)) == 1
+
+
+# ── #10 — `--avatar-file` encodes & wires through update_agent ─────────────
+
+
+def test_build_avatar_data_uri_from_file_svg(tmp_path):
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg"/>'
+    f = tmp_path / "tiny.svg"
+    f.write_bytes(svg)
+    uri = _build_avatar_data_uri_from_file(str(f))
+    assert uri.startswith("data:image/svg+xml;base64,")
+    assert base64.b64decode(uri.split(",", 1)[1]) == svg
+
+
+def test_build_avatar_data_uri_from_file_png(tmp_path):
+    f = tmp_path / "tiny.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n")
+    uri = _build_avatar_data_uri_from_file(str(f))
+    assert uri.startswith("data:image/png;base64,")
+
+
+def test_update_avatar_url_flag_passes_through(monkeypatch, tmp_path):
+    fake = _FakeClient(_RecordingHttp())
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    small_uri = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
+    assert len(small_uri) <= AVATAR_URL_MAX_LENGTH
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--avatar-url", small_uri])
+    assert result.exit_code == 0, result.output
+    assert fake.updated == {"identifier": "axolotl", "avatar_url": small_uri}
+
+
+def test_update_avatar_file_flag_reads_and_encodes(monkeypatch, tmp_path):
+    fake = _FakeClient(_RecordingHttp())
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg"/>'
+    f = tmp_path / "a.svg"
+    f.write_bytes(svg)
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--avatar-file", str(f)])
+    assert result.exit_code == 0, result.output
+    assert fake.updated["identifier"] == "axolotl"
+    assert fake.updated["avatar_url"].startswith("data:image/svg+xml;base64,")
+
+
+def test_update_avatar_mutually_exclusive(monkeypatch):
+    result = runner.invoke(
+        app,
+        [
+            "agents",
+            "update",
+            "axolotl",
+            "--avatar-url",
+            "data:image/svg+xml;base64,X",
+            "--avatar-file",
+            "/tmp/x.svg",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_update_avatar_file_rejected_over_cap(monkeypatch, tmp_path):
+    fake = _FakeClient(_RecordingHttp())
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    big = tmp_path / "big.svg"
+    big.write_bytes(b"x" * 4096)  # > cap when encoded
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--avatar-file", str(big)])
+    assert result.exit_code == 1, result.output
+    assert "backend caps at" in result.output
+    assert fake.updated is None, "update_agent must not be called if cap is exceeded"
+
+
+# ── #7 — `agents avatar --set` uses PUT, not PATCH ─────────────────────────
+
+
+def test_avatar_set_uses_put_not_patch(monkeypatch):
+    http = _RecordingHttp(
+        status_code=200, response_json={"id": "agent-1", "name": "axolotl"}
+    )
+    fake = _FakeClient(http)
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    # Provide a tiny in-process avatar generator to avoid drawing a real SVG
+    tiny_svg = b"<svg/>"
+    tiny_data_uri = "data:image/svg+xml;base64," + base64.b64encode(tiny_svg).decode()
+
+    def _fake_generate(agent, agent_type, size):
+        return tiny_svg.decode()
+
+    def _fake_data_uri(agent, agent_type, size):
+        return tiny_data_uri
+
+    monkeypatch.setattr("ax_cli.avatar.generate_avatar", _fake_generate)
+    monkeypatch.setattr("ax_cli.avatar.avatar_data_uri", _fake_data_uri)
+
+    result = runner.invoke(app, ["agents", "avatar", "axolotl", "--set"])
+    assert result.exit_code == 0, result.output
+
+    # Exactly one call, and it's a PUT
+    assert len(http.calls) == 1, http.calls
+    call = http.calls[0]
+    assert call["method"] == "PUT", f"must use PUT, got {call['method']}"
+    assert call["url"] == "/api/v1/agents/agent-1"
+    assert call["json"] == {"avatar_url": tiny_data_uri}
+
+
+def test_avatar_set_rejects_oversized_uri(monkeypatch):
+    http = _RecordingHttp()
+    fake = _FakeClient(http)
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    monkeypatch.setattr(
+        "ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>"
+    )
+    # Intentionally produce an over-cap data URI
+    oversized = "data:image/svg+xml;base64," + ("A" * (AVATAR_URL_MAX_LENGTH + 1))
+    monkeypatch.setattr(
+        "ax_cli.avatar.avatar_data_uri", lambda *a, **k: oversized
+    )
+
+    result = runner.invoke(app, ["agents", "avatar", "axolotl", "--set"])
+    assert result.exit_code == 1, result.output
+    assert "backend caps at" in result.output
+    assert http.calls == [], "no HTTP call should be made when cap is exceeded"
+
+
+# ── #2 — effective-config line is printed by mutating commands ─────────────
+
+
+def test_effective_config_line_format():
+    line = agents_cmd._effective_config_line()
+    # Stripped of Rich markup for simplicity of assertion
+    assert "base_url=" in line
+    assert "user_env=" in line
+    assert "source=" in line
+
+
+def test_update_prints_effective_config(monkeypatch):
+    fake = _FakeClient(_RecordingHttp())
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi"])
+    assert result.exit_code == 0, result.output
+    assert "base_url=" in result.output
+    assert "user_env=" in result.output
+
+
+def test_avatar_set_prints_effective_config(monkeypatch):
+    http = _RecordingHttp(
+        status_code=200, response_json={"id": "agent-1", "name": "axolotl"}
+    )
+    fake = _FakeClient(http)
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(
+        "ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>"
+    )
+    small = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
+    monkeypatch.setattr("ax_cli.avatar.avatar_data_uri", lambda *a, **k: small)
+
+    result = runner.invoke(app, ["agents", "avatar", "axolotl", "--set"])
+    assert result.exit_code == 0, result.output
+    assert "base_url=" in result.output


### PR DESCRIPTION
## Summary

Four paper-cuts the team hit while bootstrapping `@axolotl` in `ax-cli-dev` today. Details and lineage in `shared/state/axctl-friction-2026-04-17.md` (items 2, 7, 9, 10, 11). All four are surfaced by one single flow: "set an avatar on an agent I own." 234 existing tests still green, 13 new tests added.

- **Fix #7** — `ax agents avatar --set` now uses **PUT**, not PATCH. The prod ALB only proxies GET/POST/PUT on `/api/v1/agents/{id}`; PATCH always 405'd. Backend PUT accepts `avatar_url` identically. One-line behavioural fix in `ax_cli/commands/agents.py` (was line 547).
- **Fix #10** — `ax agents update` grows `--avatar-url TEXT` and `--avatar-file PATH`. The underlying `client.update_agent(**fields)` already accepted `avatar_url`; the CLI just didn't expose it. `--avatar-file` reads svg/png/jpg/gif/webp, base64-encodes into a data URI, checks the backend cap *before* calling the API.
- **Fix #9** — Client-side enforcement of the backend's **512-char cap** on `avatar_url`. Previously hitting the cap returned an opaque 500; now fails fast with an actionable message (`"backend caps at 512. Shrink to ≤ ~358 bytes before encoding, or host externally and pass an https:// URL."`).
- **Fix #2 (partial)** — Mutating agent commands (`agents update`, `agents avatar --set`) now print a one-line effective-config preamble to stderr: `base_url=…  user_env=…  source=…`. Addresses the `~/.ax/users/.active` footgun that cost ~30 min of the axolotl bootstrap — operators no longer silently target the wrong environment.

Skipped in this PR (separate tracks):
- **Item #11** (`GET /manage/{name}` drops `avatar_url` from its response) is a backend serializer parity fix — opening a separate issue against `ax-backend`.
- **Bash sandbox gaps** in `/home/ax-agent/agents/tools/__init__.py` — that code is unversioned / outside this repo; separate RFC incoming.
- **Item #0** (`axctl bootstrap-agent` one-shot) deserves its own PR with a focused test matrix for space-id + admin-JWT flows.

## Test plan

- [x] `uv run pytest tests/test_avatar_day.py -v` → 13 passed
- [x] `uv run pytest tests/` → 234 passed (no regressions)
- [x] `uv run ruff check ax_cli/commands/agents.py tests/test_avatar_day.py` → clean
- [ ] Smoke-test on `dev.paxai.app`: `ax agents avatar <name> --set` with a tiny generated SVG succeeds end-to-end via PUT
- [ ] Smoke-test on `next.paxai.app`: `ax agents update <name> --avatar-file tiny.svg` succeeds and the UI renders the new image
- [ ] Smoke-test the over-cap path: a 4 KB SVG is rejected client-side with the new error message
- [ ] Smoke-test the effective-config line is visible on `ax agents update` (stderr) when `AX_USER_ENV=dev` vs `default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)