### PR TITLE
fix(channel): filter hermes progress messages, deliver streamed final updates

### DIFF
--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import sys
 import threading
 import time
@@ -439,6 +440,28 @@ def _resolve_agent_id(client, agent_name: str | None) -> str | None:
 
 _SSE_RECONNECT_INTERVAL = 600  # reconnect every 10 min to refresh JWT before 15-min expiry
 
+# Defensive fallback for runtime progress messages that arrive without the
+# `metadata.streaming_reply.final=false` hint. Every branch is anchored with
+# \Z so we only suppress lines that are EXACTLY progress chatter — never
+# legitimate user prompts that merely start with the same word. Example:
+# "Working…" is dropped, but "Working-state cleanup proposal" is delivered.
+#
+# Emitters that feed this:
+#   - hermes_sdk / ax-agents callbacks: "Working…", "Received", "Thinking...",
+#     "Processing..." (exact word + trailing whitespace/dot/ellipsis only).
+#   - channel/server.ts: "No response after <N>[smh] - session may need
+#     attention." — the `\d+[smh]` anchor keeps user phrases like "No response
+#     after the deploy broke things" from matching.
+_RUNTIME_PROGRESS_RE = re.compile(
+    r"^(?:"
+    r"(?:Working|Received|Thinking|Processing)[\s.\u2026]*"
+    r"|"
+    r"No response after\s+\d+\s*[smh]\b.*"
+    r")\Z",
+    re.IGNORECASE,
+)
+_LEADING_MENTION_RE = re.compile(r"^@[\w-]+\s*[-\u2014]?\s*")
+
 
 def _sse_loop(bridge: ChannelBridge) -> None:
     seen_ids: set[str] = set()
@@ -466,22 +489,63 @@ def _sse_loop(bridge: ChannelBridge) -> None:
                             bridge.log("SSE reconnecting to refresh JWT")
                             break
                         continue
-                    if event_type not in {"message", "mention"} or not isinstance(data, dict):
+                    # Accept message/mention (creation) and message_updated
+                    # (final streamed content). Hermes-runtime sentinels seed a
+                    # placeholder message on start and overwrite it in place
+                    # via message_updated events as the reply streams in.
+                    if event_type not in {"message", "mention", "message_updated"} or not isinstance(data, dict):
                         bridge.log(f"skip non-msg: {event_type}")
                         if reconnect_after_event:
                             bridge.log("SSE reconnecting to refresh JWT")
                             break
                         continue
 
+                    is_update = event_type == "message_updated"
                     message_id = data.get("id") or ""
                     content_preview = (data.get("content") or "")[:60]
                     bridge.log(f"event {event_type} id={message_id[:12]} content={content_preview!r}")
-                    if not message_id or message_id in seen_ids:
+                    # New messages: skip if already delivered. Updates bypass
+                    # the dedup so the final streamed payload can supersede the
+                    # placeholder.
+                    if not message_id or (not is_update and message_id in seen_ids):
                         bridge.log("  -> skip: dup or no id")
                         if reconnect_after_event:
                             bridge.log("SSE reconnecting to refresh JWT")
                             break
                         continue
