### PR TITLE
feat(reminders): TASK-LOOP-001 v1.1 — offline-first follow-up

### DIFF
--- a/ax_cli/commands/reminders.py
+++ b/ax_cli/commands/reminders.py
@@ -212,12 +212,21 @@ def add(
     first_at = _validate_timestamp(first_at, flag="--first-at")
     next_fire = _parse_iso(first_at) if first_at else _now() + _dt.timedelta(minutes=first_in)
 
-    client = get_client()
-    try:
-        resolved_space = resolve_space_id(client, explicit=space_id)
-    except Exception as exc:
-        typer.echo(f"Error: Space ID not resolvable: {exc}. Pass --space-id or configure default.", err=True)
-        raise typer.Exit(2)
+    # Offline-first: if --space-id is provided, skip the network round-trip
+    # entirely. Otherwise resolve via the configured client.
+    if space_id:
+        resolved_space = space_id
+    else:
+        try:
+            client = get_client()
+            resolved_space = resolve_space_id(client, explicit=None)
+        except Exception as exc:
+            typer.echo(
+                f"Error: Space ID not resolvable: {exc}. Pass --space-id to add offline, "
+                "or configure a default via `ax profile`.",
+                err=True,
+            )
+            raise typer.Exit(2)
 
     path = _policy_file(policy_file)
     store = _load_store(path)
@@ -441,13 +450,47 @@ def _fire_policy(
         }
 
     # mode == "auto"
-    result = client.send_message(
-        str(policy.get("space_id")),
-        payload["content"],
-        channel=payload["channel"],
-        metadata=payload["metadata"],
-        message_type="reminder",
-    )
+    try:
+        result = client.send_message(
+            str(policy.get("space_id")),
+            payload["content"],
+            channel=payload["channel"],
+            metadata=payload["metadata"],
+            message_type="reminder",
+        )
+    except (httpx.ConnectError, httpx.ReadError) as exc:
+        # Offline-first: backend unreachable. Auto-degrade to draft so the
+        # fire is not lost. Operator dispatches via `ax reminders drafts send`
+        # once connectivity returns.
+        if drafts is None:
+            return {
+                "policy_id": policy.get("id"),
+                "error": f"network: {exc}",
+            }
+        draft = {
+            "id": _short_draft_id(),
+            "policy_id": policy.get("id"),
+            "fire_key": policy.get("_current_fire_key"),
+            "created_at": payload["fired_at"],
+            "target": payload["target"],
+            "target_resolved_from": payload["target_resolved_from"],
+            "content": payload["content"],
+            "metadata": payload["metadata"],
+            "channel": payload["channel"],
+            "space_id": str(policy.get("space_id") or ""),
+            "status": "pending",
+            "auto_degraded": True,
+            "auto_degrade_reason": str(exc),
+        }
+        drafts.append(draft)
+        return {
+            "policy_id": policy.get("id"),
+            "draft_id": draft["id"],
+            "drafted": True,
+            "auto_degraded": True,
+            "target": payload["target"],
+            "fired_at": payload["fired_at"],
+        }
     message = result.get("message", result) if isinstance(result, dict) else {}
     return {
         "policy_id": policy.get("id"),
@@ -622,6 +665,104 @@ def run(
                         f"message={item.get('message_id')} target={item.get('target')}"
                     )
         time.sleep(interval)
+
+
+# ---- Status: online/offline + queue snapshot ------------------------------
+
+
+def _probe_online(timeout: float = 2.0) -> tuple[bool, str | None]:
+    """Cheap online probe. Returns (is_online, reason_if_offline)."""
+    try:
+        client = get_client()
+    except Exception as exc:
+        return False, f"client unavailable: {exc}"
+    base = getattr(client, "_base_url", None) or getattr(client, "base_url", None)
+    if not base:
+        return False, "no base_url configured"
+    try:
+        # Most ax backends respond on /health quickly. Use a short timeout.
+        resp = httpx.get(f"{str(base).rstrip('/')}/health", timeout=timeout)
+        if resp.status_code < 500:
+            return True, None
+        return False, f"backend status {resp.status_code}"
+    except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException) as exc:
+        return False, f"network: {exc}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+@app.command("status")
+def status(
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    skip_probe: bool = typer.Option(False, "--skip-probe", help="Skip online probe (faster, offline assumed)"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Show online/offline status, queue depth, and pending drafts count.
+
+    Helps an operator answer "can my reminders fire now, and what's queued
+    for me to review?" — the offline-first contract surface.
+    """
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+
+    policies = [p for p in store.get("policies", []) if isinstance(p, dict)]
+    enabled_policies = [p for p in policies if p.get("enabled", True)]
+    drafts = [d for d in store.get("drafts", []) if isinstance(d, dict)]
+    pending_drafts = [d for d in drafts if d.get("status") == "pending"]
+    auto_degraded = [d for d in pending_drafts if d.get("auto_degraded") is True]
+
+    # Find next-due policy (in priority queue order, ignoring whether it's currently due)
+    sorted_enabled = sorted(enabled_policies, key=_policy_sort_key)
+    next_due = sorted_enabled[0] if sorted_enabled else None
+
+    if skip_probe:
+        is_online, offline_reason = False, "probe skipped"
+    else:
+        is_online, offline_reason = _probe_online()
+
+    snapshot = {
+        "online": is_online,
+        "offline_reason": offline_reason,
+        "file": str(path),
+        "policies_total": len(policies),
+        "policies_enabled": len(enabled_policies),
+        "policies_paused_or_disabled": len(policies) - len(enabled_policies),
+        "drafts_pending": len(pending_drafts),
+        "drafts_auto_degraded": len(auto_degraded),
+        "next_due": (
+            {
+                "id": next_due.get("id"),
+                "priority": int(next_due.get("priority", _DEFAULT_PRIORITY)),
+                "mode": str(next_due.get("mode", "auto")),
+                "target": next_due.get("target") or "(task default)",
+                "next_fire_at": next_due.get("next_fire_at"),
+            }
+            if next_due
+            else None
+        ),
+    }
+
+    if as_json:
+        print_json(snapshot)
+        return
+
+    state_label = "[bold green]ONLINE[/bold green]" if is_online else "[bold yellow]OFFLINE[/bold yellow]"
+    console.print(f"State: {state_label}")
+    if not is_online and offline_reason:
+        console.print(f"  reason: {offline_reason}")
+    console.print(f"Store: {path}")
+    console.print(f"Policies: {len(enabled_policies)} enabled / {len(policies)} total")
+    console.print(
+        f"Drafts: {len(pending_drafts)} pending" + (f" ({len(auto_degraded)} auto-degraded)" if auto_degraded else "")
+    )
+    if next_due:
+        console.print(
+            f"Next: {next_due.get('id')} priority={int(next_due.get('priority', _DEFAULT_PRIORITY))} "
+            f"mode={next_due.get('mode', 'auto')} target={next_due.get('target') or '(task)'} "
+            f"fires_at={next_due.get('next_fire_at')}"
+        )
+    else:
+        console.print("Next: (no enabled policies)")
 
 
 # ---- Operator commands: pause / resume / cancel / update -------------------

--- a/specs/TASK-LOOP-001/README.md
+++ b/specs/TASK-LOOP-001/README.md
@@ -1,9 +1,12 @@
 # TASK-LOOP-001: Task-Driven Loops with Priority Queue + HITL Drafts
 
-**Status:** v1 — CLI-first implementation landing in this PR
+**Status:** v1.1 — CLI-first implementation; v1 (priority + draft mode) landed in PR #98, v1.1 (offline-first) lands in this PR
 **Owner:** @orion
 **Date:** 2026-04-25
-**Source directive:** @madtank 2026-04-25 03:46 UTC ("frequency and priority… queue a priority for each assignment, moved around like a song playing"); @madtank 2026-04-25 04:00 UTC ("loop should support a draft/review state where the HITL user can inspect and explicitly send")
+**Source directives:**
+- @madtank 2026-04-25 03:46 UTC — "frequency and priority… queue a priority for each assignment, moved around like a song playing"
+- @madtank 2026-04-25 04:00 UTC — "loop should support a draft/review state where the HITL user can inspect and explicitly send"
+- @madtank 2026-04-25 04:10 UTC (via @ChatGPT and @backend_sentinel) — "CLI should support offline-first mode where agents can talk/work locally without assuming platform reachability… make delivery vs activation explicit, make offline/connected status obvious"
 
 ## Why this exists
 
@@ -15,19 +18,26 @@ Reminders (`ax reminders`) already provided 80% of the spine: task-tied policies
 
 ## Scope
 
-In:
+### v1 (PR #98)
 - Per-policy `priority` field, queue ordered by priority
 - `mode` field: `auto` / `draft` / `manual`
 - Draft store with HITL review/edit/send/cancel
 - Operator commands: `pause`, `resume`, `cancel`, `update`
 - Pytest smokes covering all three modes
 
-Out (follow-up):
+### v1.1 (this PR — offline-first)
+- `ax reminders add --space-id X` works fully offline (no `get_client` call)
+- `auto` mode auto-degrades to `draft` on network errors (`auto_degraded: true` flag on the draft, with `auto_degrade_reason`)
+- `ax reminders status` command surfaces online/offline + queue depth + pending drafts (with auto-degraded count broken out separately)
+- Pytest smokes for all three offline-first behaviors
+
+### Out (follow-up)
 - Backend persistence of loop state (currently local JSON)
 - Cross-machine queue sync (single-machine for now)
 - `ax tasks loop` semantic alias group (deferred — `ax reminders` is the implementation; the alias is naming polish)
 - Platform-side scheduler integration (TASKS-LIFECYCLE-001 territory)
 - Stop conditions beyond `max_fires` and "source task is terminal" (e.g. done-event hooks)
+- Aligning vocabulary with backend_sentinel's AGENT-TRIGGER-SEMANTICS-001 frame once it lands
 
 ## Data model — local store at `~/.ax/reminders.json` (version 2)
 
@@ -95,30 +105,35 @@ Drafted fires DO advance `fired_count` and `next_fire_at`. The HITL send/cancel 
 ## CLI surface
 
 ```
-# Existing (now with --priority and --mode)
-ax reminders add <task-id> [--priority N] [--mode auto|draft|manual] [--cadence-minutes N] [--max-fires N] [--target X]
+# v1: priority + mode
+ax reminders add <task-id> [--priority N] [--mode auto|draft|manual] [--cadence-minutes N] [--max-fires N] [--target X] [--space-id X]
 ax reminders list
 ax reminders run --once
 ax reminders run --watch --interval 30
 ax reminders disable <id>           # legacy, kept
 
-# New operator commands
+# v1: operator commands
 ax reminders pause <id>
 ax reminders resume <id>
 ax reminders cancel <id>
 ax reminders update <id> [--priority N] [--cadence-minutes N] [--max-fires N] [--mode X] [--reason ...] [--target X]
 
-# New drafts subcommand group
+# v1: drafts subcommand group
 ax reminders drafts list
 ax reminders drafts show <draft-id>
 ax reminders drafts edit <draft-id> [--body "..."] [--target X]
 ax reminders drafts send <draft-id>
 ax reminders drafts cancel <draft-id>
+
+# v1.1: offline-first surface
+ax reminders status [--skip-probe]                       # online/offline + queue + drafts snapshot
+ax reminders add ... --space-id X                        # fully offline (no backend call for space resolution)
+# auto mode: auto-degrades to draft on network errors (auto_degraded: true on the draft)
 ```
 
 ## Acceptance smokes
 
-All in `tests/test_task_loop_modes.py` — 11 pytest cases:
+### v1 (PR #98, `tests/test_task_loop_modes.py` — 11 cases)
 
 1. `add` accepts `--priority` and `--mode` and stores them on the policy
 2. `add` rejects priority outside 0-100
@@ -132,7 +147,14 @@ All in `tests/test_task_loop_modes.py` — 11 pytest cases:
 10. `pause` / `resume` cycle round-trips correctly
 11. `update --priority` re-orders the queue
 
-Existing reminder tests (8) continue to pass — backwards compatible (version 1 store loads as version 2 with empty drafts array; new fields have sensible defaults).
+### v1.1 (this PR, `tests/test_task_loop_offline.py` — 4 cases)
+
+12. `add --space-id X` works without calling `get_client` or `resolve_space_id` (fully offline)
+13. `auto` mode with `httpx.ConnectError` falls back to draft with `auto_degraded: true`, `auto_degrade_reason` populated
+14. `status --skip-probe --json` reports queue depth, pending drafts, auto-degraded count, next-due policy
+15. `status` works with empty store (no policies, `next_due: null`)
+
+Existing reminder tests (8) and v1 task-loop tests (11) continue to pass — backwards compatible (version 1 store loads as version 2 with empty drafts array; new fields have sensible defaults).
 
 ## Why this is a small spec
 

--- a/tests/test_task_loop_offline.py
+++ b/tests/test_task_loop_offline.py
@@ -1,0 +1,216 @@
+"""Tests for TASK-LOOP-001 offline-first follow-up:
+
+- ``add --space-id`` works without backend (no get_client call)
+- ``auto`` mode degrades to draft on network errors (auto_degraded flag)
+- ``status`` command reports queue depth + pending drafts
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+from typer.testing import CliRunner
+
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def test_add_works_fully_offline_with_explicit_space_id(monkeypatch, tmp_path):
+    """``ax reminders add --space-id X`` must NOT call get_client/resolve_space_id."""
+    policy_file = tmp_path / "reminders.json"
+
+    def _explode(*_a, **_kw):
+        raise RuntimeError("get_client should not be called when --space-id is provided")
+
+    monkeypatch.setattr("ax_cli.commands.reminders.get_client", _explode)
+    monkeypatch.setattr("ax_cli.commands.reminders.resolve_space_id", _explode)
+
+    result = runner.invoke(
+        app,
+        [
+            "reminders", "add", "task-O",
+            "--target", "orion",
+            "--space-id", "space-explicit",
+            "--first-in-minutes", "0",
+            "--mode", "manual",
+            "--file", str(policy_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = _load(policy_file)["policies"][0]
+    assert policy["space_id"] == "space-explicit"
+    assert policy["mode"] == "manual"
+
+
+class _ConnectErrorClient:
+    """Client whose send_message always raises httpx.ConnectError."""
+    def __init__(self):
+        self.send_attempts = 0
+
+    def send_message(self, *args, **kwargs):
+        self.send_attempts += 1
+        raise httpx.ConnectError("connection refused (test)")
+
+
+def _install_offline_runtime(monkeypatch, client):
+    monkeypatch.setattr("ax_cli.commands.reminders.get_client", lambda: client)
+    monkeypatch.setattr(
+        "ax_cli.commands.reminders.resolve_space_id",
+        lambda _client, *, explicit=None: explicit or "space-abc",
+    )
+    monkeypatch.setattr("ax_cli.commands.reminders.resolve_agent_name", lambda client=None: "orion")
+
+
+def test_auto_mode_degrades_to_draft_on_connect_error(monkeypatch, tmp_path):
+    """When the backend is unreachable, auto-mode fires save as drafts with
+    auto_degraded=true so the operator can dispatch them once online."""
+    fake = _ConnectErrorClient()
+    _install_offline_runtime(monkeypatch, fake)
+
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "drafts": [],
+                "policies": [
+                    {
+                        "id": "rem-auto-off",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-N",
+                        "reason": "auto fire while offline",
+                        "target": "orion",
+                        "severity": "info",
+                        "priority": 50,
+                        "mode": "auto",
+                        "cadence_seconds": 300,
+                        "next_fire_at": "2026-04-16T00:00:00Z",
+                        "max_fires": 1,
+                        "fired_count": 0,
+                        "fired_keys": [],
+                    }
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    # send_message was attempted (auto mode tried) but failed
+    assert fake.send_attempts == 1
+
+    # Auto-degraded into a draft
+    fired = payload["fired"][0]
+    assert fired.get("drafted") is True
+    assert fired.get("auto_degraded") is True
+
+    store = _load(policy_file)
+    assert len(store["drafts"]) == 1
+    draft = store["drafts"][0]
+    assert draft["auto_degraded"] is True
+    assert draft["status"] == "pending"
+    assert "connection refused" in draft["auto_degrade_reason"]
+
+    # Policy still advances (the fire happened, just landed as a draft)
+    policy = store["policies"][0]
+    assert policy["fired_count"] == 1
+    assert policy["last_draft_id"] == draft["id"]
+
+
+def test_status_command_shows_queue_and_drafts(monkeypatch, tmp_path):
+    """``ax reminders status --skip-probe --json`` returns a structured snapshot."""
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "policies": [
+                    {
+                        "id": "rem-A",
+                        "enabled": True,
+                        "priority": 10,
+                        "mode": "auto",
+                        "target": "orion",
+                        "next_fire_at": "2026-04-26T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                        "cadence_seconds": 300,
+                    },
+                    {
+                        "id": "rem-B",
+                        "enabled": True,
+                        "priority": 50,
+                        "mode": "draft",
+                        "target": "cipher",
+                        "next_fire_at": "2026-04-27T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                        "cadence_seconds": 600,
+                    },
+                    {
+                        "id": "rem-C",
+                        "enabled": False,
+                        "priority": 90,
+                        "mode": "auto",
+                        "target": "anvil",
+                        "next_fire_at": "2026-04-28T00:00:00Z",
+                        "max_fires": 1,
+                        "fired_count": 1,
+                    },
+                ],
+                "drafts": [
+                    {"id": "draft-1", "policy_id": "rem-B", "status": "pending"},
+                    {"id": "draft-2", "policy_id": "rem-A", "status": "pending", "auto_degraded": True},
+                    {"id": "draft-3", "policy_id": "rem-A", "status": "sent"},
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app, ["reminders", "status", "--file", str(policy_file), "--skip-probe", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    snapshot = json.loads(result.output)
+
+    assert snapshot["online"] is False
+    assert snapshot["offline_reason"] == "probe skipped"
+    assert snapshot["policies_total"] == 3
+    assert snapshot["policies_enabled"] == 2
+    assert snapshot["policies_paused_or_disabled"] == 1
+    assert snapshot["drafts_pending"] == 2
+    assert snapshot["drafts_auto_degraded"] == 1
+
+    # Next-due is the highest-priority enabled policy (rem-A, priority 10)
+    next_due = snapshot["next_due"]
+    assert next_due is not None
+    assert next_due["id"] == "rem-A"
+    assert next_due["priority"] == 10
+    assert next_due["mode"] == "auto"
+
+
+def test_status_with_no_policies(monkeypatch, tmp_path):
+    """Empty store: status still works, next_due is null."""
+    policy_file = tmp_path / "reminders.json"
+    # File doesn't exist — _load_store returns _empty_store
+
+    result = runner.invoke(
+        app, ["reminders", "status", "--file", str(policy_file), "--skip-probe", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    snapshot = json.loads(result.output)
+    assert snapshot["policies_total"] == 0
+    assert snapshot["drafts_pending"] == 0
+    assert snapshot["next_due"] is None


### PR DESCRIPTION
Stacks on PR #98. Implements @madtank's 04:10 UTC direction (relayed via @ChatGPT and @backend_sentinel) for CLI offline-first mode.

> Stacking note: this PR is based on \`orion/task-loop-policy\` (PR #98). After #98 lands, this PR's diff will rebase cleanly to main.

## What

| Capability | Behavior |
|---|---|
| \`ax reminders add --space-id X\` | Fully offline. No \`get_client\` or \`resolve_space_id\` call. |
| \`auto\` mode + network error | Auto-degrades to draft with \`auto_degraded=true\`, \`auto_degrade_reason\` string. Fire advances normally; just lands as a draft. |
| \`ax reminders status\` | Online/offline probe (\`--skip-probe\` to bypass), policies enabled/total, drafts pending with auto-degraded count broken out, next-due policy. Both \`--json\` and human readable. |

## Activation vs delivery is now fully decoupled

Per @madtank's \"make delivery vs activation explicit\":

- **auto + online** = activate AND deliver
- **auto + offline** = activate, defer delivery (auto-degraded draft)
- **draft (any state)** = activate, explicit-deliver via HITL
- **manual** = neither activates nor delivers without operator action

## Tests

- 4 new smokes in \`tests/test_task_loop_offline.py\`
- All 19 existing reminder + task-loop tests still pass (23 total)
- \`uv run ruff check\` clean, \`uv run ruff format\` clean

## Spec

\`specs/TASK-LOOP-001/README.md\` updated with v1.1 section, source directives list extended.

Vocabulary will reconcile with backend_sentinel's AGENT-TRIGGER-SEMANTICS-001 frame when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)