### PR TITLE
feat(reminders): TASK-LOOP-001 — priority queue + HITL draft mode

### DIFF
--- a/ax_cli/commands/reminders.py
+++ b/ax_cli/commands/reminders.py
@@ -69,8 +69,31 @@ def _policy_file(path: str | None) -> Path:
     return Path(path).expanduser() if path else _default_policy_file()
 
 
+_LOOP_MODES = ("auto", "draft", "manual")
+_DEFAULT_PRIORITY = 50
+
+
 def _empty_store() -> dict[str, Any]:
-    return {"version": 1, "policies": []}
+    return {"version": 2, "policies": [], "drafts": []}
+
+
+def _normalize_mode(value: str | None) -> str:
+    text = (value or "auto").strip().lower()
+    if text not in _LOOP_MODES:
+        raise typer.BadParameter(f"--mode must be one of: {', '.join(_LOOP_MODES)}")
+    return text
+
+
+def _normalize_priority(value: int | None) -> int:
+    if value is None:
+        return _DEFAULT_PRIORITY
+    if value < 0 or value > 100:
+        raise typer.BadParameter("--priority must be between 0 and 100 (lower = higher priority)")
+    return int(value)
+
+
+def _short_draft_id() -> str:
+    return f"draft-{uuid.uuid4().hex[:10]}"
 
 
 def _load_store(path: Path) -> dict[str, Any]:
@@ -86,8 +109,12 @@ def _load_store(path: Path) -> dict[str, Any]:
         raise typer.Exit(1)
     data.setdefault("version", 1)
     data.setdefault("policies", [])
+    data.setdefault("drafts", [])
     if not isinstance(data["policies"], list):
         typer.echo(f"Error: reminders policies must be a list: {path}", err=True)
+        raise typer.Exit(1)
+    if not isinstance(data["drafts"], list):
+        typer.echo(f"Error: reminders drafts must be a list: {path}", err=True)
         raise typer.Exit(1)
     return data
 
@@ -117,14 +144,26 @@ def _find_policy(store: dict[str, Any], policy_id: str) -> dict[str, Any]:
     return matches[0]
 
 
+def _policy_sort_key(policy: dict[str, Any]) -> tuple:
+    """Priority queue order: priority asc (lower = higher), then next_fire asc, then id."""
+    priority = int(policy.get("priority", _DEFAULT_PRIORITY))
+    next_fire = str(policy.get("next_fire_at") or "")
+    pol_id = str(policy.get("id") or "")
+    return (priority, next_fire, pol_id)
+
+
 def _policy_rows(store: dict[str, Any]) -> list[dict[str, Any]]:
     rows = []
