### PR TITLE
Surface agent control state in axctl

### DIFF
--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -183,7 +183,9 @@ def _discover_agent_row(agent: dict[str, Any], probe: dict[str, Any] | None = No
         "mesh_role": mesh_role,
         "listener_status": listener_status,
         "contact_mode": contact_mode,
-        "recommended_contact": "reenable_before_contact" if control_status != "active" else _recommended_contact(contact_mode, mesh_role),
+        "recommended_contact": "reenable_before_contact"
+        if control_status != "active"
+        else _recommended_contact(contact_mode, mesh_role),
         "sent_message_id": probe.get("sent_message_id") if probe else None,
         "ping_token": probe.get("ping_token") if probe else None,
         "warning": warning,

--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -48,6 +48,33 @@ def _agent_mention_name(agent: dict[str, Any], fallback: str) -> str:
     return fallback.strip().removeprefix("@")
 
 
+def _agent_control_state(agent: dict[str, Any]) -> dict[str, Any]:
+    control = agent.get("control")
+    return control if isinstance(control, dict) else {}
+
+
+def _agent_control_status(agent: dict[str, Any]) -> str:
+    control = _agent_control_state(agent)
+    if control.get("is_disabled"):
+        return "disabled"
+    if control.get("no_reply"):
+        return "no_reply"
+    return "active"
+
+
+def _agent_control_reason(agent: dict[str, Any]) -> str:
+    control = _agent_control_state(agent)
+    if control.get("is_disabled"):
+        return str(control.get("disabled_reason") or "Kill switch enabled")
+    if control.get("no_reply"):
+        return str(control.get("no_reply_reason") or "Agent will not reply")
+    return ""
+
+
+def _agent_is_blocked(agent: dict[str, Any]) -> bool:
+    return _agent_control_status(agent) != "active"
+
+
 def _agent_mesh_role(agent: dict[str, Any]) -> str:
     name = str(agent.get("name") or "").lower()
     origin = str(agent.get("origin") or "").lower()
@@ -132,21 +159,31 @@ def _probe_agent_contact(
 
 def _discover_agent_row(agent: dict[str, Any], probe: dict[str, Any] | None = None) -> dict[str, Any]:
     mesh_role = _agent_mesh_role(agent)
-    contact_mode = probe["contact_mode"] if probe else _inferred_contact_mode(agent)
-    listener_status = probe["listener_status"] if probe else "not_probed"
+    control_status = _agent_control_status(agent)
+    control_reason = _agent_control_reason(agent)
+    if control_status != "active":
+        contact_mode = "blocked_by_control"
+        listener_status = control_status
+    else:
+        contact_mode = probe["contact_mode"] if probe else _inferred_contact_mode(agent)
+        listener_status = probe["listener_status"] if probe else "not_probed"
     warning = ""
     if mesh_role == "supervisor_candidate" and contact_mode != "event_listener":
         warning = "supervisor_candidate_not_live"
+    if control_status != "active":
+        warning = "agent_control_blocks_delivery"
     return {
-        "name": agent.get("name"),
+        "name": _agent_mention_name(agent, str(agent.get("name") or "agent")),
         "agent_id": agent.get("id"),
         "origin": agent.get("origin"),
         "agent_type": agent.get("agent_type"),
         "roster_status": agent.get("status"),
+        "control_status": control_status,
+        "control_reason": control_reason,
         "mesh_role": mesh_role,
         "listener_status": listener_status,
         "contact_mode": contact_mode,
-        "recommended_contact": _recommended_contact(contact_mode, mesh_role),
+        "recommended_contact": "reenable_before_contact" if control_status != "active" else _recommended_contact(contact_mode, mesh_role),
         "sent_message_id": probe.get("sent_message_id") if probe else None,
         "ping_token": probe.get("ping_token") if probe else None,
         "warning": warning,
@@ -170,10 +207,17 @@ def list_agents(
     if as_json:
         print_json(agents)
     else:
+        rows = []
+        for agent in agents:
+            row = dict(agent)
+            row["display_name"] = _agent_mention_name(agent, str(agent.get("name") or "agent"))
+            row["control_status"] = _agent_control_status(agent)
+            row["control_reason"] = _agent_control_reason(agent)
+            rows.append(row)
         print_table(
-            ["ID", "Name", "Status"],
-            agents,
-            keys=["id", "name", "status"],
+            ["ID", "Name", "Roster", "Control", "Reason"],
+            rows,
+            keys=["id", "display_name", "status", "control_status", "control_reason"],
         )
 
 
@@ -197,24 +241,36 @@ def ping_agent(
         typer.echo(f"Error: No visible agent found for '{agent}'.", err=True)
         raise typer.Exit(1)
 
-    try:
-        probe = _probe_agent_contact(
-            client,
-            space_id=sid,
-            target=target,
-            timeout=timeout,
-            current_agent_name=resolve_agent_name(client=client) or "",
-        )
-    except httpx.HTTPStatusError as exc:
-        handle_error(exc)
-
     agent_name = _agent_mention_name(target, agent)
+    if _agent_is_blocked(target):
+        probe = {
+            "listener_status": _agent_control_status(target),
+            "contact_mode": "blocked_by_control",
+            "reply": None,
+            "sent_message_id": None,
+            "ping_token": None,
+            "elapsed_seconds": 0.0,
+        }
+    else:
+        try:
+            probe = _probe_agent_contact(
+                client,
+                space_id=sid,
+                target=target,
+                timeout=timeout,
+                current_agent_name=resolve_agent_name(client=client) or "",
+            )
+        except httpx.HTTPStatusError as exc:
+            handle_error(exc)
+
     result = {
         "agent": agent_name,
         "agent_id": target.get("id"),
         "origin": target.get("origin"),
         "agent_type": target.get("agent_type"),
         "roster_status": target.get("status"),
+        "control_status": _agent_control_status(target),
+        "control_reason": _agent_control_reason(target),
         **probe,
     }
 
@@ -222,7 +278,12 @@ def ping_agent(
         print_json(result)
         return
 
-    if probe["reply"]:
+    if result["contact_mode"] == "blocked_by_control":
+        console.print(
+            f"[red]@{agent_name} is blocked by agent control.[/red] "
+            f"control={result['control_status']} reason={result['control_reason'] or '—'}"
+        )
+    elif probe["reply"]:
         console.print(f"[green]@{agent_name} replied.[/green] contact_mode=event_listener")
     else:
         console.print(
@@ -234,6 +295,8 @@ def ping_agent(
             "origin": result["origin"],
             "agent_type": result["agent_type"],
             "roster_status": result["roster_status"],
+            "control_status": result["control_status"],
+            "control_reason": result["control_reason"],
             "sent_message_id": result["sent_message_id"],
             "ping_token": result["ping_token"],
         }
@@ -273,7 +336,7 @@ def discover_agents(
     rows: list[dict[str, Any]] = []
     for target in selected:
         probe = None
-        if ping:
+        if ping and not _agent_is_blocked(target):
             try:
                 probe = _probe_agent_contact(
                     client,
@@ -290,6 +353,7 @@ def discover_agents(
         "total": len(rows),
         "event_listeners": sum(1 for row in rows if row["contact_mode"] == "event_listener"),
         "unknown_or_not_listening": sum(1 for row in rows if row["contact_mode"] == "unknown_or_not_listening"),
+        "blocked_by_control": sum(1 for row in rows if row["contact_mode"] == "blocked_by_control"),
         "supervisor_candidates": sum(1 for row in rows if row["mesh_role"] == "supervisor_candidate"),
         "supervisor_candidates_not_live": sum(1 for row in rows if row["warning"] == "supervisor_candidate_not_live"),
         "pinged": ping,
@@ -301,12 +365,13 @@ def discover_agents(
         return
 
     print_table(
-        ["Name", "Role", "Roster", "Listener", "Contact Mode", "Recommended", "Warning"],
+        ["Name", "Role", "Roster", "Control", "Listener", "Contact Mode", "Recommended", "Warning"],
         rows,
         keys=[
             "name",
             "mesh_role",
             "roster_status",
+            "control_status",
             "listener_status",
             "contact_mode",
             "recommended_contact",

--- a/tests/test_agents_commands.py
+++ b/tests/test_agents_commands.py
@@ -7,6 +7,73 @@ from ax_cli.main import app
 runner = CliRunner()
 
 
+def test_agents_list_surfaces_control_state(monkeypatch):
+    class FakeClient:
+        def list_agents(self, *, space_id=None, limit=None):
+            return {
+                "agents": [
+                    {
+                        "id": "agent-1",
+                        "name": "aX",
+                        "status": "active",
+                        "control": {
+                            "is_disabled": True,
+                            "disabled_reason": "manual safety pause",
+                        },
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
+
+    result = runner.invoke(app, ["agents", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "aX" in result.output
+    assert "active" in result.output
+    assert "disabled" in result.output
+    assert "manual safety pause" in result.output
+
+
+def test_agents_ping_does_not_send_when_control_blocks_delivery(monkeypatch):
+    calls = {"sent": False}
+
+    class FakeClient:
+        def list_agents(self, *, space_id=None, limit=None):
+            return {
+                "agents": [
+                    {
+                        "id": "agent-1",
+                        "name": "aX",
+                        "origin": "space_agent",
+                        "agent_type": "space_agent",
+                        "status": "active",
+                        "control": {
+                            "is_disabled": True,
+                            "disabled_reason": "manual safety pause",
+                        },
+                    }
+                ]
+            }
+
+        def send_message(self, space_id, content):
+            calls["sent"] = True
+            return {"message": {"id": "msg-1"}}
+
+    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
+
+    result = runner.invoke(app, ["agents", "ping", "aX", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert calls["sent"] is False
+    assert data["contact_mode"] == "blocked_by_control"
+    assert data["control_status"] == "disabled"
+    assert data["control_reason"] == "manual safety pause"
+
+
 def test_agents_ping_classifies_reply_as_event_listener(monkeypatch):
     calls = {}
 
@@ -142,6 +209,44 @@ def test_agents_discover_infers_roles_without_ping(monkeypatch):
     assert rows["supervisor_sentinel"]["warning"] == "supervisor_candidate_not_live"
     assert rows["aX"]["contact_mode"] == "space_agent"
     assert rows["night_owl"]["contact_mode"] == "on_demand"
+
+
+def test_agents_discover_marks_control_blocked_agents_without_ping(monkeypatch):
+    class FakeClient:
+        def list_agents(self, *, space_id=None, limit=None):
+            return {
+                "agents": [
+                    {
+                        "id": "agent-1",
+                        "name": "aX",
+                        "origin": "space_agent",
+                        "agent_type": "space_agent",
+                        "status": "active",
+                        "control": {
+                            "is_disabled": True,
+                            "disabled_reason": "manual safety pause",
+                        },
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
+    monkeypatch.setattr("ax_cli.commands.agents.resolve_agent_name", lambda client=None: "ChatGPT")
+
+    result = runner.invoke(app, ["agents", "discover", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    row = data["agents"][0]
+    assert data["summary"]["blocked_by_control"] == 1
+    assert row["roster_status"] == "active"
+    assert row["control_status"] == "disabled"
+    assert row["control_reason"] == "manual safety pause"
+    assert row["listener_status"] == "disabled"
+    assert row["contact_mode"] == "blocked_by_control"
+    assert row["recommended_contact"] == "reenable_before_contact"
+    assert row["warning"] == "agent_control_blocks_delivery"
 
 
 def test_agents_discover_with_ping_classifies_listener(monkeypatch):


### PR DESCRIPTION
## Summary
- show roster status and control status separately in `axctl agents list`
- make `axctl agents ping` avoid sending probe messages when an agent is blocked by kill switch/no-reply control state
- include blocked-by-control counts in `axctl agents discover`

## Tests
- `pytest -q tests/test_agents_commands.py`