### PR TITLE
docs(spec): AVAIL-CONTRACT — iteration v2/v3/v4 (expected_response, connection_path, backend pairing)

### DIFF
--- a/specs/AGENT-AVAILABILITY-CONTRACT-001/spec.md
+++ b/specs/AGENT-AVAILABILITY-CONTRACT-001/spec.md
@@ -1,11 +1,21 @@
 # AGENT-AVAILABILITY-CONTRACT-001: Cross-Surface Presence + Routability Contract
 
-**Status:** Outline (early stub — open for shape feedback)
+**Status:** Draft v4 (spec scope locked, paired with backend `GATEWAY-PRESENCE-DATA-MODEL-001`)
 **Owner:** @orion (spec) → backend_sentinel / frontend_sentinel / cli_sentinel / mcp_sentinel (implementation per surface)
 **Source directive:** @ChatGPT 2026-04-24 23:27 (channel msg `284cd29f`)
 **Sprint:** Gateway Sprint 1 (Trifecta Parity), umbrella [`d21e60ea`](aX)
-**Date:** 2026-04-24
-**Related:** [GATEWAY-CONNECTION-MODEL-001](../GATEWAY-CONNECTION-MODEL-001/rfc.md), [GATEWAY-CONNECTIVITY-001](../GATEWAY-CONNECTIVITY-001/spec.md), [GATEWAY-PLACEMENT-POLICY-001](../GATEWAY-PLACEMENT-POLICY-001/spec.md), backend tasks `781f5781` (data model + API contract), `0706d5fa` (telemetry ingestion), `0f236fed` (disable/quarantine)
+**Date:** 2026-04-24 → 2026-04-25 (v4)
+**Related:** [GATEWAY-PRESENCE-DATA-MODEL-001](../../../ax-backend/specs/GATEWAY-PRESENCE-DATA-MODEL-001/spec.md) (backend data-model, **upstream truth for badge vocabulary**), [GATEWAY-CONNECTION-MODEL-001](../GATEWAY-CONNECTION-MODEL-001/rfc.md), [GATEWAY-CONNECTIVITY-001](../GATEWAY-CONNECTIVITY-001/spec.md), [GATEWAY-PLACEMENT-POLICY-001](../GATEWAY-PLACEMENT-POLICY-001/spec.md), backend tasks `781f5781` (data model + API contract), `0706d5fa` (telemetry ingestion), `0f236fed` (disable/quarantine). Canonical visual mock: `Agent Availability.html` (design-system project, cipher 2026-04-25).
+
+## Scope boundary (what this spec is NOT)
+
+This spec covers **agent availability and routability** as a pre-/post-send presence contract. It does NOT define:
+
+- **Message/reply lifecycle SSE contract** (e.g. `reply.received` events, spinner→✓ swap on bubble-chrome). That belongs in a separate spec keyed by `message_id`/`thread_id`/`recipient_agent_id` — flagged by backend_sentinel + cipher 2026-04-25 as not in scope here.
+- **Placement state machine** (current/default/allowed spaces, ack tracking). That lives in [GATEWAY-PLACEMENT-POLICY-001](../GATEWAY-PLACEMENT-POLICY-001/spec.md). This spec consumes placement state via `placement_state_at_check` in the resolution algorithm.
+- **Heartbeat protocol cadence and transport.** Defined elsewhere; this spec only consumes "did the agent meet its declared cadence?" as the Responsive axis.
+
+Any reply-lifecycle requirement that surfaces during implementation gets routed to that separate spec, not folded here.
 
 ## Why this exists
 
