### PR TITLE
feat(heartbeat): HEARTBEAT-001 — local-first agent heartbeat CLI primitive

### DIFF
--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -402,6 +402,36 @@ class AxClient:
 
     # --- Messages ---
 
+    def send_heartbeat(
+        self,
+        *,
+        agent_id: str | None = None,
+        status: str | None = None,
+        note: str | None = None,
+        cadence_seconds: int | None = None,
+    ) -> dict:
+        """POST /api/v1/agents/heartbeat — refresh agent presence in Redis.
+
+        Backend currently treats this as a presence ping (no body required).
+        ``status`` / ``note`` / ``cadence_seconds`` are forward-compatible —
+        sent in the body so backend can adopt them when the richer heartbeat
+        protocol lands. Backend extras are ignored gracefully.
+        """
+        body: dict = {}
+        if status is not None:
+            body["status"] = status
+        if note is not None:
+            body["note"] = note
+        if cadence_seconds is not None:
+            body["cadence_seconds"] = cadence_seconds
+        r = self._http.post(
+            "/api/v1/agents/heartbeat",
+            json=body,
+            headers=self._with_agent(agent_id),
+        )
+        r.raise_for_status()
+        return self._parse_json(r)
+
     def send_message(
         self,
         space_id: str,

--- a/ax_cli/commands/heartbeat.py
+++ b/ax_cli/commands/heartbeat.py
@@ -1,0 +1,532 @@
+"""Local-first heartbeat primitive.
+
+Per madtank 2026-04-25: connectedness is one of three urgent primitives
+(gateway / connectedness / registry). Heartbeats are the foundation —
+each agent declares its own cadence; routing asks "did it meet its own
+cadence within tolerance?" Decouples "alive" from "replied."
+
+Design:
+- Local store at ``~/.ax/heartbeats.json``: cadence, current status,
+  history, push state.
+- ``ax heartbeat send``: post to ``/api/v1/agents/heartbeat`` AND save
+  locally. Offline-first: on network error, queue locally with
+  ``pushed=false`` and mark a ``last_push_error``.
+- ``ax heartbeat status``: surface online/offline + last_sent + next_due
+  + queued count, structured for tooling.
+- ``ax heartbeat watch``: tick at cadence, send each tick.
+- ``ax heartbeat push``: drain queued (unpushed) heartbeats.
+
+Status vocabulary aligned with the heartbeat primitive memory note
+(active / busy / delayed / sleeping / unresponsive / suspended /
+disabled / unknown). Unknown values pass through to the backend body
+so the protocol can evolve without CLI updates.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+import typer
+
+from ..config import get_client, resolve_agent_name
+from ..output import JSON_OPTION, console, print_json, print_table
+
+app = typer.Typer(name="heartbeat", help="Local-first agent heartbeat primitive", no_args_is_help=True)
+
+
+_DEFAULT_CADENCE_SECONDS = 60
+_VALID_STATUSES = (
+    "active",
+    "busy",
+    "delayed",
+    "sleeping",
+    "unresponsive",
+    "suspended",
+    "disabled",
+    "unknown",
+)
+
+
+def _now() -> _dt.datetime:
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0)
+
+
+def _iso(value: _dt.datetime) -> str:
+    return value.astimezone(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> _dt.datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = _dt.datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return parsed.astimezone(_dt.timezone.utc)
+
+
+def _default_store_file() -> Path:
+    env_path = os.environ.get("AX_HEARTBEATS_FILE")
+    if env_path:
+        return Path(env_path).expanduser()
+    cwd = Path.cwd()
+    for parent in [cwd, *cwd.parents]:
+        ax_dir = parent / ".ax"
+        if ax_dir.is_dir():
+            return ax_dir / "heartbeats.json"
+    return Path.home() / ".ax" / "heartbeats.json"
+
+
+def _store_file(path: str | None) -> Path:
+    return Path(path).expanduser() if path else _default_store_file()
+
+
+def _empty_store() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "agent_name": None,
+        "agent_id": None,
+        "cadence_seconds": _DEFAULT_CADENCE_SECONDS,
+        "current_status": "unknown",
+        "current_note": None,
+        "last_sent_at": None,
+        "last_pushed_at": None,
+        "next_due_at": None,
+        "history": [],
+    }
+
+
+def _load_store(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return _empty_store()
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Error: heartbeats file is not valid JSON: {path} ({exc})", err=True)
+        raise typer.Exit(1)
+    if not isinstance(data, dict):
+        typer.echo(f"Error: heartbeats file must contain a JSON object: {path}", err=True)
+        raise typer.Exit(1)
+    # Forward-compat defaults
+    base = _empty_store()
+    for key, default in base.items():
+        data.setdefault(key, default)
+    if not isinstance(data["history"], list):
+        typer.echo(f"Error: heartbeats history must be a list: {path}", err=True)
+        raise typer.Exit(1)
+    return data
+
+
+def _save_store(path: Path, store: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(store, indent=2, sort_keys=True) + "\n")
+    tmp.replace(path)
+    path.chmod(0o600)
+
+
+def _short_id() -> str:
+    return f"hb-{uuid.uuid4().hex[:10]}"
+
+
+def _normalize_status(value: str | None, *, allow_passthrough: bool = True) -> str:
+    text = (value or "active").strip().lower()
+    if not allow_passthrough and text not in _VALID_STATUSES:
+        raise typer.BadParameter(f"--status must be one of: {', '.join(_VALID_STATUSES)} (got '{text}')")
+    # Pass-through unknown values so the protocol can evolve. Warn via stderr
+    # in human mode is the operator's call; tooling-side relies on the value.
+    return text
+
+
+def _record_heartbeat(
+    store: dict[str, Any],
+    *,
+    status: str,
+    note: str | None,
+    cadence_seconds: int,
+    pushed: bool,
+    push_error: str | None,
+    backend_response: dict | None,
+    now: _dt.datetime,
+) -> dict[str, Any]:
+    record = {
+        "id": _short_id(),
+        "status": status,
+        "note": note,
+        "sent_at": _iso(now),
+        "pushed": pushed,
+        "pushed_at": _iso(now) if pushed else None,
+        "push_error": push_error,
+        "backend_ttl_seconds": (backend_response or {}).get("ttl_seconds"),
+    }
+    store["current_status"] = status
+    store["current_note"] = note
+    store["cadence_seconds"] = int(cadence_seconds)
+    store["last_sent_at"] = record["sent_at"]
+    if pushed:
+        store["last_pushed_at"] = record["pushed_at"]
+    store["next_due_at"] = _iso(now + _dt.timedelta(seconds=int(cadence_seconds)))
+    history = list(store.get("history") or [])
+    history.append(record)
+    store["history"] = history[-100:]  # ring buffer
+    return record
+
+
+def _try_push(
+    client: Any,
+    *,
+    status: str,
+    note: str | None,
+    cadence_seconds: int,
+) -> tuple[bool, str | None, dict | None]:
+    """Attempt to POST a heartbeat. Returns (pushed, error_str, response)."""
+    try:
+        resp = client.send_heartbeat(
+            status=status,
+            note=note,
+            cadence_seconds=cadence_seconds,
+        )
+        return True, None, resp if isinstance(resp, dict) else None
+    except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException) as exc:
+        return False, f"network: {exc}", None
+    except httpx.HTTPStatusError as exc:
+        return False, f"{exc.response.status_code}: {exc.response.text[:200]}", None
+    except Exception as exc:  # noqa: BLE001 — defensive: any client error degrades to local queue
+        return False, str(exc), None
+
+
+@app.command("send")
+def send(
+    status: str = typer.Option("active", "--status", "-s", help=f"Status: {' | '.join(_VALID_STATUSES)}"),
+    note: Optional[str] = typer.Option(None, "--note", "-n", help="Optional context note"),
+    cadence: int = typer.Option(_DEFAULT_CADENCE_SECONDS, "--cadence", "-c", help="Declared cadence in seconds"),
+    skip_push: bool = typer.Option(False, "--skip-push", help="Record locally only; do not POST to backend"),
+    store_file: Optional[str] = typer.Option(None, "--file", help="Local heartbeats JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Send one heartbeat. Records locally + POSTs to backend (offline-safe).
+
+    On network failure the heartbeat is recorded locally with pushed=false
+    and a push_error string. Use ``ax heartbeat push`` to drain the queue
+    once connectivity returns.
+    """
+    if cadence < 1:
+        raise typer.BadParameter("--cadence must be at least 1 second")
+    normalized_status = _normalize_status(status)
+
+    path = _store_file(store_file)
+    store = _load_store(path)
+
+    pushed = False
+    push_error: Optional[str] = None
+    backend_response: Optional[dict] = None
+
+    if not skip_push:
+        try:
+            client = get_client()
+            try:
+                store["agent_name"] = resolve_agent_name(client=client)
+            except Exception:
+                pass
+            pushed, push_error, backend_response = _try_push(
+                client,
+                status=normalized_status,
+                note=note,
+                cadence_seconds=cadence,
+            )
+        except Exception as exc:
+            push_error = f"client unavailable: {exc}"
+
+    record = _record_heartbeat(
+        store,
+        status=normalized_status,
+        note=note,
+        cadence_seconds=cadence,
+        pushed=pushed,
+        push_error=push_error,
+        backend_response=backend_response,
+        now=_now(),
+    )
+    _save_store(path, store)
+
+    if as_json:
+        print_json(
+            {
+                "record": record,
+                "file": str(path),
+                "store": {
+                    "current_status": store["current_status"],
+                    "next_due_at": store["next_due_at"],
+                    "cadence_seconds": store["cadence_seconds"],
+                },
+            }
+        )
+        return
+
+    if pushed:
+        console.print(
+            f"[green]heartbeat[/green] {record['id']} status={normalized_status} pushed=yes "
+            f"(ttl={record.get('backend_ttl_seconds')}s)"
+        )
+    else:
+        marker = "[yellow]queued[/yellow]" if push_error else "[cyan]local-only[/cyan]"
+        reason = f" reason={push_error}" if push_error else ""
+        console.print(f"{marker} heartbeat {record['id']} status={normalized_status}{reason}")
+
+
+@app.command("list")
+def list_history(
+    limit: int = typer.Option(10, "--limit", help="Max records to show"),
+    only_unpushed: bool = typer.Option(False, "--unpushed", help="Show only queued (unpushed) heartbeats"),
+    store_file: Optional[str] = typer.Option(None, "--file", help="Local heartbeats JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """List local heartbeat history (most recent first)."""
+    path = _store_file(store_file)
+    store = _load_store(path)
+    history = list(reversed(store.get("history") or []))
+    if only_unpushed:
+        history = [h for h in history if not h.get("pushed")]
+    history = history[:limit]
+    if as_json:
+        print_json({"file": str(path), "history": history})
+        return
+    if not history:
+        console.print(f"No heartbeats in {path}")
+        return
+    rows = [
+        {
+            "id": h.get("id", ""),
+            "status": h.get("status", ""),
+            "sent_at": h.get("sent_at", ""),
+            "pushed": "yes" if h.get("pushed") else "no",
+            "ttl": h.get("backend_ttl_seconds") or "-",
+            "note": (h.get("note") or "")[:40],
+            "error": (h.get("push_error") or "")[:40],
+        }
+        for h in history
+    ]
+    print_table(
+        ["ID", "Status", "Sent", "Pushed", "TTL", "Note", "Error"],
+        rows,
+        keys=["id", "status", "sent_at", "pushed", "ttl", "note", "error"],
+    )
+
+
+def _probe_online(timeout: float = 2.0) -> tuple[bool, str | None]:
+    """Cheap online probe by attempting a real heartbeat."""
+    try:
+        client = get_client()
+    except Exception as exc:
+        return False, f"client unavailable: {exc}"
+    base = getattr(client, "_base_url", None) or getattr(client, "base_url", None)
+    if not base:
+        return False, "no base_url configured"
+    try:
+        resp = httpx.get(f"{str(base).rstrip('/')}/health", timeout=timeout)
+        if resp.status_code < 500:
+            return True, None
+        return False, f"backend status {resp.status_code}"
+    except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException) as exc:
+        return False, f"network: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+@app.command("status")
+def status_cmd(
+    skip_probe: bool = typer.Option(False, "--skip-probe", help="Skip online probe (assume offline)"),
+    store_file: Optional[str] = typer.Option(None, "--file", help="Local heartbeats JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Show current heartbeat state + queue depth."""
+    path = _store_file(store_file)
+    store = _load_store(path)
+
+    history = store.get("history") or []
+    unpushed = [h for h in history if not h.get("pushed")]
+    last_sent_at = store.get("last_sent_at")
+    last_pushed_at = store.get("last_pushed_at")
+    next_due_at = store.get("next_due_at")
+    cadence = int(store.get("cadence_seconds", _DEFAULT_CADENCE_SECONDS))
+
+    is_due = False
+    if next_due_at:
+        try:
+            is_due = _parse_iso(next_due_at) <= _now()
+        except Exception:
+            is_due = False
+
+    if skip_probe:
+        is_online, offline_reason = False, "probe skipped"
+    else:
+        is_online, offline_reason = _probe_online()
+
+    snapshot = {
+        "online": is_online,
+        "offline_reason": offline_reason,
+        "agent_name": store.get("agent_name"),
+        "current_status": store.get("current_status"),
+        "current_note": store.get("current_note"),
+        "cadence_seconds": cadence,
+        "last_sent_at": last_sent_at,
+        "last_pushed_at": last_pushed_at,
+        "next_due_at": next_due_at,
+        "is_due_now": is_due,
+        "queued_unpushed": len(unpushed),
+        "file": str(path),
+    }
+
+    if as_json:
+        print_json(snapshot)
+        return
+
+    state_label = "[bold green]ONLINE[/bold green]" if is_online else "[bold yellow]OFFLINE[/bold yellow]"
+    console.print(f"State: {state_label}")
+    if not is_online and offline_reason:
+        console.print(f"  reason: {offline_reason}")
+    console.print(f"Agent: {store.get('agent_name') or '(unknown)'}")
+    console.print(f"Status: {store.get('current_status')} (cadence={cadence}s)")
+    console.print(f"Last sent: {last_sent_at or '(never)'}")
+    console.print(f"Last pushed: {last_pushed_at or '(never)'}")
+    if next_due_at:
+        marker = "[yellow]DUE NOW[/yellow]" if is_due else "queued"
+        console.print(f"Next due: {next_due_at} ({marker})")
+    else:
+        console.print("Next due: (no heartbeats sent yet)")
+    if unpushed:
+        console.print(f"Queued (unpushed): [yellow]{len(unpushed)}[/yellow] — run `ax heartbeat push` to drain")
+
+
+@app.command("push")
+def push(
+    store_file: Optional[str] = typer.Option(None, "--file", help="Local heartbeats JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Push queued (unpushed) heartbeats to the backend.
+
+    Sends only the latest unpushed heartbeat — older ones are local-only
+    history. Backend presence is a TTL ping, so replaying stale heartbeats
+    isn't useful. If you need a richer push-history protocol later, this
+    command is the natural extension point.
+    """
+    path = _store_file(store_file)
+    store = _load_store(path)
+    history = list(store.get("history") or [])
+    unpushed = [h for h in history if not h.get("pushed")]
+
+    if not unpushed:
+        if as_json:
+            print_json({"file": str(path), "pushed": [], "reason": "no_queued_heartbeats"})
+            return
+        console.print(f"No queued heartbeats in {path}")
+        return
+
+    latest = unpushed[-1]
+    try:
+        client = get_client()
+    except Exception as exc:
+        if as_json:
+            print_json({"file": str(path), "pushed": [], "error": f"client unavailable: {exc}"})
+            return
+        console.print(f"[red]error[/red]: client unavailable ({exc})")
+        raise typer.Exit(1)
+
+    pushed, err, resp = _try_push(
+        client,
+        status=str(latest.get("status") or "active"),
+        note=latest.get("note"),
+        cadence_seconds=int(store.get("cadence_seconds", _DEFAULT_CADENCE_SECONDS)),
+    )
+
+    if pushed:
+        # Mark this record AND any older unpushed records as pushed (presence is latest-wins).
+        for record in history:
+            if not record.get("pushed"):
+                record["pushed"] = True
+                record["pushed_at"] = _iso(_now())
+                record["push_error"] = None
+                if record["id"] == latest["id"]:
+                    record["backend_ttl_seconds"] = (resp or {}).get("ttl_seconds")
+        store["history"] = history
+        store["last_pushed_at"] = _iso(_now())
+        _save_store(path, store)
+        if as_json:
+            print_json({"file": str(path), "pushed": [latest["id"]], "drained_count": len(unpushed), "backend": resp})
+            return
+        console.print(
+            f"[green]pushed[/green] {latest['id']} (drained {len(unpushed)} queued, "
+            f"backend ttl={resp.get('ttl_seconds') if resp else '-'}s)"
+        )
+    else:
+        latest["push_error"] = err
+        _save_store(path, store)
+        if as_json:
+            print_json({"file": str(path), "pushed": [], "error": err})
+        else:
+            console.print(f"[red]push failed[/red]: {err}")
+        raise typer.Exit(1)
+
+
+@app.command("watch")
+def watch(
+    interval: int = typer.Option(_DEFAULT_CADENCE_SECONDS, "--interval", "-i", help="Tick interval in seconds"),
+    status: str = typer.Option(
+        "active", "--status", "-s", help=f"Status to send each tick: {' | '.join(_VALID_STATUSES)}"
+    ),
+    note: Optional[str] = typer.Option(None, "--note", "-n", help="Optional context note"),
+    max_ticks: int = typer.Option(0, "--max-ticks", help="Stop after N ticks (0 = run forever)"),
+    store_file: Optional[str] = typer.Option(None, "--file", help="Local heartbeats JSON file"),
+) -> None:
+    """Tick a heartbeat at the given interval. Use Ctrl-C to stop."""
+    if interval < 1:
+        raise typer.BadParameter("--interval must be at least 1 second")
+    normalized_status = _normalize_status(status)
+    path = _store_file(store_file)
+
+    tick = 0
+    console.print(f"Heartbeat watch started — interval={interval}s status={normalized_status} file={path}")
+    while True:
+        tick += 1
+        try:
+            client = get_client()
+            agent_name = None
+            try:
+                agent_name = resolve_agent_name(client=client)
+            except Exception:
+                pass
+            pushed, err, resp = _try_push(client, status=normalized_status, note=note, cadence_seconds=interval)
+        except Exception as exc:
+            pushed, err, resp, agent_name = False, f"client unavailable: {exc}", None, None
+
+        store = _load_store(path)
+        if agent_name and not store.get("agent_name"):
+            store["agent_name"] = agent_name
+        record = _record_heartbeat(
+            store,
+            status=normalized_status,
+            note=note,
+            cadence_seconds=interval,
+            pushed=pushed,
+            push_error=err,
+            backend_response=resp,
+            now=_now(),
+        )
+        _save_store(path, store)
+
+        if pushed:
+            console.print(f"[green]tick {tick}[/green] heartbeat {record['id']} pushed")
+        else:
+            console.print(f"[yellow]tick {tick}[/yellow] heartbeat {record['id']} queued (err={err})")
+
+        if max_ticks and tick >= max_ticks:
+            console.print(f"Reached --max-ticks ({max_ticks}), stopping.")
+            return
+        time.sleep(interval)

--- a/ax_cli/main.py
+++ b/ax_cli/main.py
@@ -18,6 +18,7 @@ from .commands import (
     events,
     gateway,
     handoff,
+    heartbeat,
     keys,
     listen,
     messages,
@@ -40,6 +41,7 @@ app.add_typer(apps.app, name="apps")
 app.add_typer(messages.app, name="messages")
 app.add_typer(alerts.app, name="alerts")
 app.add_typer(reminders.app, name="reminders")
+app.add_typer(heartbeat.app, name="heartbeat")
 app.add_typer(tasks.app, name="tasks")
 app.add_typer(events.app, name="events")
 app.add_typer(listen.app, name="listen")

--- a/specs/HEARTBEAT-001/README.md
+++ b/specs/HEARTBEAT-001/README.md
@@ -1,0 +1,114 @@
+# HEARTBEAT-001: Local-First Agent Heartbeat Primitive
+
+**Status:** v1 — CLI-first implementation landing in this PR
+**Owner:** @orion
+**Date:** 2026-04-25
+**Source directives:**
+- @madtank 2026-04-25 04:11 UTC — "we need to start getting features like heartbeat... we need to have our own pulse on the gateway"
+- @madtank 2026-04-25 15:25 UTC — "keep moving and shipping faster, especially around gateway and connectedness and the registry... it's funny how we might be competing against AWS and Google"
+- Heartbeat primitive memory note (2026-04-09) — "each agent declares its own cadence, routing asks 'did it meet its own cadence within tolerance?'"
+
+## Why this exists
+
+**Connectedness** is one of three primitives madtank named as urgent (gateway / connectedness / registry). The heartbeat is the foundation of connectedness: it decouples "alive" from "replied" by letting each agent declare its own cadence, then asking "did it meet its own cadence within tolerance?"
+
+The platform already has a backend heartbeat endpoint (`POST /api/v1/agents/heartbeat`) used by SSE listeners. This spec adds the **CLI primitive** so any agent — not just SSE-connected ones — can ping presence on its own cadence.
+
+**CLI-first.** Local store at `~/.ax/heartbeats.json`; offline-safe; pushes when online. Same offline-first pattern as TASK-LOOP-001. Promote richer protocol semantics to the platform after the CLI version is validated.
+
+## Scope
+
+In:
+- `ax heartbeat send/list/status/push/watch` commands
+- Local store with cadence, current status/note, push state, history (ring-buffer 100)
+- Status vocabulary: `active` / `busy` / `delayed` / `sleeping` / `unresponsive` / `suspended` / `disabled` / `unknown` (with pass-through for unknown values so the protocol can evolve)
+- Offline-first: network errors queue locally with `pushed=false` and `push_error`
+- `ax heartbeat push` drains queued (presence is latest-wins; only the newest unpushed heartbeat hits the wire, older ones are local history)
+- `ax heartbeat watch --interval N --max-ticks N` daemon mode
+
+Out (follow-up):
+- Backend richer heartbeat schema (currently backend treats body extras as ignorable; once the protocol matures, backend ingests `status`/`note`/`cadence_seconds`)
+- Heartbeat-derived `responsive` axis on the AVAIL-CONTRACT-001 resolved DTO (depends on backend wiring)
+- Gateway daemon emitting heartbeats on behalf of managed sentinels (separate task #19, GATEWAY-PULSE-001)
+- MCP tool surface for heartbeats (separate, AWS-Agent-Registry-equivalent surface)
+
+## Data model — local store at `~/.ax/heartbeats.json`
+
+```json
+{
+  "version": 1,
+  "agent_name": "orion",
+  "agent_id": "...",
+  "cadence_seconds": 60,
+  "current_status": "active",
+  "current_note": null,
+  "last_sent_at": "ISO",
+  "last_pushed_at": "ISO?",
+  "next_due_at": "ISO",
+  "history": [
+    {
+      "id": "hb-...",
+      "status": "active",
+      "note": "...",
+      "sent_at": "ISO",
+      "pushed": true,
+      "pushed_at": "ISO?",
+      "push_error": null,
+      "backend_ttl_seconds": 30
+    }
+  ]
+}
+```
+
+## CLI surface
+
+```
+ax heartbeat send [--status STATUS] [--note "..."] [--cadence N] [--skip-push] [--file PATH]
+  # Records locally + POSTs to /api/v1/agents/heartbeat
+  # On network error: queued with pushed=false + push_error
+  # --skip-push: record locally only (offline mode without retry attempt)
+
+ax heartbeat list [--limit N] [--unpushed]
+  # Local heartbeat history, most recent first
+  # --unpushed filters to queued records
+
+ax heartbeat status [--skip-probe]
+  # Online/offline (cheap GET /health probe; --skip-probe to assume offline)
+  # Current status + cadence + last_sent_at + next_due_at + queued count
+  # --json for tooling
+
+ax heartbeat push
+  # Drain queued (unpushed) heartbeats. Sends ONLY the latest — presence is
+  # latest-wins; older heartbeats are local-only history. All older
+  # unpushed records are marked pushed=true.
+
+ax heartbeat watch --interval N [--status S] [--note "..."] [--max-ticks N]
+  # Tick-based daemon. Each tick: send heartbeat, record locally, log result.
+  # Use --max-ticks for bounded runs (CI smokes); 0 = run forever.
+```
+
+## Acceptance smokes (`tests/test_heartbeat_commands.py`)
+
+11 pytest cases covering:
+
+1. `send` records and pushes when online (verifies backend call, store update, ttl)
+2. `send` queues locally on network error (verifies push_error, no last_pushed_at)
+3. `send --skip-push` records local-only without calling backend
+4. `send` rejects invalid cadence (`--cadence 0`)
+5. `send --status future_value_xyz` passes unknown status through (protocol evolution)
+6. `status` reports queued unpushed count + agent name + cadence + next_due
+7. `status` handles empty store gracefully (no crash, sensible defaults)
+8. `list --unpushed` returns only queued records, most recent first
+9. `push` drains queue when online: sends LATEST status, marks all older unpushed as pushed
+10. `push` returns clean (no error) when no queued records
+11. `push` returns error + non-zero exit when offline; record updated with push_error
+
+## Why this is a small spec
+
+Per @orion's SDD critique 2026-04-25: implementation-first. The contract is the 11 pytests. Spec evolves with code.
+
+## Out-of-scope cross-references
+
+- **AGENT-AVAILABILITY-CONTRACT-001** (PR #97 merged) — heartbeats feed the Responsive axis. When backend wires `agent_state.responsive` from heartbeat freshness × declared cadence, this primitive becomes the data source.
+- **GATEWAY-PULSE-001** (task #19) — Gateway daemon emitting heartbeats on behalf of managed sentinels. Will reuse this primitive's local store + push semantics.
+- **AGENT-TRIGGER-SEMANTICS-001** (backend_sentinel pending) — vocabulary alignment when that frame lands.

--- a/tests/test_heartbeat_commands.py
+++ b/tests/test_heartbeat_commands.py
@@ -1,0 +1,303 @@
+"""Tests for HEARTBEAT-001: local-first heartbeat CLI primitive."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+from typer.testing import CliRunner
+
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    def __init__(self, *, raise_on_send: Exception | None = None) -> None:
+        self.heartbeats: list[dict[str, Any]] = []
+        self._raise_on_send = raise_on_send
+
+    def send_heartbeat(self, *, agent_id=None, status=None, note=None, cadence_seconds=None) -> dict:
+        if self._raise_on_send is not None:
+            raise self._raise_on_send
+        record = {
+            "agent_id": "agent-orion",
+            "status": status,
+            "note": note,
+            "cadence_seconds": cadence_seconds,
+            "ttl_seconds": 30,
+            "last_heartbeat": "2026-04-25T00:00:00Z",
+            "presence": "online",
+        }
+        self.heartbeats.append(record)
+        return record
+
+
+def _install_runtime(monkeypatch, client: _FakeClient) -> None:
+    monkeypatch.setattr("ax_cli.commands.heartbeat.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.heartbeat.resolve_agent_name", lambda client=None: "orion")
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def test_send_records_and_pushes_when_online(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "heartbeat", "send",
+            "--status", "active",
+            "--note", "starting up",
+            "--cadence", "30",
+            "--file", str(store_file),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    assert payload["record"]["status"] == "active"
+    assert payload["record"]["pushed"] is True
+    assert payload["record"]["backend_ttl_seconds"] == 30
+
+    assert len(fake.heartbeats) == 1
+    assert fake.heartbeats[0]["status"] == "active"
+    assert fake.heartbeats[0]["cadence_seconds"] == 30
+
+    store = _load(store_file)
+    assert store["current_status"] == "active"
+    assert store["cadence_seconds"] == 30
+    assert store["last_pushed_at"] is not None
+    assert len(store["history"]) == 1
+
+
+def test_send_queues_locally_on_network_error(monkeypatch, tmp_path):
+    fake = _FakeClient(raise_on_send=httpx.ConnectError("offline (test)"))
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+
+    result = runner.invoke(
+        app,
+        ["heartbeat", "send", "--status", "active", "--cadence", "60",
+         "--file", str(store_file), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["record"]["pushed"] is False
+    assert "network" in payload["record"]["push_error"]
+
+    store = _load(store_file)
+    assert store["last_pushed_at"] is None
+    assert len(store["history"]) == 1
+    assert store["history"][0]["pushed"] is False
+
+
+def test_send_skip_push_records_local_only(monkeypatch, tmp_path):
+    """--skip-push records locally without attempting a network call."""
+    class _ExplodingClient:
+        def send_heartbeat(self, *_a, **_kw):
+            raise AssertionError("should not be called when --skip-push")
+
+    monkeypatch.setattr("ax_cli.commands.heartbeat.get_client", lambda: _ExplodingClient())
+    monkeypatch.setattr("ax_cli.commands.heartbeat.resolve_agent_name", lambda client=None: "orion")
+
+    store_file = tmp_path / "heartbeats.json"
+    result = runner.invoke(
+        app,
+        ["heartbeat", "send", "--status", "busy", "--skip-push",
+         "--file", str(store_file), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["record"]["pushed"] is False
+    assert payload["record"]["push_error"] is None  # not queued, just local-only
+
+
+def test_send_rejects_invalid_cadence(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+
+    result = runner.invoke(
+        app,
+        ["heartbeat", "send", "--cadence", "0", "--file", str(store_file)],
+    )
+    assert result.exit_code != 0
+    assert "cadence" in result.output.lower()
+
+
+def test_send_passes_through_unknown_status(monkeypatch, tmp_path):
+    """Unknown status values pass through so the protocol can evolve."""
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+
+    result = runner.invoke(
+        app,
+        ["heartbeat", "send", "--status", "future_value_xyz", "--cadence", "30",
+         "--skip-push",  # don't depend on backend accepting it
+         "--file", str(store_file), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    store = _load(store_file)
+    assert store["current_status"] == "future_value_xyz"
+
+
+def test_status_reports_queued_unpushed(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+    store_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "agent_name": "orion",
+                "agent_id": "abc",
+                "cadence_seconds": 60,
+                "current_status": "active",
+                "current_note": None,
+                "last_sent_at": "2026-04-25T15:00:00Z",
+                "last_pushed_at": "2026-04-25T15:00:00Z",
+                "next_due_at": "2026-04-25T15:01:00Z",
+                "history": [
+                    {"id": "hb-1", "status": "active", "sent_at": "2026-04-25T15:00:00Z", "pushed": True},
+                    {"id": "hb-2", "status": "active", "sent_at": "2026-04-25T15:01:00Z", "pushed": False, "push_error": "network"},
+                    {"id": "hb-3", "status": "busy", "sent_at": "2026-04-25T15:02:00Z", "pushed": False, "push_error": "network"},
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app, ["heartbeat", "status", "--file", str(store_file), "--skip-probe", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    snapshot = json.loads(result.output)
+    assert snapshot["online"] is False
+    assert snapshot["offline_reason"] == "probe skipped"
+    assert snapshot["queued_unpushed"] == 2
+    assert snapshot["agent_name"] == "orion"
+    assert snapshot["current_status"] == "active"
+    assert snapshot["cadence_seconds"] == 60
+    assert snapshot["next_due_at"] == "2026-04-25T15:01:00Z"
+
+
+def test_status_reports_no_history_gracefully(tmp_path):
+    """Empty store: status returns sensible defaults, never crashes."""
+    store_file = tmp_path / "heartbeats.json"
+    result = runner.invoke(
+        app, ["heartbeat", "status", "--file", str(store_file), "--skip-probe", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    snapshot = json.loads(result.output)
+    assert snapshot["queued_unpushed"] == 0
+    assert snapshot["last_sent_at"] is None
+    assert snapshot["next_due_at"] is None
+
+
+def test_list_filters_unpushed_only(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+    store_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "history": [
+                    {"id": "hb-1", "status": "active", "sent_at": "T1", "pushed": True},
+                    {"id": "hb-2", "status": "active", "sent_at": "T2", "pushed": False},
+                    {"id": "hb-3", "status": "busy", "sent_at": "T3", "pushed": False},
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app, ["heartbeat", "list", "--unpushed", "--file", str(store_file), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ids = [h["id"] for h in payload["history"]]
+    assert ids == ["hb-3", "hb-2"], "most recent first, only unpushed"
+
+
+def test_push_drains_queue_when_online(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+    store_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "agent_name": "orion",
+                "cadence_seconds": 30,
+                "current_status": "busy",
+                "history": [
+                    {"id": "hb-1", "status": "active", "sent_at": "T1", "pushed": False, "push_error": "old"},
+                    {"id": "hb-2", "status": "busy", "sent_at": "T2", "pushed": False, "push_error": "old"},
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(
+        app, ["heartbeat", "push", "--file", str(store_file), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["pushed"] == ["hb-2"]
+    assert payload["drained_count"] == 2
+
+    store = _load(store_file)
+    assert all(h["pushed"] for h in store["history"]), "all queued records marked pushed"
+    assert store["history"][-1]["backend_ttl_seconds"] == 30
+    assert store["last_pushed_at"] is not None
+    # The push uses the LATEST (busy) status, not the oldest
+    assert fake.heartbeats[0]["status"] == "busy"
+
+
+def test_push_no_queued_returns_clean(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+    store_file.write_text(
+        json.dumps({"version": 1, "history": [{"id": "hb-1", "pushed": True}]})
+    )
+
+    result = runner.invoke(
+        app, ["heartbeat", "push", "--file", str(store_file), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["pushed"] == []
+    assert payload["reason"] == "no_queued_heartbeats"
+    assert fake.heartbeats == []
+
+
+def test_push_returns_error_when_offline(monkeypatch, tmp_path):
+    fake = _FakeClient(raise_on_send=httpx.ConnectError("offline"))
+    _install_runtime(monkeypatch, fake)
+    store_file = tmp_path / "heartbeats.json"
+    store_file.write_text(
+        json.dumps({"version": 1, "history": [{"id": "hb-1", "status": "active", "pushed": False}]})
+    )
+
+    result = runner.invoke(
+        app, ["heartbeat", "push", "--file", str(store_file), "--json"]
+    )
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload["pushed"] == []
+    assert "network" in payload["error"]
+
+    # Record updated with push_error but still queued
+    store = _load(store_file)
+    assert store["history"][0]["pushed"] is False
+    assert "network" in store["history"][0]["push_error"]


### PR DESCRIPTION
Per @madtank 2026-04-25 15:25 UTC — connectedness is one of three urgent primitives (gateway / connectedness / registry) we need to ship faster than AWS+Google. This PR ships the connectedness foundation as a CLI-first primitive.

## What

| Command | Behavior |
|---|---|
| `ax heartbeat send` | Records locally + POSTs to `/api/v1/agents/heartbeat`. Offline-safe: network errors queue with `pushed=false` + `push_error`. |
| `ax heartbeat list [--unpushed]` | Local history, most recent first. `--unpushed` filters to queued records. |
| `ax heartbeat status [--skip-probe]` | Online/offline probe + current status + cadence + last_sent + next_due + queued count. `--json` for tooling. |
| `ax heartbeat push` | Drain queued. Presence is latest-wins; only the newest unpushed heartbeat hits the wire, older ones marked pushed. |
| `ax heartbeat watch [--interval N] [--max-ticks N]` | Tick-based daemon, bounded runs supported. |

## Status vocabulary

`active` / `busy` / `delayed` / `sleeping` / `unresponsive` / `suspended` / `disabled` / `unknown`

Unknown values pass through to the backend body so the protocol can evolve without CLI updates. Aligns with the heartbeat primitive memory note 2026-04-09.

## Backend integration

POSTs to `/api/v1/agents/heartbeat` (existing endpoint; sets Redis presence with TTL=30s). Body carries `status`/`note`/`cadence_seconds` extras that the backend currently ignores — ready when the protocol matures.

## Local store

`~/.ax/heartbeats.json` (override via `AX_HEARTBEATS_FILE` or `--file`). Same offline-first pattern as TASK-LOOP-001 — proven structure.

## Test plan

- [x] 11 new pytest smokes in `tests/test_heartbeat_commands.py`
- [x] 23 existing reminder + task-loop tests still pass (34 total green)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format` — clean
- [ ] Manual smoke against dev backend: `ax heartbeat send`, `ax heartbeat status`, simulate offline by killing network, `ax heartbeat send` again, `ax heartbeat status` shows queued, recover network, `ax heartbeat push`

## Source directives

- @madtank 2026-04-25 15:25 UTC — "keep moving and shipping faster, especially around gateway and connectedness and the registry"
- @madtank 2026-04-25 04:11 UTC — "we need to start getting features like heartbeat... we need to have our own pulse on the gateway"
- Heartbeat primitive memory note (2026-04-09) — declared cadence + tolerance

## Cross-refs

- **AGENT-AVAILABILITY-CONTRACT-001** (PR #97 merged) — heartbeats feed the Responsive axis when backend wires `agent_state.responsive` from heartbeat freshness × declared cadence
- **GATEWAY-PULSE-001** (task #19) — Gateway daemon emitting heartbeats on behalf of managed sentinels. Will reuse this primitive's local store + push semantics.
- **AGENT-TRIGGER-SEMANTICS-001** (backend_sentinel pending) — vocabulary alignment when that frame lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)