### PR TITLE
chore(precommit): run pytest on pre-push, match CI fully

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,34 @@
-# Pre-commit hooks for ax-cli — mirrors what CI runs so format/lint failures
-# are caught before they reach a PR.
+# Pre-commit hooks for ax-cli — mirrors what CI runs so format/lint/test
+# failures are caught before they reach a PR.
 #
 # CI runs (.github/workflows/ci.yml):
 #   - ruff check ax_cli/
 #   - ruff format --check ax_cli/
+#   - pytest tests/
 #
-# These hooks run the same checks locally on every git commit. If a commit
-# would fail in CI, it fails locally first — no more red PRs from things that
-# could have been caught at commit time.
+# Fast checks run at `commit`; the test suite runs at `push` so everyday
+# commits stay snappy but nothing unreviewed lands on origin.
 #
 # Setup (one-time, per developer/agent):
 #
 #     pip install pre-commit
-#     pre-commit install
+#     pre-commit install --install-hooks
+#     pre-commit install --hook-type pre-push
 #
-# Now `git commit` runs the hooks automatically. To run against all files
-# without committing:
+# Run against all files without committing:
 #
 #     pre-commit run --all-files
+#     pre-commit run --all-files --hook-stage pre-push
 #
 # To skip hooks for a specific commit (use sparingly):
 #
 #     git commit --no-verify ...
 #
-# To update the hook versions to whatever's latest:
+# Bump hook versions:
 #
 #     pre-commit autoupdate
+
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -40,3 +43,13 @@ repos:
         files: ^ax_cli/.*\.py$
       - id: ruff-format
         files: ^ax_cli/.*\.py$
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest (matches CI)
+        entry: pytest tests/ --tb=short -q
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        # Runs on every `git push`. Add --no-verify to bypass in emergencies.


### PR DESCRIPTION
## Summary
- Adds a local `pytest tests/` hook at the `pre-push` stage so the full CI bar (ruff check + ruff format --check + pytest) is enforced locally before anything hits origin.
- Sets `default_install_hook_types: [pre-commit, pre-push]` so a single `pre-commit install --install-hooks` wires up both stages.
- Updates the setup comment to reflect the new install command.

## Why
PR #70's lint failure (`ruff format --check` caught `ax_cli/commands/channel.py`) is exactly the class of regression the existing hooks were supposed to prevent — but hooks were never installed locally for that worktree. Making install one command and extending coverage to tests closes the gap.

## Test plan
- [x] `pre-commit run --all-files` → ruff check + ruff format Passed
- [x] `pre-commit run --all-files --hook-stage pre-push` → all three Passed
- [x] Push of this branch triggered the pre-push hook; pytest ran locally before git push completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)