### PR TITLE
chore(cli): default runtime host to paxai.app

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -24,7 +24,7 @@ app = typer.Typer(name="auth", help="Authentication & identity", no_args_is_help
 token_app = typer.Typer(name="token", help="Token management", no_args_is_help=True)
 app.add_typer(token_app, name="token")
 
-DEFAULT_LOGIN_BASE_URL = "https://next.paxai.app"
+DEFAULT_LOGIN_BASE_URL = "https://paxai.app"
 
 
 def _mask_token_prefix(token: str) -> str:
@@ -258,7 +258,7 @@ def init(
 
     \b
         axctl login
-        axctl login --url https://next.paxai.app
+        axctl login --url https://paxai.app
 
     The CLI will:
     1. Verify the token works (exchange it for a JWT)
@@ -508,7 +508,7 @@ def exchange(
     ),
     agent_id: str = typer.Option(None, "--agent", "-a", help="Agent ID (required for agent_access)"),
     audience: str = typer.Option("ax-api", "--audience", help="Target audience: ax-api or ax-mcp"),
-    resource: str = typer.Option(None, "--resource", help="RFC 8707 resource URI (e.g. https://next.paxai.app/mcp)"),
+    resource: str = typer.Option(None, "--resource", help="RFC 8707 resource URI (e.g. https://paxai.app/mcp)"),
     as_json: bool = JSON_OPTION,
 ):
     """Exchange PAT for a short-lived JWT (AUTH-SPEC-001 §9).

--- a/ax_cli/commands/profile.py
+++ b/ax_cli/commands/profile.py
@@ -157,7 +157,7 @@ def _register_fingerprint(profile: dict) -> str | None:
 @app.command("add")
 def add(
     name: str = typer.Argument(..., help="Profile name (e.g. next-orion)"),
-    url: str = typer.Option(..., "--url", help="Base URL (e.g. https://next.paxai.app)"),
+    url: str = typer.Option(..., "--url", help="Base URL (e.g. https://paxai.app)"),
     token_file: str = typer.Option(..., "--token-file", help="Path to token file"),
     agent_name: str = typer.Option(..., "--agent-name", help="Agent name"),
     agent_id: Optional[str] = typer.Option(None, "--agent-id", help="Agent UUID"),

--- a/channel/server.ts
+++ b/channel/server.ts
@@ -2,7 +2,7 @@
 /**
  * aX Channel for Claude Code.
  *
- * Bridges @mentions from the aX platform (next.paxai.app) into a running
+ * Bridges @mentions from the aX platform (paxai.app) into a running
  * Claude Code session via the MCP channel protocol.
  *
  * Modeled on fakechat — uses the official MCP SDK with StdioServerTransport.
@@ -84,7 +84,7 @@ function cfg(key: string, fallback: string, axKey?: string): string {
 }
 
 // --- Config: explicit env > AX_CONFIG_FILE/local .ax/config.toml > .env fallback > defaults ---
-const BASE_URL = cfg("AX_BASE_URL", "https://next.paxai.app", "base_url");
+const BASE_URL = cfg("AX_BASE_URL", "https://paxai.app", "base_url");
 const AGENT_NAME = cfg("AX_AGENT_NAME", "", "agent_name");
 const AGENT_ID = cfg("AX_AGENT_ID", "", "agent_id");
 const SPACE_ID = cfg("AX_SPACE_ID", "", "space_id");

--- a/channel/skills/configure/SKILL.md
+++ b/channel/skills/configure/SKILL.md
@@ -29,7 +29,7 @@ Read `~/.claude/channels/ax-channel/.env` and show the user their current config
 
 1. **Config** — `AX_CONFIG_FILE` or `AX_TOKEN_FILE`. Prefer `AX_CONFIG_FILE`
    from `axctl token mint --save-to`.
-2. **API URL** — `AX_BASE_URL` (default: `https://next.paxai.app`)
+2. **API URL** — `AX_BASE_URL` (default: `https://paxai.app`)
 3. **Agent** — `AX_AGENT_NAME` (who the channel listens as)
 4. **Agent ID** — `AX_AGENT_ID` (for reply identity)
 5. **Space** — `AX_SPACE_ID` (which space to bridge)
@@ -61,7 +61,7 @@ Update `AX_SPACE_ID` in `.env`.
 
 ### `url <base_url>` — set API URL
 
-Update `AX_BASE_URL` in `.env`. Default is `https://next.paxai.app`.
+Update `AX_BASE_URL` in `.env`. Default is `https://paxai.app`.
 
 ### `clear` — remove all config
 

--- a/channel/test-channel.mjs
+++ b/channel/test-channel.mjs
@@ -54,7 +54,7 @@ function liveEnv() {
     return env;
   }
   env.AX_TOKEN_FILE = process.env.AX_TOKEN_FILE || `${homedir()}/.ax/user_token`;
-  env.AX_BASE_URL = process.env.AX_BASE_URL || 'https://next.paxai.app';
+  env.AX_BASE_URL = process.env.AX_BASE_URL || 'https://paxai.app';
   env.AX_AGENT_NAME = process.env.AX_AGENT_NAME || 'test_echo';
   env.AX_SPACE_ID = process.env.AX_SPACE_ID || '';
   return env;
@@ -74,7 +74,7 @@ const config = {
       ...process.env,
       // Use a fake token for protocol tests — SSE will fail but MCP works
       AX_TOKEN: process.env.AX_TOKEN || 'test-token-for-protocol-only',
-      AX_BASE_URL: process.env.AX_BASE_URL || 'https://next.paxai.app',
+      AX_BASE_URL: process.env.AX_BASE_URL || 'https://paxai.app',
       AX_AGENT_NAME: process.env.AX_AGENT_NAME || 'test_agent',
       AX_SPACE_ID: process.env.AX_SPACE_ID || 'test-space',
     }

--- a/channel/test-headless-mcp.mjs
+++ b/channel/test-headless-mcp.mjs
@@ -56,7 +56,7 @@ if (!configPath) {
 }
 
 const config = parseFlatToml(readFileSync(expandHome(configPath), "utf-8"));
-const baseUrl = process.env.AX_BASE_URL || config.base_url || "https://next.paxai.app";
+const baseUrl = process.env.AX_BASE_URL || config.base_url || "https://paxai.app";
 const agentName = process.env.AX_AGENT_NAME || config.agent_name;
 const agentId = process.env.AX_AGENT_ID || config.agent_id;
 const spaceId = process.env.AX_SPACE_ID || config.space_id;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://next.paxai.app"
+Homepage = "https://paxai.app"
 Repository = "https://github.com/ax-platform/ax-cli"
 Documentation = "https://github.com/ax-platform/ax-cli#readme"
 

--- a/specs/RUNTIME-CONFIG-001/spec.md
+++ b/specs/RUNTIME-CONFIG-001/spec.md
@@ -16,7 +16,7 @@ client can consume:
 
 ```toml
 token_file = "/home/ax-agent/agents/orion/.ax/orion_token"
-base_url = "https://next.paxai.app"
+base_url = "https://paxai.app"
 agent_name = "orion"
 agent_id = "agent-uuid"
 space_id = "optional-default-space-uuid"

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -33,7 +33,7 @@ def test_login_calls_user_login(monkeypatch):
             "--token",
             "axp_u_test.token",
             "--url",
-            "https://next.paxai.app",
+            "https://paxai.app",
             "--env",
             "next",
             "--agent",
@@ -46,7 +46,7 @@ def test_login_calls_user_login(monkeypatch):
     assert result.exit_code == 0
     assert called == {
         "token": "axp_u_test.token",
-        "base_url": "https://next.paxai.app",
+        "base_url": "https://paxai.app",
         "agent": "anvil",
         "space_id": "space-123",
         "env_name": "next",
@@ -75,7 +75,7 @@ def test_login_defaults_to_next_without_space_requirement(monkeypatch):
     assert result.exit_code == 0
     assert called == {
         "token": "axp_u_test.token",
-        "base_url": "https://next.paxai.app",
+        "base_url": "https://paxai.app",
         "agent": None,
         "space_id": None,
         "env_name": None,
@@ -136,7 +136,7 @@ def test_user_login_does_not_modify_local_agent_config(monkeypatch, write_config
             self.token = token
 
         def get_token(self, token_class, *, scope, force_refresh):
-            assert self.base_url == "https://next.paxai.app"
+            assert self.base_url == "https://paxai.app"
             assert self.token == "axp_u_new.secret"
             assert token_class == "user_access"
             assert scope == "messages tasks context agents spaces search"
@@ -174,7 +174,7 @@ def test_user_login_does_not_modify_local_agent_config(monkeypatch, write_config
     user_cfg = tomllib.loads((config_dir.parent / "_global_config" / "user.toml").read_text())
     assert user_cfg == {
         "token": "axp_u_new.secret",
-        "base_url": "https://next.paxai.app",
+        "base_url": "https://paxai.app",
         "principal_type": "user",
         "space_id": "space-current",
     }

--- a/tests/test_bootstrap_agent.py
+++ b/tests/test_bootstrap_agent.py
@@ -70,7 +70,7 @@ class _FakeHttp:
 
 
 class _FakeClient:
-    base_url = "https://next.paxai.app"
+    base_url = "https://paxai.app"
 
     def __init__(self, http: _FakeHttp):
         self._http = http
@@ -129,7 +129,7 @@ def user_pat(monkeypatch):
     monkeypatch.setattr(
         bootstrap_cmd, "resolve_user_token", lambda: "axp_u_test1234567890abcd.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     )
-    monkeypatch.setattr(bootstrap_cmd, "resolve_user_base_url", lambda: "https://next.paxai.app")
+    monkeypatch.setattr(bootstrap_cmd, "resolve_user_base_url", lambda: "https://paxai.app")
     monkeypatch.setattr(bootstrap_cmd, "_resolve_user_env", lambda: "default")
     monkeypatch.setattr(bootstrap_cmd, "_user_config_path", lambda: Path("/tmp/nope-not-real.toml"))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ def _write_active_profile(global_dir: Path, *, name: str = "next-orion") -> Path
     token_file.write_text("axp_a_agent.secret")
     (global_dir / "profiles" / ".active").write_text(f"{name}\n")
     (global_dir / "profiles" / name / "profile.toml").write_text(
-        f'base_url = "https://next.paxai.app"\n'
+        f'base_url = "https://paxai.app"\n'
         f'agent_name = "orion"\n'
         f'agent_id = "agent-orion"\n'
         f'space_id = "next-space"\n'
@@ -132,7 +132,7 @@ class TestLoadConfig:
         runtime_config = runtime_dir / "config.toml"
         runtime_config.write_text(
             f'token_file = "{token_file.name}"\n'
-            'base_url = "https://next.paxai.app"\n'
+            'base_url = "https://paxai.app"\n'
             'agent_name = "orion"\n'
             'agent_id = "agent-orion"\n'
             'space_id = "space-next"\n'
@@ -143,7 +143,7 @@ class TestLoadConfig:
         cfg = _load_config()
 
         assert cfg["token"] == "axp_a_runtime.secret"
-        assert cfg["base_url"] == "https://next.paxai.app"
+        assert cfg["base_url"] == "https://paxai.app"
         assert cfg["agent_name"] == "orion"
         assert cfg["agent_id"] == "agent-orion"
         assert cfg["space_id"] == "space-next"
@@ -156,7 +156,7 @@ class TestLoadConfig:
         _save_user_config(
             {
                 "token": "axp_u_user.secret",
-                "base_url": "https://next.paxai.app",
+                "base_url": "https://paxai.app",
                 "principal_type": "user",
             }
         )
@@ -176,7 +176,7 @@ class TestLoadConfig:
         _save_user_config(
             {
                 "token": "axp_u_user.secret",
-                "base_url": "https://next.paxai.app",
+                "base_url": "https://paxai.app",
                 "principal_type": "user",
             }
         )
@@ -184,7 +184,7 @@ class TestLoadConfig:
         local_ax.mkdir()
         (local_ax / "config.toml").write_text(
             'token = "axp_a_agent.secret"\n'
-            'base_url = "https://next.paxai.app"\n'
+            'base_url = "https://paxai.app"\n'
             'agent_name = "orion"\n'
             'agent_id = "agent-orion"\n'
         )
@@ -209,7 +209,7 @@ class TestLoadConfig:
         token_file.write_text("axp_a_agent.secret")
         (global_dir / "profiles" / ".active").write_text("next-orion\n")
         (global_dir / "profiles" / "next-orion" / "profile.toml").write_text(
-            f'base_url = "https://next.paxai.app"\n'
+            f'base_url = "https://paxai.app"\n'
             f'agent_name = "orion"\n'
             f'agent_id = "agent-orion"\n'
             f'space_id = "next-space"\n'
@@ -230,7 +230,7 @@ class TestLoadConfig:
         cfg = _load_config()
 
         assert cfg["token"] == "axp_a_agent.secret"
-        assert cfg["base_url"] == "https://next.paxai.app"
+        assert cfg["base_url"] == "https://paxai.app"
         assert cfg["agent_name"] == "orion"
         assert cfg["agent_id"] == "agent-orion"
         assert cfg["space_id"] == "next-space"
@@ -300,7 +300,7 @@ class TestAuthDoctorDiagnostics:
         _save_user_config(
             {
                 "token": "axp_u_next.secret",
-                "base_url": "https://next.paxai.app",
+                "base_url": "https://paxai.app",
                 "principal_type": "user",
                 "space_id": "next-space",
             },
@@ -313,7 +313,7 @@ class TestAuthDoctorDiagnostics:
         assert diagnostic["ok"] is True
         assert diagnostic["selected_env"] == "default"
         assert diagnostic["effective"]["auth_source"] == "user_login:default"
-        assert diagnostic["effective"]["base_url"] == "https://next.paxai.app"
+        assert diagnostic["effective"]["base_url"] == "https://paxai.app"
         assert diagnostic["effective"]["space_id"] == "next-space"
         assert diagnostic["effective"]["principal_intent"] == "user"
 
@@ -479,7 +479,7 @@ class TestResolveToken:
         _save_user_config(
             {
                 "token": "axp_u_user.secret",
-                "base_url": "https://next.paxai.app",
+                "base_url": "https://paxai.app",
                 "principal_type": "user",
             }
         )
@@ -500,7 +500,7 @@ class TestResolveToken:
         _save_user_config(
             {
                 "token": "axp_u_next.secret",
-                "base_url": "https://next.paxai.app",
+                "base_url": "https://paxai.app",
                 "principal_type": "user",
             },
             env_name="next",

--- a/tests/test_context_commands.py
+++ b/tests/test_context_commands.py
@@ -14,7 +14,7 @@ def test_context_download_uses_base_url_and_auth_headers(monkeypatch, tmp_path):
     calls = {}
 
     class FakeClient:
-        base_url = "https://next.paxai.app"
+        base_url = "https://paxai.app"
 
         def get_context(self, key, *, space_id=None):
             assert key == "image.png"
@@ -68,7 +68,7 @@ def test_context_download_uses_base_url_and_auth_headers(monkeypatch, tmp_path):
     assert "Downloaded:" in result.output
     assert "[green]" not in result.output
     assert output.read_bytes() == b"png-bytes"
-    assert calls["url"] == "https://next.paxai.app/api/v1/uploads/files/image.png"
+    assert calls["url"] == "https://paxai.app/api/v1/uploads/files/image.png"
     assert calls["params"] == {"space_id": "space-1"}
     assert calls["headers"] == {
         "Authorization": "Bearer exchanged.jwt",
@@ -81,7 +81,7 @@ def test_context_load_fetches_to_preview_cache(monkeypatch, tmp_path):
     calls = {}
 
     class FakeClient:
-        base_url = "https://next.paxai.app"
+        base_url = "https://paxai.app"
 
         def get_context(self, key, *, space_id=None):
             assert key == "upload-key"
@@ -142,7 +142,7 @@ def test_context_load_fetches_to_preview_cache(monkeypatch, tmp_path):
     preview_files = list(tmp_path.glob("*/image.png"))
     assert len(preview_files) == 1
     assert preview_files[0].read_bytes() == b"png-bytes"
-    assert calls["url"] == "https://next.paxai.app/api/v1/uploads/files/image.png"
+    assert calls["url"] == "https://paxai.app/api/v1/uploads/files/image.png"
     assert calls["params"] == {"space_id": "space-1"}
     assert calls["headers"] == {"Authorization": "Bearer exchanged.jwt"}
     assert '"text_like": false' in result.output
@@ -150,7 +150,7 @@ def test_context_load_fetches_to_preview_cache(monkeypatch, tmp_path):
 
 def test_context_load_can_include_text_content(monkeypatch, tmp_path):
     class FakeClient:
-        base_url = "https://next.paxai.app"
+        base_url = "https://paxai.app"
 
         def get_context(self, key, *, space_id=None):
             return {

--- a/tests/test_mint_command.py
+++ b/tests/test_mint_command.py
@@ -11,7 +11,7 @@ runner = CliRunner()
 
 
 class FakeMintClient:
-    base_url = "https://next.paxai.app"
+    base_url = "https://paxai.app"
 
     def list_agents(self):
         return {
@@ -40,23 +40,23 @@ class FakeCreateFallbackClient(FakeMintClient):
     def get_agent(self, agent):
         raise httpx.HTTPStatusError(
             "not found",
-            request=httpx.Request("GET", f"https://next.paxai.app/api/v1/agents/manage/{agent}"),
+            request=httpx.Request("GET", f"https://paxai.app/api/v1/agents/manage/{agent}"),
             response=httpx.Response(
                 404,
                 json={"detail": "not found"},
-                request=httpx.Request("GET", f"https://next.paxai.app/api/v1/agents/manage/{agent}"),
+                request=httpx.Request("GET", f"https://paxai.app/api/v1/agents/manage/{agent}"),
             ),
         )
 
     def mgmt_create_agent(self, agent):
         raise httpx.HTTPStatusError(
             "Expected JSON but got HTML",
-            request=httpx.Request("POST", "https://next.paxai.app/api/v1/agents/manage/create"),
+            request=httpx.Request("POST", "https://paxai.app/api/v1/agents/manage/create"),
             response=httpx.Response(
                 200,
                 text="<!DOCTYPE html><html></html>",
                 headers={"content-type": "text/html"},
-                request=httpx.Request("POST", "https://next.paxai.app/api/v1/agents/manage/create"),
+                request=httpx.Request("POST", "https://paxai.app/api/v1/agents/manage/create"),
             ),
         )
 
@@ -65,7 +65,7 @@ class FakeCreateFallbackClient(FakeMintClient):
 
 
 def test_token_mint_prints_token_when_not_saving(monkeypatch, write_config):
-    write_config(token="axp_u_user.secret", base_url="https://next.paxai.app")
+    write_config(token="axp_u_user.secret", base_url="https://paxai.app")
     monkeypatch.setattr("ax_cli.commands.mint.get_user_client", lambda: FakeMintClient())
 
     result = runner.invoke(app, ["token", "mint", "orion"])
@@ -77,7 +77,7 @@ def test_token_mint_prints_token_when_not_saving(monkeypatch, write_config):
 def test_token_mint_create_falls_back_to_agents_api_when_management_route_is_frontend(
     monkeypatch, write_config, tmp_path
 ):
-    write_config(token="axp_u_user.secret", base_url="https://next.paxai.app")
+    write_config(token="axp_u_user.secret", base_url="https://paxai.app")
     monkeypatch.setattr("ax_cli.commands.mint.get_user_client", lambda: FakeCreateFallbackClient())
 
     result = runner.invoke(
@@ -100,7 +100,7 @@ def test_token_mint_create_falls_back_to_agents_api_when_management_route_is_fro
 
 
 def test_token_mint_hides_token_when_saved(monkeypatch, write_config, tmp_path):
-    write_config(token="axp_u_user.secret", base_url="https://next.paxai.app")
+    write_config(token="axp_u_user.secret", base_url="https://paxai.app")
     monkeypatch.setattr("ax_cli.commands.mint.get_user_client", lambda: FakeMintClient())
 
     result = runner.invoke(app, ["token", "mint", "orion", "--save-to", str(tmp_path)])
@@ -112,7 +112,7 @@ def test_token_mint_hides_token_when_saved(monkeypatch, write_config, tmp_path):
 
 
 def test_token_mint_json_hides_token_when_saved(monkeypatch, write_config, tmp_path):
-    write_config(token="axp_u_user.secret", base_url="https://next.paxai.app")
+    write_config(token="axp_u_user.secret", base_url="https://paxai.app")
     (tmp_path / ".ax" / "config.toml").chmod(0o600)
     monkeypatch.setattr("ax_cli.commands.mint.get_user_client", lambda: FakeMintClient())
 
@@ -127,7 +127,7 @@ def test_token_mint_json_hides_token_when_saved(monkeypatch, write_config, tmp_p
 
 
 def test_token_mint_can_print_saved_token_when_explicit(monkeypatch, write_config, tmp_path):
-    write_config(token="axp_u_user.secret", base_url="https://next.paxai.app")
+    write_config(token="axp_u_user.secret", base_url="https://paxai.app")
     (tmp_path / ".ax" / "config.toml").chmod(0o600)
     monkeypatch.setattr("ax_cli.commands.mint.get_user_client", lambda: FakeMintClient())
 
@@ -142,14 +142,14 @@ def test_token_mint_can_print_saved_token_when_explicit(monkeypatch, write_confi
 def test_token_mint_uses_user_login_when_local_config_is_agent(monkeypatch, write_config):
     write_config(
         token="axp_a_agent.secret",
-        base_url="https://next.paxai.app",
+        base_url="https://paxai.app",
         agent_name="orion",
         agent_id="agent-orion",
     )
     user_config_dir = Path(os.environ["AX_CONFIG_DIR"])
     user_config_dir.mkdir(parents=True, exist_ok=True)
     (user_config_dir / "user.toml").write_text(
-        'token = "axp_u_user.secret"\nbase_url = "https://next.paxai.app"\nprincipal_type = "user"\n'
+        'token = "axp_u_user.secret"\nbase_url = "https://paxai.app"\nprincipal_type = "user"\n'
     )
     monkeypatch.setattr("ax_cli.commands.mint.get_user_client", lambda: FakeMintClient())
 
@@ -160,7 +160,7 @@ def test_token_mint_uses_user_login_when_local_config_is_agent(monkeypatch, writ
 
 
 def test_token_mint_env_selects_named_user_login(monkeypatch, write_config):
-    write_config(token="axp_a_agent.secret", base_url="https://next.paxai.app", agent_name="orion")
+    write_config(token="axp_a_agent.secret", base_url="https://paxai.app", agent_name="orion")
     monkeypatch.setenv("AX_USER_TOKEN", "axp_u_dev.secret")
 
     def fake_get_user_client():


### PR DESCRIPTION
## Summary
- change CLI and channel production defaults from `https://next.paxai.app` to `https://paxai.app`
- update channel runtime/configure defaults and package metadata
- update focused tests and runtime-config example to match the canonical host

## Scope
- runtime defaults and code-level examples only
- leaves explicit `next` compatibility QA coverage in place

## Validation
- `python3 -m pytest tests/test_auth_commands.py tests/test_config.py tests/test_mint_command.py tests/test_context_commands.py tests/test_bootstrap_agent.py -q`
- `rg -n "next\.paxai\.app" ax_cli channel tests pyproject.toml specs/RUNTIME-CONFIG-001/spec.md` only returns the explicit QA alias check