+                    if is_update and message_id in seen_ids:
+                        bridge.log("  -> skip: update for already-delivered msg")
+                        if reconnect_after_event:
+                            bridge.log("SSE reconnecting to refresh JWT")
+                            break
+                        continue
+
+                    # Skip runtime progress chatter. Two signals:
+                    #   1. metadata.streaming_reply.final is explicitly false,
+                    #      meaning the payload is a placeholder/progress chunk
+                    #      the runtime will overwrite via message_updated.
+                    #   2. Defensive regex: first line matches the known
+                    #      progress patterns ("Working…", "Received",
+                    #      "Thinking", "Processing", "No response after").
+                    # We skip WITHOUT adding to seen_ids so the subsequent
+                    # final message_updated for the same id can be delivered.
+                    metadata_obj = data.get("metadata") or {}
+                    streaming = metadata_obj.get("streaming_reply") if isinstance(metadata_obj, dict) else None
+                    if isinstance(streaming, dict) and streaming.get("final") is False:
+                        bridge.log("  -> skip: streaming_reply non-final")
+                        if reconnect_after_event:
+                            bridge.log("SSE reconnecting to refresh JWT")
+                            break
+                        continue
+                    raw_first_line = (data.get("content") or "").strip().split("\n", 1)[0].strip()
+                    stripped_first_line = _LEADING_MENTION_RE.sub("", raw_first_line, count=1).strip()
+                    if _RUNTIME_PROGRESS_RE.match(stripped_first_line):
+                        bridge.log(f"  -> skip: runtime progress message ({raw_first_line!r})")
+                        if reconnect_after_event:
+                            bridge.log("SSE reconnecting to refresh JWT")
+                            break
+                        continue
+
                     if _is_self_authored(data, bridge.agent_name, bridge.agent_id):
                         _remember_reply_anchor(bridge._reply_anchor_ids, message_id)
                         seen_ids.add(message_id)

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -37,7 +37,7 @@ class CaptureBridge(ChannelBridge):
     def __init__(self, client, *, agent_id="agent-123", processing_status=True):
         super().__init__(
             client=client,
-            agent_name="anvil",
+            agent_name="peer-agent",
             agent_id=agent_id,
             space_id="space-123",
             queue_size=10,
@@ -53,8 +53,9 @@ class CaptureBridge(ChannelBridge):
 class FakeSseResponse:
     status_code = 200
 
-    def __init__(self, payload):
+    def __init__(self, payload, *, event_type: str = "message"):
         self.payload = payload
+        self.event_type = event_type
 
     def __enter__(self):
         return self
@@ -63,9 +64,30 @@ class FakeSseResponse:
         return False
 
     def iter_lines(self):
-        yield "event: message"
+        yield f"event: {self.event_type}"
         yield f"data: {json.dumps(self.payload)}"
         yield ""
+
+
+class FakeMultiEventSseResponse:
+    """SSE response that yields a scripted sequence of (event_type, payload) events."""
+
+    status_code = 200
+
+    def __init__(self, events: list[tuple[str, dict]]):
+        self.events = events
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def iter_lines(self):
+        for event_type, payload in self.events:
+            yield f"event: {event_type}"
+            yield f"data: {json.dumps(payload)}"
+            yield ""
 
 
 def test_channel_rejects_user_pat_for_agent_reply():
@@ -103,7 +125,7 @@ def test_channel_sends_with_agent_bound_pat():
         {
             "message_id": "incoming-123",
             "status": "completed",
-            "agent_name": "anvil",
+            "agent_name": "peer-agent",
             "space_id": "space-123",
         }
     ]
@@ -122,7 +144,7 @@ def test_channel_can_publish_working_status_on_delivery():
         {
             "message_id": "incoming-123",
             "status": "working",
-            "agent_name": "anvil",
+            "agent_name": "peer-agent",
             "space_id": "space-123",
         }
     ]
@@ -142,9 +164,9 @@ def test_channel_processes_idle_event_before_jwt_reconnect(monkeypatch):
             return FakeSseResponse(
                 {
                     "id": "incoming-123",
-                    "content": "@anvil please check this",
-                    "author": {"id": "user-123", "name": "madtank", "type": "user"},
-                    "mentions": ["anvil"],
+                    "content": "@peer-agent please check this",
+                    "author": {"id": "user-123", "name": "alex", "type": "user"},
+                    "mentions": ["peer-agent"],
                 }
             )
 
@@ -168,6 +190,233 @@ def test_channel_processes_idle_event_before_jwt_reconnect(monkeypatch):
 
     assert [event.message_id for event in delivered] == ["incoming-123"]
     assert delivered[0].prompt == "please check this"