-    for policy in store.get("policies", []):
-        if not isinstance(policy, dict):
-            continue
+    sorted_policies = sorted(
+        (p for p in store.get("policies", []) if isinstance(p, dict)),
+        key=_policy_sort_key,
+    )
+    for policy in sorted_policies:
         rows.append(
             {
                 "id": policy.get("id", ""),
+                "priority": int(policy.get("priority", _DEFAULT_PRIORITY)),
+                "mode": str(policy.get("mode", "auto")),
                 "enabled": policy.get("enabled", True),
                 "task": policy.get("source_task_id", ""),
                 "target": policy.get("target") or "(task default)",
@@ -147,6 +186,8 @@ def add(
     max_fires: int = typer.Option(1, "--max-fires", help="Maximum reminder fires before disabling"),
     severity: str = typer.Option("info", "--severity", "-s", help="info | warn | critical"),
     expected_response: Optional[str] = typer.Option(None, "--expected-response", help="What response is expected"),
+    priority: int = typer.Option(_DEFAULT_PRIORITY, "--priority", help="Queue priority 0-100 (lower = higher)"),
+    mode: str = typer.Option("auto", "--mode", help="auto | draft | manual"),
     space_id: Optional[str] = typer.Option(None, "--space-id", help="Override default space"),
     policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
     as_json: bool = JSON_OPTION,
@@ -154,6 +195,10 @@ def add(
     """Add a local reminder policy.
 
     The policy is local state. Use ``ax reminders run`` to fire due policies.
+    Mode controls firing behavior:
+      auto   — fire immediately when due (default)
+      draft  — prepare draft, queue for HITL review via ``ax reminders drafts``
+      manual — never auto-fire; only fired by explicit ``run --force``
     """
     if max_fires < 1:
         raise typer.BadParameter("--max-fires must be at least 1")
@@ -161,6 +206,8 @@ def add(
         raise typer.BadParameter("--cadence-minutes must be at least 1")
     if first_in < 0:
         raise typer.BadParameter("--first-in-minutes cannot be negative")
+    normalized_priority = _normalize_priority(priority)
+    normalized_mode = _normalize_mode(mode)
 
     first_at = _validate_timestamp(first_at, flag="--first-at")
     next_fire = _parse_iso(first_at) if first_at else _now() + _dt.timedelta(minutes=first_in)
@@ -183,6 +230,8 @@ def add(
         "target": _strip_at(target),
         "severity": _normalize_severity(severity),
         "expected_response": expected_response,
+        "priority": normalized_priority,
+        "mode": normalized_mode,
         "cadence_seconds": cadence * 60,
         "next_fire_at": _iso(next_fire),
         "max_fires": max_fires,
@@ -219,9 +268,9 @@ def list_policies(
         console.print(f"No reminder policies in {path}")
         return
     print_table(
-        ["ID", "Enabled", "Task", "Target", "Next Fire", "Fires", "Reason"],
+        ["ID", "Pri", "Mode", "Enabled", "Task", "Target", "Next Fire", "Fires", "Reason"],
         rows,
-        keys=["id", "enabled", "task", "target", "next_fire", "fires", "reason"],
+        keys=["id", "priority", "mode", "enabled", "task", "target", "next_fire", "fires", "reason"],
     )
 
 
@@ -244,7 +293,13 @@ def disable(
     console.print(f"Disabled reminder policy {policy['id']}")
 
 
-def _fire_policy(client: Any, policy: dict[str, Any], *, now: _dt.datetime) -> dict[str, Any]:
+def _build_fire_payload(client: Any, policy: dict[str, Any], *, now: _dt.datetime) -> dict[str, Any] | None:
+    """Build target/reason/content/metadata for a due policy.
+
+    Returns None if the policy must be skipped (e.g. source task is terminal —
+    side-effect: marks the policy disabled). Otherwise returns a dict with
+    keys: target, target_resolved_from, content, metadata, channel.
+    """
     source_task = str(policy.get("source_task_id") or "")
     reason = str(policy.get("reason") or "Please review this task.")
     target = _strip_at(policy.get("target"))
@@ -256,13 +311,8 @@ def _fire_policy(client: Any, policy: dict[str, Any], *, now: _dt.datetime) -> d
         policy["enabled"] = False
         policy["disabled_reason"] = f"source task {source_task} is {lifecycle.get('status')}"
         policy["updated_at"] = _iso(now)
-        return {
-            "policy_id": policy.get("id"),
-            "skipped": True,
-            "reason": f"source_task_terminal:{lifecycle.get('status')}",
-            "source_task_id": source_task,
-            "fired_at": None,
-        }
+        policy["_skip_reason"] = f"source_task_terminal:{lifecycle.get('status')}"
+        return None
 
     if lifecycle and lifecycle.get("is_pending_review"):
         review_target = lifecycle.get("review_owner") or lifecycle.get("creator_name")
@@ -314,29 +364,111 @@ def _fire_policy(client: Any, policy: dict[str, Any], *, now: _dt.datetime) -> d
         "fired_count": policy.get("fired_count", 0) + 1,
         "max_fires": policy.get("max_fires"),
         "target_resolved_from": target_resolved_from,
+        "mode": str(policy.get("mode", "auto")),
     }
 
+    return {
+        "target": target,
+        "target_resolved_from": target_resolved_from,
+        "content": _format_mention_content(target, reason, "reminder"),
+        "metadata": metadata,
+        "channel": str(policy.get("channel") or "main"),
+        "fired_at": fired_at,
+    }
+
+
+def _fire_policy(
+    client: Any,
+    policy: dict[str, Any],
+    *,
+    now: _dt.datetime,
+    drafts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Fire a due policy according to its mode.
+
+    - auto:   send immediately (existing behavior)
+    - draft:  build payload, append to drafts, do NOT send
+    - manual: skip (manual policies should not appear in due_policies; safety net)
+    """
+    payload = _build_fire_payload(client, policy, now=now)
+    if payload is None:
+        # Skipped — _build_fire_payload populated _skip_reason on the policy.
+        skip_reason = str(policy.pop("_skip_reason", "skipped"))
+        return {
+            "policy_id": policy.get("id"),
+            "skipped": True,
+            "reason": skip_reason,
+            "source_task_id": str(policy.get("source_task_id") or ""),
+            "fired_at": None,
+        }
+
+    mode = str(policy.get("mode", "auto"))
+
+    if mode == "manual":
+        return {
+            "policy_id": policy.get("id"),
+            "skipped": True,
+            "reason": "manual_mode",
+            "fired_at": None,
+        }
+
+    if mode == "draft":
+        if drafts is None:
+            return {
+                "policy_id": policy.get("id"),
+                "error": "draft mode requires a drafts store; pass --file to a v2 store",
+            }
+        draft = {
+            "id": _short_draft_id(),
+            "policy_id": policy.get("id"),
+            "fire_key": policy.get("_current_fire_key"),
+            "created_at": payload["fired_at"],
+            "target": payload["target"],
+            "target_resolved_from": payload["target_resolved_from"],
+            "content": payload["content"],
+            "metadata": payload["metadata"],
+            "channel": payload["channel"],
+            "space_id": str(policy.get("space_id") or ""),
+            "status": "pending",
+        }
+        drafts.append(draft)
+        return {
+            "policy_id": policy.get("id"),
+            "draft_id": draft["id"],
+            "drafted": True,
+            "target": payload["target"],
+            "fired_at": payload["fired_at"],
+        }
+
+    # mode == "auto"
     result = client.send_message(
         str(policy.get("space_id")),
-        _format_mention_content(target, reason, "reminder"),
-        channel=str(policy.get("channel") or "main"),
-        metadata=metadata,
+        payload["content"],
+        channel=payload["channel"],
+        metadata=payload["metadata"],
         message_type="reminder",
     )
     message = result.get("message", result) if isinstance(result, dict) else {}
     return {
         "policy_id": policy.get("id"),
         "message_id": message.get("id"),
-        "target": target,
-        "target_resolved_from": target_resolved_from,
-        "fired_at": fired_at,
+        "target": payload["target"],
+        "target_resolved_from": payload["target_resolved_from"],
+        "fired_at": payload["fired_at"],
     }
 
 
-def _due_policies(store: dict[str, Any], *, now: _dt.datetime) -> list[dict[str, Any]]:
+def _due_policies(store: dict[str, Any], *, now: _dt.datetime, include_manual: bool = False) -> list[dict[str, Any]]:
+    """Return enabled, due policies in priority queue order.
+
+    Manual-mode policies are excluded by default; pass ``include_manual=True``
+    to include them (e.g. for an explicit ``run --force <id>`` path).
+    """
     due = []
     for policy in store.get("policies", []):
         if not isinstance(policy, dict) or not policy.get("enabled", True):
+            continue
+        if not include_manual and str(policy.get("mode", "auto")) == "manual":
             continue
         if int(policy.get("fired_count", 0)) >= int(policy.get("max_fires", 1)):
             policy["enabled"] = False
@@ -355,10 +487,23 @@ def _due_policies(store: dict[str, Any], *, now: _dt.datetime) -> list[dict[str,
                 continue
             policy["_current_fire_key"] = fire_key
             due.append(policy)
+    due.sort(key=_policy_sort_key)
     return due
 
 
-def _advance_policy(policy: dict[str, Any], *, now: _dt.datetime, message_id: str | None) -> None:
+def _advance_policy(
+    policy: dict[str, Any],
+    *,
+    now: _dt.datetime,
+    message_id: str | None,
+    draft_id: str | None = None,
+) -> None:
+    """Advance a policy after a successful fire (auto-sent or drafted).
+
+    Drafted fires DO advance fired_count and next_fire_at — drafts are
+    real fires from the loop's perspective. The HITL send/cancel does not
+    re-tick the policy.
+    """
     fire_key = str(policy.pop("_current_fire_key", ""))
     fired_keys = list(policy.get("fired_keys") or [])
     if fire_key:
@@ -367,6 +512,7 @@ def _advance_policy(policy: dict[str, Any], *, now: _dt.datetime, message_id: st
     policy["fired_count"] = int(policy.get("fired_count", 0)) + 1
     policy["last_fired_at"] = _iso(now)
     policy["last_message_id"] = message_id
+    policy["last_draft_id"] = draft_id
     policy["updated_at"] = _iso(now)
 
     max_fires = int(policy.get("max_fires", 1))
@@ -403,9 +549,10 @@ def run(
         store = _load_store(path)
         now = _now()
         pass_results: list[dict[str, Any]] = []
+        drafts_list = store.setdefault("drafts", [])
         for policy in _due_policies(store, now=now):
             try:
-                result = _fire_policy(client, policy, now=now)
+                result = _fire_policy(client, policy, now=now, drafts=drafts_list)
             except httpx.HTTPStatusError as exc:
                 result = {
                     "policy_id": policy.get("id"),
@@ -414,7 +561,12 @@ def run(
             except (httpx.ConnectError, httpx.ReadError) as exc:
                 result = {"policy_id": policy.get("id"), "error": str(exc)}
             if not result.get("error") and not result.get("skipped"):
-                _advance_policy(policy, now=now, message_id=result.get("message_id"))
+                _advance_policy(
+                    policy,
+                    now=now,
+                    message_id=result.get("message_id"),
+                    draft_id=result.get("draft_id"),
+                )
             pass_results.append(result)
             all_results.append(result)
         _save_store(path, store)
@@ -423,10 +575,30 @@ def run(
             if as_json:
                 print_json({"file": str(path), "fired": all_results})
             elif pass_results:
+                rows = []
+                for item in pass_results:
+                    if item.get("error"):
+                        status = f"error: {item['error'][:40]}"
+                    elif item.get("skipped"):
+                        status = f"skipped ({item.get('reason', '')})"
+                    elif item.get("drafted"):
+                        status = f"drafted: {item.get('draft_id')}"
+                    elif item.get("message_id"):
+                        status = f"sent: {item['message_id']}"
+                    else:
+                        status = "fired"
+                    rows.append(
+                        {
+                            "policy_id": item.get("policy_id"),
+                            "status": status,
+                            "target": item.get("target"),
+                            "fired_at": item.get("fired_at"),
+                        }
+                    )
                 print_table(
-                    ["Policy", "Message", "Target", "Fired At"],
-                    pass_results,
-                    keys=["policy_id", "message_id", "target", "fired_at"],
+                    ["Policy", "Status", "Target", "Fired At"],
+                    rows,
+                    keys=["policy_id", "status", "target", "fired_at"],
                 )
             else:
                 console.print(f"No due reminders in {path}")
@@ -437,8 +609,12 @@ def run(
                 if item.get("error"):
                     console.print(f"[red]{item['policy_id']}[/red]: {item['error']}")
                 elif item.get("skipped"):
+                    reason = item.get("reason") or "skipped"
+                    console.print(f"[yellow]{item['policy_id']}[/yellow] skipped ({reason})")
+                elif item.get("drafted"):
                     console.print(
-                        f"[yellow]{item['policy_id']}[/yellow] skipped ({item.get('reason')}) — policy disabled"
+                        f"[cyan]{item['policy_id']}[/cyan] drafted "
+                        f"draft={item.get('draft_id')} target={item.get('target')}"
                     )
                 else:
                     console.print(
@@ -446,3 +622,279 @@ def run(
                         f"message={item.get('message_id')} target={item.get('target')}"
                     )
         time.sleep(interval)
+
+
+# ---- Operator commands: pause / resume / cancel / update -------------------
+
+
+@app.command("pause")
+def pause(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Pause a reminder policy. Use ``resume`` to re-enable."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    policy = _find_policy(store, policy_id)
+    policy["enabled"] = False
+    policy["disabled_reason"] = "paused"
+    policy["updated_at"] = _iso(_now())
+    _save_store(path, store)
+    if as_json:
+        print_json({"policy": policy, "file": str(path)})
+        return
+    console.print(f"Paused reminder policy {policy['id']}")
+
+
+@app.command("resume")
+def resume(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Resume a paused reminder policy.
+
+    Refuses to resume policies that finished (max_fires reached) or were
+    auto-disabled because the source task is terminal.
+    """
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    policy = _find_policy(store, policy_id)
+    if int(policy.get("fired_count", 0)) >= int(policy.get("max_fires", 1)):
+        typer.echo(f"Error: policy {policy['id']} has reached max_fires; create a new policy", err=True)
+        raise typer.Exit(1)
+    disabled_reason = str(policy.get("disabled_reason") or "")
+    if disabled_reason.startswith("source task"):
+        typer.echo(f"Error: source task is terminal; refusing to resume {policy['id']}", err=True)
+        raise typer.Exit(1)
+    policy["enabled"] = True
+    policy.pop("disabled_reason", None)
+    policy["updated_at"] = _iso(_now())
+    _save_store(path, store)
+    if as_json:
+        print_json({"policy": policy, "file": str(path)})
+        return
+    console.print(f"Resumed reminder policy {policy['id']}")
+
+
+@app.command("cancel")
+def cancel(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Cancel a reminder policy permanently. Like ``disable`` but with explicit cancel reason."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    policy = _find_policy(store, policy_id)
+    policy["enabled"] = False
+    policy["disabled_reason"] = "cancelled"
+    policy["updated_at"] = _iso(_now())
+    _save_store(path, store)
+    if as_json:
+        print_json({"policy": policy, "file": str(path)})
+        return
+    console.print(f"Cancelled reminder policy {policy['id']}")
+
+
+@app.command("update")
+def update_policy(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    priority: Optional[int] = typer.Option(None, "--priority", help="New priority (0-100, lower = higher)"),
+    cadence: Optional[int] = typer.Option(None, "--cadence-minutes", help="New cadence in minutes"),
+    max_fires: Optional[int] = typer.Option(None, "--max-fires", help="New max-fires cap"),
+    mode: Optional[str] = typer.Option(None, "--mode", help="auto | draft | manual"),
+    reason: Optional[str] = typer.Option(None, "--reason", help="New reason text"),
+    target: Optional[str] = typer.Option(None, "--target", help="New target @agent/user"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Update fields on a reminder policy. ``--priority`` re-orders the queue."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    policy = _find_policy(store, policy_id)
+    if priority is not None:
+        policy["priority"] = _normalize_priority(priority)
+    if mode is not None:
+        policy["mode"] = _normalize_mode(mode)
+    if cadence is not None:
+        if cadence < 1:
+            raise typer.BadParameter("--cadence-minutes must be at least 1")
+        policy["cadence_seconds"] = cadence * 60
+    if max_fires is not None:
+        if max_fires < 1:
+            raise typer.BadParameter("--max-fires must be at least 1")
+        policy["max_fires"] = max_fires
+    if reason is not None:
+        policy["reason"] = reason
+    if target is not None:
+        policy["target"] = _strip_at(target)
+    policy["updated_at"] = _iso(_now())
+    _save_store(path, store)
+    if as_json:
+        print_json({"policy": policy, "file": str(path)})
+        return
+    console.print(f"Updated reminder policy {policy['id']}")
+
+
+# ---- Drafts subcommand group: list / show / edit / send / cancel ----------
+
+drafts_app = typer.Typer(name="drafts", help="HITL drafts queued by draft-mode policies", no_args_is_help=True)
+app.add_typer(drafts_app, name="drafts")
+
+
+def _find_draft(store: dict[str, Any], draft_id: str) -> dict[str, Any]:
+    matches = [
+        d
+        for d in store.get("drafts", [])
+        if isinstance(d, dict) and str(d.get("id", "")).startswith(draft_id) and d.get("status") == "pending"
+    ]
+    if not matches:
+        typer.echo(f"Error: pending draft not found: {draft_id}", err=True)
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        typer.echo(f"Error: draft id is ambiguous: {draft_id}", err=True)
+        raise typer.Exit(1)
+    return matches[0]
+
+
+@drafts_app.command("list")
+def drafts_list(
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """List pending HITL drafts."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    pending = [d for d in store.get("drafts", []) if isinstance(d, dict) and d.get("status") == "pending"]
+    if as_json:
+        print_json({"file": str(path), "drafts": pending})
+        return
+    if not pending:
+        console.print(f"No pending drafts in {path}")
+        return
+    rows = [
+        {
+            "id": d.get("id", ""),
+            "policy": d.get("policy_id", ""),
+            "target": d.get("target") or "(none)",
+            "created_at": d.get("created_at", ""),
+            "preview": (d.get("content") or "")[:60],
+        }
+        for d in pending
+    ]
+    print_table(
+        ["ID", "Policy", "Target", "Created", "Preview"],
+        rows,
+        keys=["id", "policy", "target", "created_at", "preview"],
+    )
+
+
+@drafts_app.command("show")
+def drafts_show(
+    draft_id: str = typer.Argument(..., help="Draft ID or unique prefix"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Show a pending draft's full body and metadata."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    draft = _find_draft(store, draft_id)
+    if as_json:
+        print_json({"draft": draft, "file": str(path)})
+        return
+    console.print(f"[bold]{draft['id']}[/bold] (policy={draft.get('policy_id')})")
+    console.print(f"[bold]target[/bold]: {draft.get('target')}")
+    console.print(f"[bold]channel[/bold]: {draft.get('channel')}")
+    console.print(f"[bold]created[/bold]: {draft.get('created_at')}")
+    console.print()
+    console.print(draft.get("content", ""))
+
+
+@drafts_app.command("edit")
+def drafts_edit(
+    draft_id: str = typer.Argument(..., help="Draft ID or unique prefix"),
+    body: Optional[str] = typer.Option(None, "--body", help="New message body"),
+    target: Optional[str] = typer.Option(None, "--target", help="New target @agent/user"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Edit a pending draft before sending."""
+    if body is None and target is None:
+        raise typer.BadParameter("--body and/or --target required")
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    draft = _find_draft(store, draft_id)
+    if target is not None:
+        draft["target"] = _strip_at(target)
+        # Re-mention prefix the body if it doesn't already lead with @target
+        if body is None and draft.get("content"):
+            existing = str(draft["content"])
+            # strip the old @mention if present
+            if existing.startswith("@"):
+                existing_body = existing.split(" ", 1)[1] if " " in existing else ""
+            else:
+                existing_body = existing
+            draft["content"] = _format_mention_content(draft["target"], existing_body, "reminder")
+    if body is not None:
+        draft["content"] = _format_mention_content(draft.get("target"), body, "reminder")
+    draft["edited"] = True
+    draft["updated_at"] = _iso(_now())
+    _save_store(path, store)
+    if as_json:
+        print_json({"draft": draft, "file": str(path)})
+        return
+    console.print(f"Edited draft {draft['id']}")
+
+
+@drafts_app.command("send")
+def drafts_send(
+    draft_id: str = typer.Argument(..., help="Draft ID or unique prefix"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Send a pending draft via the messages API."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    draft = _find_draft(store, draft_id)
+    client = get_client()
+    try:
+        result = client.send_message(
+            str(draft.get("space_id")),
+            str(draft.get("content") or ""),
+            channel=str(draft.get("channel") or "main"),
+            metadata=draft.get("metadata") or {},
+            message_type="reminder",
+        )
+    except httpx.HTTPStatusError as exc:
+        typer.echo(f"Error: send failed: {exc.response.status_code} {exc.response.text[:200]}", err=True)
+        raise typer.Exit(1)
+    message = result.get("message", result) if isinstance(result, dict) else {}
+    draft["status"] = "sent"
+    draft["sent_at"] = _iso(_now())
+    draft["message_id"] = message.get("id")
+    _save_store(path, store)
+    if as_json:
+        print_json({"draft": draft, "message_id": message.get("id"), "file": str(path)})
+        return
+    console.print(f"Sent draft {draft['id']} (message {message.get('id')})")
+
+
+@drafts_app.command("cancel")
+def drafts_cancel(
+    draft_id: str = typer.Argument(..., help="Draft ID or unique prefix"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Cancel a pending draft. Does NOT re-tick the source policy."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    draft = _find_draft(store, draft_id)
+    draft["status"] = "cancelled"
+    draft["cancelled_at"] = _iso(_now())
+    _save_store(path, store)
+    if as_json:
+        print_json({"draft": draft, "file": str(path)})
+        return
+    console.print(f"Cancelled draft {draft['id']}")

--- a/specs/TASK-LOOP-001/README.md
+++ b/specs/TASK-LOOP-001/README.md
@@ -1,0 +1,147 @@
+# TASK-LOOP-001: Task-Driven Loops with Priority Queue + HITL Drafts
+
+**Status:** v1 — CLI-first implementation landing in this PR
+**Owner:** @orion
+**Date:** 2026-04-25
+**Source directive:** @madtank 2026-04-25 03:46 UTC ("frequency and priority… queue a priority for each assignment, moved around like a song playing"); @madtank 2026-04-25 04:00 UTC ("loop should support a draft/review state where the HITL user can inspect and explicitly send")
+
+## Why this exists
+
+The team needs task-driven loops, not time-driven cron. Each assignment carries: how often it runs, when it stops (if ever), priority, assignee. Operators reorder the queue "like a song playing." High-stakes loops should produce drafts a human reviews before they go out.
+
+Reminders (`ax reminders`) already provided 80% of the spine: task-tied policies, cadence, max-fires, target resolution. This spec extends reminders with the missing primitives.
+
+**CLI-first.** Prove the model in `~/.ax/reminders.json`. Promote to platform only after the loop pattern is validated in real use.
+
+## Scope
+
+In:
+- Per-policy `priority` field, queue ordered by priority
+- `mode` field: `auto` / `draft` / `manual`
+- Draft store with HITL review/edit/send/cancel
+- Operator commands: `pause`, `resume`, `cancel`, `update`
+- Pytest smokes covering all three modes
+
+Out (follow-up):
+- Backend persistence of loop state (currently local JSON)
+- Cross-machine queue sync (single-machine for now)
+- `ax tasks loop` semantic alias group (deferred — `ax reminders` is the implementation; the alias is naming polish)
+- Platform-side scheduler integration (TASKS-LIFECYCLE-001 territory)
+- Stop conditions beyond `max_fires` and "source task is terminal" (e.g. done-event hooks)
+
+## Data model — local store at `~/.ax/reminders.json` (version 2)
+
+```json
+{
+  "version": 2,
+  "policies": [
+    {
+      "id": "rem-...",
+      "enabled": true,
+      "space_id": "...",
+      "source_task_id": "...",
+      "reason": "...",
+      "target": "orion",
+      "severity": "info",
+      "priority": 50,            // NEW: 0-100, lower = higher priority
+      "mode": "auto",            // NEW: auto | draft | manual
+      "cadence_seconds": 600,
+      "next_fire_at": "ISO",
+      "max_fires": 4,
+      "fired_count": 0,
+      "fired_keys": [...],
+      "last_fired_at": "ISO?",
+      "last_message_id": "msg-...?",
+      "last_draft_id": "draft-...?"  // NEW
+    }
+  ],
+  "drafts": [                    // NEW: HITL draft queue
+    {
+      "id": "draft-...",
+      "policy_id": "rem-...",
+      "fire_key": "...",
+      "created_at": "ISO",
+      "target": "orion",
+      "content": "@orion Reminder: ...",
+      "metadata": {...},
+      "channel": "main",
+      "space_id": "...",
+      "status": "pending",       // pending | sent | cancelled
+      "edited": false,
+      "sent_at": "ISO?",
+      "message_id": "msg-...?",
+      "cancelled_at": "ISO?"
+    }
+  ]
+}
+```
+
+### Mode semantics
+
+| Mode | Behavior on due |
+|---|---|
+| `auto` | Build payload, send via API, advance policy. (Existing reminder behavior.) |
+| `draft` | Build payload, append to `drafts` as `pending`, advance policy. **No API call.** Operator sends/cancels via `ax reminders drafts`. |
+| `manual` | Excluded from `due_policies` entirely. Only fires via explicit operator action (future: `ax reminders fire <id>`). |
+
+Drafted fires DO advance `fired_count` and `next_fire_at`. The HITL send/cancel does NOT re-tick the policy — the draft was the fire.
+
+### Priority queue
+
+`due_policies()` sorts by `(priority asc, next_fire_at asc, id)`. Lower priority number = higher priority. Default 50. Range 0-100.
+
+`ax reminders update <id> --priority N` re-orders without recreating policies. List output reflects current queue order.
+
+## CLI surface
+
+```
+# Existing (now with --priority and --mode)
+ax reminders add <task-id> [--priority N] [--mode auto|draft|manual] [--cadence-minutes N] [--max-fires N] [--target X]
+ax reminders list
+ax reminders run --once
+ax reminders run --watch --interval 30
+ax reminders disable <id>           # legacy, kept
+
+# New operator commands
+ax reminders pause <id>
+ax reminders resume <id>
+ax reminders cancel <id>
+ax reminders update <id> [--priority N] [--cadence-minutes N] [--max-fires N] [--mode X] [--reason ...] [--target X]
+
+# New drafts subcommand group
+ax reminders drafts list
+ax reminders drafts show <draft-id>
+ax reminders drafts edit <draft-id> [--body "..."] [--target X]
+ax reminders drafts send <draft-id>
+ax reminders drafts cancel <draft-id>
+```
+
+## Acceptance smokes
+
+All in `tests/test_task_loop_modes.py` — 11 pytest cases:
+
+1. `add` accepts `--priority` and `--mode` and stores them on the policy
+2. `add` rejects priority outside 0-100
+3. `add` rejects unknown mode values
+4. Multiple due policies fire in priority order (lower number first)
+5. Draft mode creates a draft record and does NOT call `send_message`
+6. Manual mode is excluded from `due_policies` (no fire, no draft)
+7. `drafts send` dispatches a pending draft via the API and marks it `sent`
+8. `drafts cancel` discards a draft without sending
+9. `drafts edit` updates body and preserves `@target` mention prefix
+10. `pause` / `resume` cycle round-trips correctly
+11. `update --priority` re-orders the queue
+
+Existing reminder tests (8) continue to pass — backwards compatible (version 1 store loads as version 2 with empty drafts array; new fields have sensible defaults).
+
+## Why this is a small spec
+
+Per orion's SDD critique 2026-04-25 03:55 UTC: "stop opening new spec PRs until you've shipped one implementation PR against an existing spec." TASK-LOOP-001 is implementation-first. The spec is this 1-page README; the contract is the 11 pytests; the surface is the merged PR.
+
+If we want to evolve the model (backend persistence, cross-machine sync, semantic `ax tasks loop` alias), each evolution gets a numbered iteration. v1 is what's in this PR.
+
+## Out-of-scope cross-references
+
+- **TASKS-LIFECYCLE-001** (orion task #9, pending) — stale auto-cancel + alerts/reminders to activity stream. Coordinates with TASK-LOOP-001 but is its own spec.
+- **AX-SCHEDULE-001** (orion + anvil) — periodic command runner (cron-like). Different primitive: schedules execute commands; loops drive task assignments.
+- **AGENT-AVAILABILITY-CONTRACT-001** (orion, PR #97) — when a loop targets an agent, the resolved availability DTO (`agent_state`) determines whether to fire, defer, or auto-draft. Future iteration: when target's `expected_response in {unlikely, unavailable}`, automatically degrade to draft mode.

--- a/tests/test_reminders_commands.py
+++ b/tests/test_reminders_commands.py
@@ -84,7 +84,8 @@ def test_add_creates_local_policy_file(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.output
     store = _load(policy_file)
-    assert store["version"] == 1
+    assert store["version"] == 2
+    assert store["drafts"] == []
     assert len(store["policies"]) == 1
     policy = store["policies"][0]
     assert policy["source_task_id"] == "task-1"
@@ -92,6 +93,9 @@ def test_add_creates_local_policy_file(monkeypatch, tmp_path):
     assert policy["target"] == "orion"
     assert policy["max_fires"] == 2
     assert policy["enabled"] is True
+    # Defaults for new fields
+    assert policy["mode"] == "auto"
+    assert policy["priority"] == 50
 
 
 def test_run_once_fires_due_policy_and_disables_at_max(monkeypatch, tmp_path):

--- a/tests/test_task_loop_modes.py
+++ b/tests/test_task_loop_modes.py
@@ -1,0 +1,442 @@
+"""Tests for TASK-LOOP-001: priority + mode (auto/draft/manual) on reminder policies."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    def send_message(
+        self,
+        space_id: str,
+        content: str,
+        *,
+        channel: str = "main",
+        metadata: dict | None = None,
+        message_type: str = "text",
+        **_kwargs: Any,
+    ) -> dict:
+        message_id = f"msg-{len(self.sent) + 1}"
+        self.sent.append(
+            {
+                "id": message_id,
+                "space_id": space_id,
+                "content": content,
+                "channel": channel,
+                "metadata": metadata,
+                "message_type": message_type,
+            }
+        )
+        return {"id": message_id}
+
+
+def _install_fake_runtime(monkeypatch, client: _FakeClient) -> None:
+    monkeypatch.setattr("ax_cli.commands.reminders.get_client", lambda: client)
+    monkeypatch.setattr(
+        "ax_cli.commands.reminders.resolve_space_id",
+        lambda _client, *, explicit=None: explicit or "space-abc",
+    )
+    monkeypatch.setattr(
+        "ax_cli.commands.reminders.resolve_agent_name",
+        lambda client=None: "orion",
+    )
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def test_add_accepts_priority_and_mode(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "reminders", "add", "task-A",
+            "--target", "orion",
+            "--priority", "10",
+            "--mode", "draft",
+            "--first-in-minutes", "0",
+            "--file", str(policy_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = _load(policy_file)["policies"][0]
+    assert policy["priority"] == 10
+    assert policy["mode"] == "draft"
+
+
+def test_add_rejects_invalid_priority(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+
+    result = runner.invoke(
+        app,
+        ["reminders", "add", "task-A", "--target", "orion", "--priority", "999",
+         "--first-in-minutes", "0", "--file", str(policy_file), "--json"],
+    )
+    assert result.exit_code != 0
+    assert "priority" in result.output.lower()
+
+
+def test_add_rejects_invalid_mode(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+
+    result = runner.invoke(
+        app,
+        ["reminders", "add", "task-A", "--target", "orion", "--mode", "weird",
+         "--first-in-minutes", "0", "--file", str(policy_file), "--json"],
+    )
+    assert result.exit_code != 0
+    assert "mode" in result.output.lower()
+
+
+def test_due_policies_sort_by_priority(monkeypatch, tmp_path):
+    """Higher-priority (lower number) policy fires first when multiple are due."""
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    base_policy = {
+        "enabled": True,
+        "space_id": "space-abc",
+        "source_task_id": "task-1",
+        "reason": "review",
+        "target": "orion",
+        "severity": "info",
+        "mode": "auto",
+        "cadence_seconds": 300,
+        "next_fire_at": "2026-04-16T00:00:00Z",
+        "max_fires": 1,
+        "fired_count": 0,
+        "fired_keys": [],
+    }
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "drafts": [],
+                "policies": [
+                    {**base_policy, "id": "rem-low", "priority": 80},
+                    {**base_policy, "id": "rem-high", "priority": 10},
+                    {**base_policy, "id": "rem-mid", "priority": 50},
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    fired_order = [item["policy_id"] for item in payload["fired"]]
+    # All three should fire since all are due, but in priority order
+    assert fired_order == ["rem-high", "rem-mid", "rem-low"]
+
+
+def test_draft_mode_creates_draft_does_not_send(monkeypatch, tmp_path):
+    """A due draft-mode policy creates a draft record and does not call send_message."""
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "drafts": [],
+                "policies": [
+                    {
+                        "id": "rem-draft",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-D",
+                        "reason": "needs HITL review",
+                        "target": "orion",
+                        "severity": "info",
+                        "priority": 10,
+                        "mode": "draft",
+                        "cadence_seconds": 600,
+                        "next_fire_at": "2026-04-16T00:00:00Z",
+                        "max_fires": 3,
+                        "fired_count": 0,
+                        "fired_keys": [],
+                    }
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    # send_message NOT called
+    assert fake.sent == [], "draft mode must not send to the API"
+
+    # Draft was created
+    fired = payload["fired"][0]
+    assert fired.get("drafted") is True
+    assert fired.get("draft_id", "").startswith("draft-")
+
+    store = _load(policy_file)
+    assert len(store["drafts"]) == 1
+    draft = store["drafts"][0]
+    assert draft["status"] == "pending"
+    assert draft["target"] == "orion"
+    assert draft["content"].startswith("@orion Reminder:")
+
+    # Policy advanced (drafted fires count toward max_fires)
+    policy = store["policies"][0]
+    assert policy["fired_count"] == 1
+    assert policy["last_draft_id"] == draft["id"]
+
+
+def test_manual_mode_excluded_from_due_run(monkeypatch, tmp_path):
+    """Manual-mode policies are skipped by ``run --once``."""
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "drafts": [],
+                "policies": [
+                    {
+                        "id": "rem-manual",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-M",
+                        "reason": "manual only",
+                        "target": "orion",
+                        "severity": "info",
+                        "priority": 50,
+                        "mode": "manual",
+                        "cadence_seconds": 300,
+                        "next_fire_at": "2026-04-16T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                        "fired_keys": [],
+                    }
+                ],
+            }
+        )
+    )
+    result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    assert fake.sent == []
+    payload = json.loads(result.output)
+    # Manual policies excluded from due — fired list empty
+    assert payload["fired"] == []
+    # Policy unchanged
+    policy = _load(policy_file)["policies"][0]
+    assert policy["fired_count"] == 0
+
+
+def test_drafts_send_dispatches_via_api(monkeypatch, tmp_path):
+    """``drafts send <id>`` dispatches a pending draft and marks it sent."""
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    # Seed a pending draft directly
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "policies": [],
+                "drafts": [
+                    {
+                        "id": "draft-abc1234567",
+                        "policy_id": "rem-x",
+                        "space_id": "space-abc",
+                        "channel": "main",
+                        "target": "orion",
+                        "content": "@orion Reminder: test draft",
+                        "metadata": {"alert": {"kind": "task_reminder"}},
+                        "status": "pending",
+                        "created_at": "2026-04-25T00:00:00Z",
+                    }
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app, ["reminders", "drafts", "send", "draft-abc", "--file", str(policy_file), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    assert len(fake.sent) == 1
+    sent = fake.sent[0]
+    assert sent["content"] == "@orion Reminder: test draft"
+    assert sent["message_type"] == "reminder"
+    assert sent["metadata"]["alert"]["kind"] == "task_reminder"
+
+    draft = _load(policy_file)["drafts"][0]
+    assert draft["status"] == "sent"
+    assert draft["message_id"] == "msg-1"
+
+
+def test_drafts_cancel_does_not_send(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "policies": [],
+                "drafts": [
+                    {
+                        "id": "draft-xyz9876543",
+                        "policy_id": "rem-y",
+                        "status": "pending",
+                        "target": "orion",
+                        "content": "@orion test",
+                    }
+                ],
+            }
+        )
+    )
+    result = runner.invoke(
+        app, ["reminders", "drafts", "cancel", "draft-xyz", "--file", str(policy_file), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.sent == []
+    draft = _load(policy_file)["drafts"][0]
+    assert draft["status"] == "cancelled"
+
+
+def test_drafts_edit_updates_body_with_mention_prefix(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "policies": [],
+                "drafts": [
+                    {
+                        "id": "draft-edit000001",
+                        "policy_id": "rem-z",
+                        "status": "pending",
+                        "target": "orion",
+                        "content": "@orion Reminder: original body",
+                    }
+                ],
+            }
+        )
+    )
+    result = runner.invoke(
+        app,
+        ["reminders", "drafts", "edit", "draft-edit", "--body", "revised text",
+         "--file", str(policy_file), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    draft = _load(policy_file)["drafts"][0]
+    assert draft["edited"] is True
+    assert "revised text" in draft["content"]
+    assert draft["content"].startswith("@orion ")
+
+
+def test_pause_resume_cycle(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "drafts": [],
+                "policies": [
+                    {
+                        "id": "rem-pause",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-P",
+                        "reason": "pausable",
+                        "target": "orion",
+                        "priority": 50,
+                        "mode": "auto",
+                        "cadence_seconds": 300,
+                        "next_fire_at": "2099-01-01T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                        "fired_keys": [],
+                    }
+                ],
+            }
+        )
+    )
+    # Pause
+    result = runner.invoke(app, ["reminders", "pause", "rem-pause", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    policy = _load(policy_file)["policies"][0]
+    assert policy["enabled"] is False
+    assert policy["disabled_reason"] == "paused"
+
+    # Resume
+    result = runner.invoke(app, ["reminders", "resume", "rem-pause", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    policy = _load(policy_file)["policies"][0]
+    assert policy["enabled"] is True
+    assert "disabled_reason" not in policy
+
+
+def test_update_priority_reorders_queue(monkeypatch, tmp_path):
+    """``update --priority`` re-orders the queue without re-creating policies."""
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    base = {
+        "enabled": True,
+        "space_id": "space-abc",
+        "source_task_id": "task-1",
+        "reason": "r",
+        "target": "orion",
+        "mode": "auto",
+        "cadence_seconds": 300,
+        "next_fire_at": "2026-04-16T00:00:00Z",
+        "max_fires": 1,
+        "fired_count": 0,
+        "fired_keys": [],
+    }
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "drafts": [],
+                "policies": [
+                    {**base, "id": "rem-A", "priority": 50},
+                    {**base, "id": "rem-B", "priority": 50},
+                ],
+            }
+        )
+    )
+    # Bump rem-B to top
+    result = runner.invoke(
+        app,
+        ["reminders", "update", "rem-B", "--priority", "5", "--file", str(policy_file), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Verify sort order on run
+    result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    payload = json.loads(result.output)
+    fired_order = [item["policy_id"] for item in payload["fired"]]
+    assert fired_order[0] == "rem-B", "rem-B should fire first after priority bump"


### PR DESCRIPTION
First implementation PR per @madtank's CLI-first directive. Extends `ax reminders` with the primitives needed for task-driven loops with priority, frequency, mode, and operator controls.

## What

Closes the CLI side of the task-loop ask. `ax reminders` is now a real priority-queued task-loop runner with three modes:

| Mode | Behavior on due |
|---|---|
| `auto` | Send via API immediately (existing behavior) |
| `draft` | Prepare draft, queue for HITL review, no API call |
| `manual` | Excluded from due-policies; only fires via explicit operator action |

## New commands

```
ax reminders add <task-id> [--priority N] [--mode auto|draft|manual] ...
ax reminders pause <id>
ax reminders resume <id>
ax reminders cancel <id>
ax reminders update <id> [--priority N] [--cadence-minutes N] [--max-fires N] [--mode X] [--reason ...] [--target X]
ax reminders drafts list
ax reminders drafts show <draft-id>
ax reminders drafts edit <draft-id> [--body "..."] [--target X]
ax reminders drafts send <draft-id>
ax reminders drafts cancel <draft-id>
```

## Implementation notes

- Store schema bumped 1 → 2 (adds `drafts` array, `priority` and `mode` fields). Backwards compatible: v1 stores load cleanly with sensible defaults.
- Drafted fires advance `fired_count` + `next_fire_at` — the draft IS the fire from the loop's perspective. The HITL send/cancel does NOT re-tick the policy.
- Priority queue: sort by `(priority asc, next_fire_at asc, id)`. Lower priority number = higher priority. Default 50, range 0-100.
- `ax reminders update --priority N` re-orders the queue without recreating policies. "Move around like a song playing" — done.

## Test plan

- [x] All 8 existing reminder tests still pass (backwards compatibility verified)
- [x] 11 new pytest smokes covering all three modes, priority sort, draft send/edit/cancel, pause/resume, priority reorder
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format` — clean
- [ ] Manual smoke against dev backend: `ax reminders add <task> --mode draft`, `ax reminders run --once`, `ax reminders drafts list`, `ax reminders drafts send`

## Spec

`specs/TASK-LOOP-001/README.md` — 1-page implementation spec. Per orion's SDD critique 2026-04-25 03:55 UTC, the contract is the 11 pytests, not 400 lines of prose.

## Source directives

- @madtank 2026-04-25 03:46 UTC — "frequency and priority… queue a priority for each assignment, moved around like a song playing"
- @madtank 2026-04-25 04:00 UTC — "loop should support a draft/review state where the HITL user can inspect and explicitly send"
- @orion 2026-04-25 03:55 UTC SDD critique — "stop opening new spec PRs until you've shipped one implementation PR against an existing spec"

🤖 Generated with [Claude Code](https://claude.com/claude-code)