### PR TITLE
docs(claude-md): add current-state header, align on main/paxai.app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,14 @@
-# CLAUDE.md
+# CLAUDE.md — ax-cli
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+> **Current state (read first, 2026-04-23)**
+>
+> | Target | Branch | URL | Gating |
+> |---|---|---|---|
+> | Local dev | any | local backend | none |
+> | Staging | `dev/staging` | https://dev.paxai.app | @orion merge review |
+> | Production | `main` | https://paxai.app | @madtank signoff + CI (PyPI as `axctl`) |
+>
+> **`aws/prod` is frozen legacy** — do not target. ax-cli ships via PyPI from `main`.
 
 ## What This Is
 
@@ -55,3 +63,9 @@ User login credentials are deliberately separate from runtime agent config:
 - Selection: `AX_ENV`, `AX_USER_ENV`, `axctl login --env`, and user-authored commands that take `--env`
 
 Do not put reusable user PATs in `.ax/config.toml` or `~/.ax/config.toml`. User PATs bootstrap and mint agent credentials; agent runtime work should use agent PAT profiles or project-local agent runtime config.
+
+## How to ship
+
+1. Branch off `dev/staging` (or `main` for tight hotfixes).
+2. PR against `main`. CI runs pytest + ruff. Merge → PyPI publish on tag.
+3. `ax-cli` does not use `aws/prod` — that branch exists for historical alignment only.


### PR DESCRIPTION
Part of CLAUDE.md PR wave. Siblings: ax-backend#306, ax-frontend#267, ax-mcp-server#208, ax-agents#111.

ax-cli was already clean — this adds just the decision-table header + a brief `How to ship` section for consistency with the other 4 repos. ~10 additive lines.