+
+
+def _run_sse_loop_with_events(
+    events: list[tuple[str, dict]],
+    *,
+    stop_after_delivery: int = 1,
+    monkeypatch=None,
+):
+    """Drive `_sse_loop` against a scripted SSE event list and capture deliveries."""
+
+    class ScriptedClient(FakeClient):
+        def __init__(self):
+            super().__init__()
+            self.connect_calls = 0
+            self.get_message_calls: list[str] = []
+
+        def connect_sse(self, *, space_id):
+            self.connect_calls += 1
+            return FakeMultiEventSseResponse(events)
+
+        def get_message(self, message_id):
+            self.get_message_calls.append(message_id)
+            return {"message": {"metadata": {}}}
+
+    client = ScriptedClient()
+    bridge = CaptureBridge(client)
+    delivered: list[MentionEvent] = []
+    deliveries_needed = stop_after_delivery
+
+    def capture_delivery(event):
+        delivered.append(event)
+        if len(delivered) >= deliveries_needed:
+            bridge.shutdown.set()
+
+    bridge.enqueue_from_thread = capture_delivery
+
+    # Make reconnect path inert so the bridge processes all scripted events in
+    # one pass and only stops when shutdown is set (either by delivery capture
+    # or because the scripted stream is exhausted).
+    if monkeypatch is not None:
+        monkeypatch.setattr(channel_mod.time, "monotonic", lambda: 0.0)
+
+    # Run the loop; it exits when the scripted iter_lines generator completes
+    # and ConnectionError propagates, or when shutdown is set inside capture.
+    # We wrap in a bounded number of connect_sse calls to avoid infinite loop
+    # if the test script doesn't produce deliveries.
+    original_connect = client.connect_sse
+
+    def limited_connect(*args, **kwargs):
+        if client.connect_calls >= 2:
+            bridge.shutdown.set()
+            raise ConnectionError("test: exhausted scripted connects")
+        return original_connect(*args, **kwargs)
+
+    client.connect_sse = limited_connect  # type: ignore[assignment]
+
+    channel_mod._sse_loop(bridge)
+    return bridge, client, delivered
+
+
+def test_channel_skips_streaming_reply_non_final(monkeypatch):
+    """Placeholder/progress chunks marked non-final must not wake the session."""
+
+    events = [
+        (
+            "message",
+            {
+                "id": "stream-1",
+                "content": "Working…",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+                "metadata": {
+                    "streaming_reply": {"enabled": True, "final": False, "runtime": "hermes_sdk"},
+                },
+            },
+        ),
+    ]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert delivered == []
+
+
+def test_channel_skips_working_progress_message(monkeypatch):
+    """Defensive regex catches progress payloads even without streaming metadata."""
+
+    events = [
+        (
+            "message",
+            {
+                "id": "progress-1",
+                "content": "@peer-agent Working…",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+        (
+            "message",
+            {
+                "id": "progress-2",
+                "content": "Received",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+        (
+            "message",
+            {
+                "id": "progress-3",
+                "content": "@peer-agent Thinking...",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+        (
+            "message",
+            {
+                "id": "progress-4",
+                "content": "@peer-agent No response after 5m - session may need attention.",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+    ]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert delivered == []
+
+
+def test_channel_delivers_prompts_that_merely_start_with_progress_words(monkeypatch):
+    """A legitimate prompt like '@peer-agent Working-state cleanup proposal' must land.
+
+    The fallback progress regex must be anchored — otherwise user messages that
+    happen to start with Working/Processing/Thinking/Received would be dropped
+    silently. Regression for PR #70 review (2026-04-18).
+    """
+
+    events = [
+        (
+            "message",
+            {
+                "id": "real-prompt-1",
+                "content": "@peer-agent Working-state cleanup proposal",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+    ]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert len(delivered) == 1
+    assert "Working-state cleanup proposal" in delivered[0].prompt
+
+
+def test_channel_delivers_processing_webhook_errors_prompt(monkeypatch):
+    """`Processing webhook errors` is a real user prompt, not a progress marker."""
+
+    events = [
+        (
+            "message",
+            {
+                "id": "real-prompt-2",
+                "content": "@peer-agent Processing webhook errors in the dispatch queue",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+    ]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert len(delivered) == 1
+    assert "Processing webhook errors" in delivered[0].prompt
+
+
+def test_channel_delivers_thinking_through_issue_prompt(monkeypatch):
+    """`Thinking through this API issue` must be delivered, not suppressed."""
+
+    events = [
+        (
+            "message",
+            {
+                "id": "real-prompt-3",
+                "content": "@peer-agent Thinking through this API issue",
+                "author": {"id": "user-1", "name": "alex", "type": "user"},
+                "mentions": ["peer-agent"],
+            },
+        ),
+    ]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert len(delivered) == 1
+    assert "Thinking through this API issue" in delivered[0].prompt
+
+
+def test_channel_delivers_message_updated_final(monkeypatch):
+    """When hermes streams a final payload via message_updated we deliver it."""
+
+    placeholder = {
+        "id": "hermes-1",
+        "content": "Working…",
+        "author": {"id": "agent-2", "name": "frontend_sentinel", "type": "agent"},
+        "mentions": ["peer-agent"],
+        "metadata": {
+            "streaming_reply": {"enabled": True, "final": False, "runtime": "hermes_sdk"},
+        },
+    }
+    final_update = {
+        "id": "hermes-1",
+        "content": "@peer-agent here is the real reply",
+        "author": {"id": "agent-2", "name": "frontend_sentinel", "type": "agent"},
+        "mentions": ["peer-agent"],
+        "metadata": {
+            "streaming_reply": {"enabled": True, "final": True, "runtime": "hermes_sdk"},
+        },
+    }
+    events = [("message", placeholder), ("message_updated", final_update)]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert [e.message_id for e in delivered] == ["hermes-1"]
+    assert delivered[0].prompt == "here is the real reply"
+
+
+def test_channel_skips_message_updated_for_already_delivered(monkeypatch):
+    """Once a final payload is delivered, subsequent updates for that id do not re-wake."""
+
+    payload = {
+        "id": "msg-dup",
+        "content": "@peer-agent please review",
+        "author": {"id": "user-1", "name": "alex", "type": "user"},
+        "mentions": ["peer-agent"],
+    }
+    events = [("message", payload), ("message_updated", payload)]
+    _, _, delivered = _run_sse_loop_with_events(events, monkeypatch=monkeypatch)
+    assert [e.message_id for e in delivered] == ["msg-dup"]
 
 
 def test_channel_processing_status_can_be_disabled():
@@ -212,9 +461,9 @@ def test_channel_get_messages_returns_pending_mentions():
             message_id="incoming-123",
             parent_id=None,
             conversation_id=None,
-            author="madtank",
+            author="alex",
             prompt="please check this",
-            raw_content="@anvil please check this",
+            raw_content="@peer-agent please check this",
             created_at="2026-04-15T23:00:00Z",
             space_id="space-123",
         )
@@ -238,9 +487,9 @@ def test_channel_notification_metadata_matches_claude_channel_contract():
                 message_id="incoming-123",
                 parent_id=None,
                 conversation_id="conversation-ignored",
-                author="madtank",
+                author="alex",
                 prompt="please check this",
-                raw_content="@anvil please check this",
+                raw_content="@peer-agent please check this",
                 created_at=None,
                 space_id="space-123",
             )
@@ -289,11 +538,11 @@ def test_listener_treats_parent_reply_as_delivery_signal():
         "id": "reply-1",
         "content": "I looked at this",
         "parent_id": "agent-message-1",
-        "author": {"id": "other-agent", "name": "orion", "type": "agent"},
+        "author": {"id": "other-agent", "name": "demo-agent", "type": "agent"},
         "mentions": [],
     }
 
-    assert _should_respond(data, "anvil", "agent-123", reply_anchor_ids=anchors) is True
+    assert _should_respond(data, "peer-agent", "agent-123", reply_anchor_ids=anchors) is True
 
 
 def test_listener_treats_conversation_reply_as_delivery_signal():
@@ -302,23 +551,23 @@ def test_listener_treats_conversation_reply_as_delivery_signal():
         "id": "reply-1",
         "content": "I looked at this",
         "conversation_id": "agent-message-1",
-        "author": {"id": "other-agent", "name": "orion", "type": "agent"},
+        "author": {"id": "other-agent", "name": "demo-agent", "type": "agent"},
         "mentions": [],
     }
 
-    assert _should_respond(data, "anvil", "agent-123", reply_anchor_ids=anchors) is True
+    assert _should_respond(data, "peer-agent", "agent-123", reply_anchor_ids=anchors) is True
 
 
 def test_listener_tracks_self_authored_messages_without_responding():
     anchors: set[str] = set()
     data = {
         "id": "agent-message-1",
-        "content": "@orion please check this",
-        "author": {"id": "agent-123", "name": "anvil", "type": "agent"},
-        "mentions": ["orion"],
+        "content": "@demo-agent please check this",
+        "author": {"id": "agent-123", "name": "peer-agent", "type": "agent"},
+        "mentions": ["demo-agent"],
     }
 
-    assert _is_self_authored(data, "anvil", "agent-123") is True
+    assert _is_self_authored(data, "peer-agent", "agent-123") is True
     _remember_reply_anchor(anchors, data["id"])
-    assert _should_respond(data, "anvil", "agent-123", reply_anchor_ids=anchors) is False
+    assert _should_respond(data, "peer-agent", "agent-123", reply_anchor_ids=anchors) is False
     assert anchors == {"agent-message-1"}


### PR DESCRIPTION
## Summary

Restores two ax-channel bridge behaviors that regressed when the TypeScript bridge was ported to Python `axctl channel`.

## Root cause

1. The Python bridge subscribed only to `message` and `mention` SSE events; `message_updated` was dropped. Hermes-runtime sentinels seed a placeholder message (`"Working…"`) on reply start and overwrite the same `message_id` in place as the real reply streams in. Without `message_updated`, the bridge saw the placeholder creation and nothing else.
2. The Python bridge had no filter for progress/chunk payloads, so every `"Working…"` / `"Received"` / streaming placeholder woke the Claude Code session.

Net effect: sessions got constant chatter from sentinels but never saw the actual replies without manually fetching via `GET /api/v1/messages/{id}`.

## Fix

- Subscribe to `message_updated` in addition to `message` / `mention`.
- Allow `message_updated` to bypass seen-dedup only when the id has NOT been delivered yet (so final streaming updates supersede the placeholder but can't re-wake after delivery).
- Skip payloads where `metadata.streaming_reply.final` is explicitly `false` (structured runtime signal).
- Defensive regex fallback anchored with `\Z`: drop payloads whose first line (after stripping any leading `@mention`) is **entirely** progress-only — `Working…` / `Received` / `Thinking...` / `Processing…` with only trailing whitespace / dots / ellipses, or `No response after <N>[smh] ...`. Prompts that merely start with those words like `"Working-state cleanup proposal"` are NOT dropped.
- Skipped payloads are NOT added to `seen_ids` so the subsequent final update for the same id still delivers.
- Also fixes the leading-mention strip regex to handle hyphenated agent handles.

## Tests

Seven targeted tests in `tests/test_channel.py`:

- `test_channel_skips_streaming_reply_non_final` — structured `metadata.streaming_reply.final=false` filter.
- `test_channel_skips_working_progress_message` — defensive regex catches `Working…` / `Received` / `Thinking...` / `No response after 5m ...`.
- `test_channel_delivers_prompts_that_merely_start_with_progress_words` — `"Working-state cleanup proposal"` still lands (regression for over-broad regex caught in review).
- `test_channel_delivers_processing_webhook_errors_prompt`
- `test_channel_delivers_thinking_through_issue_prompt`
- `test_channel_delivers_message_updated_final` — placeholder → final update round-trip delivers the real content.
- `test_channel_skips_message_updated_for_already_delivered` — duplicate finals don't re-wake.

All 20 channel tests pass. `ruff check` and `ruff format --check` clean. Full test suite: 224 passed.

## Test plan

- [x] CI green
- [ ] Install from branch, restart a Claude Code session, verify sentinel replies deliver without progress noise
- [ ] Regression check: a normal non-streaming message still delivers immediately