@@ -21,7 +31,7 @@ This spec defines the contract once and forces all four surfaces (backend, front
 
 `active` is a control-plane label only — it means "not disabled, allowed by control plane." It must NEVER appear alone as a presence/availability indicator. Whatever the UI shows the user pre-send must answer the response-expectation question, not the registry-state question.
 
-This shapes everything below: the 6 axes are how we *compute* presence; `expected_response` is how we *display* it; the surface contracts enforce that no surface lies by collapsing.
+This shapes everything below: the 6 axes are how we *compute* presence; `expected_response` is the *semantic* answer; `badge_state`/`badge_label` are the *visual* answer; the surface contracts enforce that no surface lies by collapsing.
 
 ## The six axes (orthogonal, not hierarchical)
 
@@ -44,9 +54,16 @@ A disabled agent: Registered ✓, Enabled ✗, anything else moot.
 
 The contract preserves these orthogonally instead of OR-merging.
 
-## Data model — 10-field presence record
+## Data model — resolved DTO (`agent_state`)
 
-Every agent has one record. Refresh on Gateway events, on heartbeat ingestion, and on a 60s reconcile sweep.
+Every agent has one resolved record. Backend distinguishes:
+
+- **`agent_presence`** — raw observations/events reported by gateways, runtimes, dispatchers, backend probes. Used for diagnostics and audit trail.
+- **`agent_state`** — resolved DTO consumed by clients (frontend, CLI, MCP, agent-to-agent). This is the field set defined below. Backend confidence, TTLs, and source-of-truth precedence are all applied here before the DTO ships.
+
+**Clients render and route on `agent_state` only.** Raw `agent_presence` is for debugging and audit, not for display. This separation is required so a noisy gateway event stream can't poison the UI.
+
+Refresh `agent_state` on Gateway events, on heartbeat ingestion, on placement transitions, and on a 60s reconcile sweep.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -57,13 +74,17 @@ Every agent has one record. Refresh on Gateway events, on heartbeat ingestion, a
 | `presence_confidence` | enum | `high` \| `medium` \| `low` — `high` only when source_of_truth is Gateway and last reconcile was within 60s |
 | `messages_routable` | bool | Derived per the Routable axis logic |
 | `connection_mode` | enum | `live_listener` \| `on_demand_warm` \| `inbox_queue` \| `disconnected` — runtime *processing* model: how the runtime handles a message when it arrives |
-| `connection_path` | enum | **Orthogonal to `connection_mode`**. How the agent reaches the platform at all: `gateway_managed` \| `mcp_only` \| `direct_cli` \| `direct_sse`. A `gateway_managed` agent can be `live_listener`; an `mcp_only` agent can never be `live_listener` — only `on_demand_warm` or `inbox_queue`. |
+| `connection_path` | enum | **Orthogonal to `connection_mode`**. How the agent reaches the platform at all: `gateway_managed` \| `mcp_only` \| `direct_cli` \| `direct_sse` \| `unknown`. A `gateway_managed` agent can be `live_listener`; an `mcp_only` agent can never be `live_listener` — only `on_demand_warm` or `inbox_queue`. `unknown` only when no observation has been recorded (cold start). |
 | `gateway_label` | string? | "managed by `<gateway_id>` on `<host>`" — null for direct-mode agents |
 | `disconnect_reason` | enum? | `clean_shutdown` \| `crash` \| `idle_timeout` \| `auth_failure` \| `network_error` \| `disabled_by_operator` \| `unknown` — null while connected |
 | `status_explanation` | string | Human-readable one-liner. UI tooltip surfaces this. Generated server-side from the structured fields. |
-| `expected_response` | enum | **First-class display field.** `immediate` \| `warming` \| `queued` \| `unlikely` \| `unavailable`. Derived from the rest of the record but elevated as the answer to "what happens if I send now?" |
-| `unavailable_reason` | enum? | Machine-readable reason when `expected_response in {unlikely, unavailable}`: `disabled` \| `no_live_session` \| `warming_available` \| `gateway_disconnected` \| `heartbeat_stale` \| `runtime_stuck` \| `setup_required` \| `unknown`. Null when response is expected. Distinct from `disconnect_reason` (history) — this is current-state. |
+| `expected_response` | enum | **First-class semantic field.** `immediate` \| `warming` \| `dispatch_delayed` \| `queued` \| `unlikely` \| `unavailable` \| `unknown`. Derived from the rest of the record. Answers "what happens if I send now?" Routing-decision field for cloud agents. |
+| `unavailable_reason` | enum? | Machine-readable reason when `expected_response in {unlikely, unavailable}`: `disabled` \| `no_live_session` \| `warming_available` \| `gateway_disconnected` \| `heartbeat_stale` \| `runtime_stuck` \| `setup_required` \| `placement_unconfirmed` \| `unknown`. Null when response is expected. Distinct from `disconnect_reason` (history) — this is current-state. |
 | `presence_age_seconds` | int | Derived: seconds since `last_seen_at`. Lets UI render "last seen 2m ago" without each surface re-computing. Confidence visibly decays with age. |
+| `badge_state` | enum | **Primary UI display field** (per backend `GATEWAY-PRESENCE-DATA-MODEL-001`). `live` \| `routable_delayed` \| `queued_only` \| `blocked` \| `offline` \| `unknown`. Six values, one vocabulary across all four surfaces. Derived from `expected_response` per the badge mapping table below. |
+| `badge_label` | string | Human-readable label paired with `badge_state`: `Live` / `Warming` / `Dispatch` / `Queued` / `Stuck` / `Blocked` / `Offline` / `Unknown`. Note: `routable_delayed` resolves to `Warming` for hermes-style warm-up paths and `Dispatch` for `mcp_only` cloud-agent paths — same state, two contextual labels. |
+| `badge_color` | string | Semantic token (`success` / `info` / `warning` / `danger` / `neutral`), NOT a hard-coded color. Frontend/MCP own the actual hex/OKLCH mapping in their design tokens. |
+| `pre_send_warning` | object? | Structured warning when delivery is non-immediate or blocked: `{severity: "info"\|"warning"\|"error", title, body}`. Null when `expected_response == immediate`. Composer/CLI/widget surface this verbatim before send. |
 
 `status_explanation` is the single string the UI shows on hover. Examples:
 - "Connected to Gateway `e6ec96…` on `paxai-staging-1`. Last heartbeat 4s ago."
@@ -106,13 +127,15 @@ For each agent:
 
 ```
 - not enabled                                            → unavailable    (reason: disabled)
-- connection_path == mcp_only AND messages_routable      → warming OR queued (NEVER immediate — MCP-only agents always go through cloud-agent dispatch, never have a live local listener)
+- connection_path == mcp_only AND messages_routable      → dispatch_delayed (NEVER immediate — MCP-only agents always go through cloud-agent dispatch, typically 5-30s)
+- placement_state in {pending, runtime_unconfirmed}      → unlikely (reason: placement_unconfirmed)  — overrides immediate even when connected
 - online_now AND responsive                              → immediate
 - online_now AND NOT responsive (heartbeat stale)        → unlikely (reason: runtime_stuck)
 - NOT online_now AND connection_mode == on_demand_warm AND messages_routable → warming
 - NOT online_now AND connection_mode == inbox_queue      → queued
 - NOT online_now AND messages_routable == false          → unavailable (reason matches latest disconnect/setup state)
 - presence_confidence == low AND last_seen > 24h         → unlikely (reason: heartbeat_stale)
+- presence_confidence == low AND no recent observation   → unknown
 - otherwise                                              → queued (default soft-fail)
 ```
 
@@ -120,15 +143,70 @@ For each agent:
 
 Precedence is **explicit** — Gateway truth always wins. No OR-merge.
 
+**Hard invariant** (from backend `GATEWAY-PRESENCE-DATA-MODEL-001`): `connection_path == "mcp_only"` MUST NOT resolve to `expected_response == "immediate"` regardless of any other signal. MCP-only / dispatch-mediated agents are routable at best, but must not render as live/immediate. Implementations enforce this at the resolver layer, not at each surface.
+
+## UI badge contract — `badge_state` mapping
+
+The 7-value `expected_response` enum maps to a 6-value `badge_state` vocabulary that all four surfaces render against. Surfaces choose color/iconography from local design tokens but MUST NOT re-infer state from raw fields.
+
+| `expected_response` | `badge_state` | `badge_label` | `badge_color` (semantic) |
+|---|---|---|---|
+| `immediate` | `live` | `Live` | `success` |
+| `warming` | `routable_delayed` | `Warming` | `info` |
+| `dispatch_delayed` | `routable_delayed` | `Dispatch` | `info` |
+| `queued` | `queued_only` | `Queued` | `info` |
+| `unlikely` | `blocked` | `Stuck` | `warning` |
+| `unavailable` (reason: disabled) | `blocked` | `Blocked` | `danger` |
+| `unavailable` (other reasons) | `offline` | `Offline` | `neutral` |
+| `unknown` | `unknown` | `Unknown` | `neutral` (dashed/outline variant) |
+
+`routable_delayed` is the only `badge_state` with two `badge_label` variants — `Warming` for hermes-style local warm-up, `Dispatch` for cloud-agent paths. The split tells users *why* delay is expected without forcing two separate states. Backend resolves which label to attach based on `connection_path`.
+
+`badge_color` is a **semantic token**, not a CSS color. Frontend/MCP own the OKLCH/hex mapping per their design tokens.
+
+### Picker grouping (mention picker / quick-action surfaces)
+
+The mention picker collapses the 6 `badge_state` values into 3 user-facing groups for compose-time routing decisions. **Picker grouping is a presentation concern, not a backend state** — backend never returns a "Reachable" or "Won't reach" group code; surfaces compute it.
+
+| Group | `badge_state` members | Meaning |
+|---|---|---|
+| **Live** | `live` | Send now, expect reply within seconds |
+| **Reachable** | `routable_delayed`, `queued_only` | Send now, expect reply with delay (warming / dispatch / queue) |
+| **Won't reach** | `blocked`, `offline`, `unknown` | Send is blocked or fails — composer warns or refuses |
+
+Grouping reflects current state only. Picker does NOT show historical state (e.g. "alice was Live 30s ago"). Bubble-chrome handles per-message lifecycle and persistence; picker stays compose-time-only.
+
+### `pre_send_warning` shape
+
+When `expected_response != immediate`, the resolved DTO carries a structured warning the composer surfaces verbatim:
+
+```json
+{
+  "severity": "info" | "warning" | "error",
+  "title": "Delivery may be delayed",
+  "body": "This agent is reachable through MCP dispatch, not a live immediate session."
+}
+```
+
+`severity == info` for `dispatch_delayed`/`warming`/`queued`. `severity == warning` for `unlikely` (stuck/heartbeat-stale). `severity == error` for `unavailable` with `unavailable_reason in {disabled, runtime_stuck}`. CLI prints the title before the prompt; widgets show a colored callout; frontend renders an inline composer banner.
+
 ## API shape
 
 ### `GET /api/v1/agents` — list
 
-Each row gains a `presence` sub-object containing all 10 fields above. Backwards compat: `agents.is_online` (legacy) deprecated, kept for one release with a deprecation header, then removed.
+Each row gains an `agent_state` sub-object (the resolved DTO). Backwards compat: `agents.is_online` (legacy) deprecated, kept for one release with a deprecation header, then removed.
+
+### `GET /api/v1/agents/availability` — list/filter for pickers + dashboards
+
+Returns array of `agent_state` DTOs scoped to the caller's space, optimized for picker rendering. Supports query params `?connection_path=…&badge_state=…&filter=available_now|gateway_connected|cloud_agent|disabled|recently_active` (multi-filter AND-composed). This is the canonical endpoint for the mention picker, MCP app widget, and quick-action bar.
 
 ### `GET /api/v1/agents/{id}/presence` — full record + audit
 
-Returns the 10 fields plus an `audit` array of last 10 transitions (timestamp, from-state, to-state, source) so debugging "why is this agent stuck" is possible without reading server logs.
+Returns the resolved `agent_state` DTO plus an `audit` array of last 10 transitions (timestamp, from-state, to-state, source) so debugging "why is this agent stuck" is possible without reading server logs. Also returns last N raw `agent_presence` events for diagnostics.
+
+### `POST /api/v1/agents/{id}/presence/events` — gateway/runtime ingestion
+
+Authenticated event-ingestion endpoint for gateway daemons, runtimes, and dispatchers to push raw observations. Body is a single observation event with source, timestamps, and any axis evidence. Backend persists to `agent_presence` (raw) and triggers re-resolution of `agent_state` (resolved). Auth: gateway principal or scoped token only — never a user PAT.
 
 ### `POST /api/v1/messages` (send path)
 
@@ -199,35 +277,72 @@ The expectation: cloud agents make routing decisions on structured data, not by 
 
 ### Frontend (`AVAIL-CONTRACT-001-frontend` → frontend_sentinel)
 
-**Primary display field**: `expected_response`. Every agent card/row leads with this, not with a generic "active" pill. **`active` is never shown alone** as a presence indicator.
+**Primary display field**: `badge_state` + `badge_label`. Every agent card/row leads with the badge, not with a generic "active" pill. **`active` is never shown alone** as a presence indicator. Canonical visual mock: `Agent Availability.html` (design-system project, 4 surfaces × 6 states).
 
-- Replace single "Active/Online" pill on agent cards with **expected-response chip + supporting badges**:
-  - **Expected response chip** (primary, large): "Immediate" / "Warming" / "Queued" / "Unlikely" / "Unavailable" with color-coding (green / amber / blue / orange / red)
-  - **Connected Now** badge — green if `online_now=true`, gray if false
-  - **Confidence** badge — High / Medium / Low (visually distinct from connection state)
+Four surfaces consume the same DTO with the same vocabulary:
+
+#### 1. Agent card (roster view)
+
+- Replace single "Active/Online" pill with **badge chip + supporting metadata**:
+  - **Badge chip** (primary, large): renders `badge_label` colored per `badge_color` semantic token. Six-state vocabulary: Live / Warming / Dispatch / Queued / Stuck / Blocked / Offline / Unknown.
+  - **Connection-path tag** (secondary, distinct): `Gateway` (success), `Cloud` (info), `CLI` (neutral), `SSE` (neutral), `Unknown` (neutral outline).
   - **Last seen** chip — relative time from `presence_age_seconds`, decays visibly with age
+  - **Confidence** indicator — high / medium / low (visually distinct from badge state)
   - **Disabled** banner overrides everything when not control-active
-- Tooltip on the expected-response chip shows: `status_explanation` + structured `unavailable_reason` when present.
-- Composer / mention picker surfaces the same chip+badges before send. When `expected_response in {unlikely, unavailable}`, render a soft warning ("This agent is `<reason>`. Send anyway?").
-- Activity stream renders `delivery_path` after send, with explicit disagreement signal when prediction ≠ reality ("predicted warming, actually live").
-- Filters in roster view: `Connected now`, `Routable now` (= expected_response in {immediate, warming, queued}), `Gateway-managed`, `Disabled`, `Needs setup/attention` (= unavailable_reason in {setup_required, runtime_stuck}). Multi-filter = AND.
-- Concrete target UX (from ChatGPT 2026-04-25 directive):
-  - `night_owl`: Connected now · Immediate · CLI session · High confidence
-  - `backend_sentinel`: Enabled · Not connected · Warming · Last replied 12m ago · Medium confidence
-  - `aX`: Disabled · Unavailable · Not routable
-  - stuck agent: Connected · Unlikely · Needs attention (heartbeat_stale)
-- Acceptance: roster reads correctly for all 4 test agents above; filters return expected subsets; composer warns appropriately; activity stream shows delivery_path post-send with disagreement signal when applicable.
+- Tooltip on the badge chip shows: `status_explanation` + structured `unavailable_reason` when present. For `connection_path == mcp_only` agents, tooltip explicitly notes "Cloud agent — replies via dispatch, typically 5-30s, not a live listener."
+
+#### 2. Mention picker (`@name` autocomplete)
+
+Three groups, deterministic from `badge_state` (per design-system mock):
+
+- **Live** — `badge_state == live` agents
+- **Reachable** — `badge_state in {routable_delayed, queued_only}`
+- **Won't reach** — `badge_state in {blocked, offline, unknown}`
+
+Group headers are picker-side labels (not backend state codes). Within each group, sort by `presence_age_seconds` ascending. "Won't reach" group is collapsed by default — user expands to send anyway.
+
+#### 3. Composer (pre-send)
+
+When the targeted agent's `pre_send_warning` is non-null, render an inline composer banner with `severity` color, `title` as headline, `body` as supporting copy. Severity `error` (e.g. `unavailable + disabled`) blocks the send button; severity `warning` (`unlikely`) shows a confirm-dialog ("Send anyway?"); severity `info` lets send proceed but visibly informs.
+
+#### 4. Activity stream (post-send)
+
+Render `delivery_path` inline on the message bubble — chip transitions Send → Reply → Settled per the bubble-chrome FRONTEND-021 polish (separate spec). Disagreement signal explicit when prediction ≠ reality ("predicted warming, actually live"). Note: bubble-chrome lifecycle is owned by a separate message/reply-lifecycle spec (out of scope here); this contract just supplies the `expected_response_at_send` and `delivery_path` fields.
+
+#### Filters in roster view
+
+Multi-filter, AND-composed:
+
+- **Available now** (= `badge_state in {live, routable_delayed, queued_only}`)
+- **Live only** (= `badge_state == live`)
+- **Gateway-connected** (= `connection_path == gateway_managed`)
+- **Cloud agent** (= `connection_path == mcp_only`)
+- **Disabled**
+- **Needs attention** (= `unavailable_reason in {setup_required, runtime_stuck, placement_unconfirmed}`)
+- **Recently active** (replied within last hour)
+
+#### Concrete target UX
+
+- `night_owl`: Live · Gateway · Last seen 4s · High confidence
+- `backend_sentinel`: Warming · Cloud · Last replied 12m ago · Medium confidence
+- `aX`: Disabled · Blocked · Not routable
+- `mcp_only` cloud agent under load: Dispatch · Cloud · 18s avg dispatch
+- stuck agent: Stuck · Gateway · Needs attention (heartbeat_stale)
+
+#### Acceptance
+
+Roster reads correctly for all 5 target UX agents; mention picker groups them into Live/Reachable/Won't reach correctly; filters return expected subsets; composer surfaces `pre_send_warning` verbatim; activity stream shows `delivery_path` post-send with disagreement signal when applicable. 24 Storybook stories (4 surfaces × 6 states) and 48 Playwright snapshots (× dark/light) per design-system mock checklist.
 
 ### CLI (`AVAIL-CONTRACT-001-cli` → cli_sentinel)
 
-**Primary column**: `Expected` (response). `axctl agents list` leads with `Expected` not with `Active`.
+**Primary column**: `Status` (= `badge_label`). `axctl agents list` leads with `Status` not with `Active`.
 
-- `axctl agents list` default columns: Name, **Expected**, Connected, Last seen, Mode, Gateway, Confidence. Add `--full` flag for all 13 fields (10 base + `expected_response` + `unavailable_reason` + `presence_age_seconds`).
-- New flags: `--filter connected | routable | gateway-managed | disabled | attention | expected:immediate | expected:warming | expected:queued | expected:unlikely | expected:unavailable`.
-- New command: `axctl agents check <name>` — returns full presence record + audit array. Output includes the structured `unavailable_reason` field, not just prose.
-- Pre-send confirmation: `axctl messages send` against an agent whose `expected_response in {unlikely, unavailable}` prints a one-line warning ("`<name>` is `<unavailable_reason>`. Continue? [y/N]") unless `--no-confirm` is set.
-- `--json` everywhere serializes the same record as the API.
-- Acceptance: `axctl agents list` and the Agents widget show identical Expected/Connected/Mode columns for the same set of agents; pre-send warning fires for unlikely/unavailable targets.
+- `axctl agents list` default columns: Name, **Status**, Path, Last seen, Mode, Confidence. `Status` renders `badge_label` (Live / Warming / Dispatch / Queued / Stuck / Blocked / Offline / Unknown). `Path` renders `connection_path` short-form (Gateway / Cloud / CLI / SSE / Unknown). Add `--full` flag for the entire resolved DTO.
+- New flags: `--filter connected | routable | gateway-managed | cloud-agent | disabled | attention | live | reachable | wont-reach`. Group filters (`live`, `reachable`, `wont-reach`) match the picker grouping vocabulary; per-axis filters (`connected`, `gateway-managed`) match backend axes.
+- New command: `axctl agents check <name>` — returns full resolved DTO + audit array. Output includes the structured `unavailable_reason` and `pre_send_warning` fields, not just prose.
+- Pre-send confirmation: `axctl messages send` consumes the target's `pre_send_warning`. When present with `severity in {warning, error}`, prints `title` and prompts confirm ("Continue? [y/N]") unless `--no-confirm` is set. `severity == info` prints the title but proceeds without prompt.
+- `--json` everywhere serializes the same DTO as the API.
+- Acceptance: `axctl agents list` and the MCP app widget show identical Status/Path/Last seen columns for the same set of agents; pre-send warning fires for warning/error severities; group filters return same membership as picker groupings.
 
 ### MCP (`AVAIL-CONTRACT-001-mcp` → mcp_sentinel)
 
@@ -246,26 +361,30 @@ The agents quick-action picker in the MCP app widget is **the canonical user-fac
 
 Required widget capabilities:
 
-- **Per-row display**: Name, Expected response chip (Immediate / Warming / Queued / Unlikely / Unavailable), Connection-path tag (visually distinct), Last seen, Confidence — same fields as frontend roster, same color scheme so the user sees identical information across surfaces.
-- **Connection-path tag is visually distinct**:
-  - `gateway_managed` — green "Gateway" tag (live, supervised, fast paths expected)
-  - `mcp_only` — blue "Cloud" tag (replies via cloud-agent dispatch, **typically 5-30s — NOT immediate**)
-  - `direct_cli` — neutral "CLI" tag (legacy direct subscriber)
-  - `direct_sse` — neutral "SSE" tag (frontend / third-party)
+- **Per-row display**: Name, badge chip (`badge_label` colored per `badge_color` token), Connection-path tag (visually distinct), Last seen, Confidence — same fields as frontend roster, same vocabulary so the user sees identical information across surfaces.
+- **Connection-path tag** uses semantic tokens, NOT hard-coded colors:
+  - `gateway_managed` — `success` "Gateway" tag (live, supervised, fast paths expected)
+  - `mcp_only` — `info` "Cloud" tag (replies via cloud-agent dispatch, **typically 5-30s — NOT immediate**)
+  - `direct_cli` — `neutral` "CLI" tag (legacy direct subscriber)
+  - `direct_sse` — `neutral` "SSE" tag (frontend / third-party)
+  - `unknown` — `neutral` outline "Unknown" tag (no observation yet)
 - **Filters in the picker** (multi-select, AND-compose):
-  - **Available now** (= `expected_response in {immediate, warming}`)
+  - **Available now** (= `badge_state in {live, routable_delayed, queued_only}`)
+  - **Live only** (= `badge_state == live`)
   - **Gateway-connected** (= `connection_path == gateway_managed`)
   - **Cloud agent** (= `connection_path == mcp_only`)
   - **Disabled**
   - **Recently active** (replied within last hour)
-- **Hover/tooltip on Expected chip**: surfaces `status_explanation` + `unavailable_reason` (if applicable). For `mcp_only` agents, tooltip explicitly notes "Cloud agent — replies via dispatch, typically 5-30s, not a live listener."
-- **Pre-send confirmation in widget**: when user picks an agent whose `expected_response in {unlikely, unavailable}`, show a soft warning ("This agent is `<reason>`. Send anyway?").
+- **Picker grouping** (when rendered as a list, not flat search): Live · Reachable · Won't reach groups, identical to frontend mention picker — same DTO, same grouping, same vocabulary.
+- **Hover/tooltip on badge chip**: surfaces `status_explanation` + `unavailable_reason` (if applicable). For `mcp_only` agents, tooltip explicitly notes "Cloud agent — replies via dispatch, typically 5-30s, not a live listener."
+- **Pre-send confirmation in widget**: surfaces `pre_send_warning` verbatim. `severity == info` shows callout but allows send; `severity == warning` requires confirm; `severity == error` blocks send.
 - **`active` is never shown alone** in the widget — same rule as the frontend roster.
 
 **Acceptance** (combined tool + widget):
-- Programmatic: an MCP-driven agent can call `agents(action='check', name='dev_sentinel')`, read `expected_response='immediate'` and `connection_path='gateway_managed'`, and decide to send vs route elsewhere without any additional probe.
-- Widget: a user opening the agents quick-action sees `dev_sentinel` with green "Gateway" tag + Immediate chip; `mcp_only` cloud agents with blue "Cloud" tag + Warming/Queued chip; disabled agents red-banner-suppressed.
+- Programmatic: an MCP-driven agent can call `agents(action='check', name='dev_sentinel')`, read `expected_response='immediate'`, `badge_state='live'`, and `connection_path='gateway_managed'`, and decide to send vs route elsewhere without any additional probe.
+- Widget: a user opening the agents quick-action sees `dev_sentinel` with `success` "Gateway" tag + `Live` chip; `mcp_only` cloud agents with `info` "Cloud" tag + `Dispatch` chip; disabled agents red-banner-suppressed.
 - Filter test: applying "Cloud agent" filter shows only `connection_path=mcp_only` agents; "Gateway-connected" shows only `gateway_managed`. Multi-filter intersection AND-composes.
+- Cross-surface invariant: same agent rendered in mention picker, MCP app widget, and `axctl agents list` shows the same `badge_label` and `connection_path` short-form. Programmatic comparison gates the smoke.
 
 ### Smoke (`AVAIL-CONTRACT-001-smoke` → orion)
 
@@ -310,4 +429,16 @@ Concrete coupling: a Gateway-managed agent in `placement_state=pending` shows:
 - **2026-04-24** — Outline posted as draft PR. Spec scope locked: 10-field presence record, 4-surface contract, send-time stamping, 5-smoke acceptance gate.
 - **2026-04-25** — Iteration after @ChatGPT 2026-04-25 00:05 directive: elevated `expected_response` to first-class display field, separated from `messages_routable`; added `unavailable_reason` structured enum (9 codes incl. `placement_unconfirmed`); added `presence_age_seconds` for confidence decay; added explicit pre-send + post-send UX requirement sections; added agent-to-agent contract section; clarified that `active` is control-plane only, never sole presence indicator; linked placement (`36fd22ed`) as paired upstream truth.
 - **2026-04-25 (later)** — Iteration after @madtank 2026-04-25 00:39 directive: added `connection_path` field (orthogonal to `connection_mode`) with values `gateway_managed`/`mcp_only`/`direct_cli`/`direct_sse`; expanded MCP surface contract to TWO deliverables (programmatic tool + user-facing app widget) with the widget defined as the canonical user surface for presence; specified per-row display, connection-path color tags, multi-select filters (Available now / Gateway-connected / Cloud agent / Disabled / Recently active), and hover tooltip behavior; encoded rule that `connection_path == mcp_only` can never produce `expected_response == immediate` (cloud agents always go through dispatch, never have live local listener).
+- **2026-04-25 v4** — Paired with backend `GATEWAY-PRESENCE-DATA-MODEL-001` (backend_sentinel, just landed). Folded in:
+  - **Resolved DTO vs raw observations**: backend distinguishes `agent_state` (resolved, what clients consume) from `agent_presence` (raw observations, for diagnostics/audit). Spec adopts this terminology and clarifies clients render on `agent_state` only.
+  - **`expected_response` enum extended to 7 values**: added `dispatch_delayed` (MCP-only path; routable but not immediate, typically 5-30s) and `unknown` (low-confidence cold start). The previous "warming OR queued (NEVER immediate)" rule for `mcp_only` is sharpened to a dedicated `dispatch_delayed` value so warming (hermes-style local warm-up) and dispatch (cloud-agent path) are visually distinct.
+  - **`connection_path` enum extended**: added `unknown` for cold-start agents with no observation yet.
+  - **`unavailable_reason` enum extended**: added `placement_unconfirmed` for connected-but-placement-pending agents.
+  - **Four new DTO fields** (UI-ready, computed server-side): `badge_state` (6 values: live/routable_delayed/queued_only/blocked/offline/unknown), `badge_label` (Live/Warming/Dispatch/Queued/Stuck/Blocked/Offline/Unknown), `badge_color` (semantic token: success/info/warning/danger/neutral), `pre_send_warning` (structured `{severity, title, body}`). Surfaces consume these directly; never re-infer.
+  - **`badge_state` mapping table** ties expected_response → badge_state → badge_label → badge_color. `routable_delayed` is the only state with two label variants (Warming vs Dispatch) — same state, two contextual labels selected by `connection_path`.
+  - **Picker grouping section**: 3 user-facing groups (Live / Reachable / Won't reach) collapse 6 badge_state values for compose-time routing. Picker grouping is presentation-only — backend never returns a group code. Bubble-chrome lifecycle stays out of scope (separate spec).
+  - **API surface added**: `GET /api/v1/agents/availability` (canonical picker/widget endpoint with multi-filter), `POST /api/v1/agents/{id}/presence/events` (gateway/runtime ingestion with TTL-bound observations).
+  - **All four surface contracts updated** to lead with `badge_state`/`badge_label` instead of `expected_response` chip vocabulary; CLI primary column renamed Expected → Status; mention-picker grouping made canonical with backend-blessed mapping; MCP widget acceptance includes cross-surface vocabulary invariant (axctl + widget + roster all show identical labels for the same agent).
+  - **Scope boundary section added**: explicit out-of-scope for message/reply lifecycle SSE contract, placement state machine, heartbeat protocol cadence — flagged by backend_sentinel + cipher 2026-04-25 to prevent fold-in pressure during implementation.
+  - **Cross-ref to canonical mock**: `Agent Availability.html` (design-system project, cipher 2026-04-25) is the canonical visual mock; sign-off checklist on the mock is the spec acceptance for the four surfaces.
 - (subsequent decisions land here.)


### PR DESCRIPTION
Iterates the AGENT-AVAILABILITY-CONTRACT-001 spec from the v1 outline merged in #96 to v4 paired with backend's GATEWAY-PRESENCE-DATA-MODEL-001 spec.

## What changed

Three iterations stack on top of v1:

**v2** (`52b3146`) — elevated `expected_response` to first-class field, separated from `messages_routable`; added `unavailable_reason` structured enum; added `presence_age_seconds` for confidence decay; added explicit pre-send + post-send UX requirement sections; added agent-to-agent contract section; clarified `active` is control-plane only; linked placement spec.

**v3** (`e1fca23`) — added `connection_path` field (orthogonal to `connection_mode`) with values `gateway_managed` / `mcp_only` / `direct_cli` / `direct_sse`; expanded MCP surface contract to TWO deliverables (programmatic tool + user-facing app widget) with widget defined as the canonical user surface for presence; encoded hard invariant: `connection_path == mcp_only` never produces `expected_response == immediate`.

**v4** (`6fe1b55`) — pairs with backend `GATEWAY-PRESENCE-DATA-MODEL-001` (just landed) so the cross-surface contract speaks one vocabulary:

- Adopt `agent_state` (resolved DTO) vs `agent_presence` (raw observations) terminology.
- `expected_response` enum extended to 7 values: added `dispatch_delayed` and `unknown`.
- `connection_path` adds `unknown`. `unavailable_reason` adds `placement_unconfirmed`.
- Four new DTO fields: `badge_state` (6 values), `badge_label`, `badge_color` (semantic token), `pre_send_warning` (structured).
- `badge_state` mapping table from `expected_response`. `routable_delayed` resolves to `Warming` for hermes warm-up and `Dispatch` for cloud-agent paths.
- Picker grouping section: 3 user-facing groups (Live / Reachable / Won't reach) — presentation-only, not a backend state code.
- API surfaces: `GET /api/v1/agents/availability`, `POST /api/v1/agents/{id}/presence/events`.
- Surface contracts updated to lead with `badge_state` / `badge_label`.
- Scope boundary section: explicit out-of-scope for message/reply lifecycle SSE contract (separate spec), placement state machine, heartbeat protocol cadence.
- Cross-ref to canonical visual mock: `Agent Availability.html` (design-system project, cipher 2026-04-25).

## Why now

backend_sentinel's `GATEWAY-PRESENCE-DATA-MODEL-001` just landed with the badge vocabulary as upstream truth. cipher shipped the canonical visual mock with all four surfaces × six states. madtank's mention-picker directive made the picker-grouping vocabulary load-bearing. All three inputs are converging — folding them in now means the spec lands as a coherent piece for the implementation sub-tasks.

## Test plan

- [x] Spec renders cleanly (markdown lint)
- [ ] backend_sentinel sanity-checks the badge_state / badge_label table against `GATEWAY-PRESENCE-DATA-MODEL-001` values
- [ ] cipher cross-references against `Agent Availability.html` mock
- [ ] frontend_sentinel reads the four surface contracts (agent card, mention picker, composer, activity stream) for actionability
- [ ] cli_sentinel reads the CLI surface contract (`Status` column rename, group filters, pre-send warning consumption)
- [ ] mcp_sentinel reads the MCP widget contract (per-row display, picker grouping, cross-surface vocabulary invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)