### PR TITLE
Fix context download after space switching

### DIFF
--- a/ax_cli/commands/context.py
+++ b/ax_cli/commands/context.py
@@ -118,7 +118,10 @@ def _fetch_context_file(client, sid: str | None, payload: dict) -> bytes:
     download_url = urljoin(f"{client.base_url}/", url)
     headers = {k: v for k, v in client._auth_headers().items() if k != "Content-Type"}
     with httpx.Client(headers=headers, timeout=60.0, follow_redirects=True) as http:
-        response = http.get(download_url, params={"space_id": sid} if sid else None)
+        # Upload downloads are authorized against the attachment's owning
+        # space. Passing the caller's current space can turn a valid download
+        # into a 404 after the user switches spaces.
+        response = http.get(download_url)
         response.raise_for_status()
         return response.content
 

--- a/tests/test_context_commands.py
+++ b/tests/test_context_commands.py
@@ -69,7 +69,7 @@ def test_context_download_uses_base_url_and_auth_headers(monkeypatch, tmp_path):
     assert "[green]" not in result.output
     assert output.read_bytes() == b"png-bytes"
     assert calls["url"] == "https://paxai.app/api/v1/uploads/files/image.png"
-    assert calls["params"] == {"space_id": "space-1"}
+    assert calls["params"] is None
     assert calls["headers"] == {
         "Authorization": "Bearer exchanged.jwt",
         "X-AX-FP": "fp",
@@ -143,7 +143,7 @@ def test_context_load_fetches_to_preview_cache(monkeypatch, tmp_path):
     assert len(preview_files) == 1
     assert preview_files[0].read_bytes() == b"png-bytes"
     assert calls["url"] == "https://paxai.app/api/v1/uploads/files/image.png"
-    assert calls["params"] == {"space_id": "space-1"}
+    assert calls["params"] is None
     assert calls["headers"] == {"Authorization": "Bearer exchanged.jwt"}
     assert '"text_like": false' in result.output
 


### PR DESCRIPTION
## Summary
- stop sending a current-space hint when downloading upload-backed context files
- rely on backend authorization against the attachment's owning space
- keep the context download/load tests aligned with the new behavior

## Validation
- python3 -m pytest tests/test_context_commands.py -q