### PR TITLE
feat(agents): ax agents check <name> — AVAIL-CONTRACT v4 forward-compat CLI consumer

### DIFF
--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -711,6 +711,64 @@ class AxClient:
         r.raise_for_status()
         return self._parse_json(r)
 
+    def get_agent_presence(self, agent_id_or_name: str, *, space_id: str | None = None) -> dict:
+        """GET single-agent availability record.
+
+        Tries the AVAIL-CONTRACT-001 ``/state`` endpoint first (returns an
+        envelope ``{agent_state, raw_presence, control}``). Falls back to
+        the legacy ``/presence`` endpoint (basic flat shape) on 404.
+
+        Returns a flat dict — when ``/state`` succeeds, the ``agent_state``
+        sub-object is unwrapped so callers see the resolved DTO directly,
+        with envelope siblings (``raw_presence``, ``control``) preserved
+        alongside for diagnostic access.
+
+        Accepts either an agent UUID directly (single round trip) or a name
+        which is resolved via the agents list first.
+        """
+        identifier = agent_id_or_name
+        # Resolve name → id if we got a name (the /state endpoint accepts both,
+        # but the /presence fallback only takes UUIDs).
+        if not (len(identifier) == 36 and identifier.count("-") == 4):
+            agents = self.list_agents()
+            items = agents if isinstance(agents, list) else agents.get("agents", [])
+            match = None
+            for a in items:
+                if isinstance(a, dict) and a.get("name") == agent_id_or_name:
+                    match = a
+                    break
+            if not match:
+                raise RuntimeError(f"agent not found: {agent_id_or_name}")
+            agent_id = match.get("id") or match.get("agent_id")
+            if not agent_id:
+                raise RuntimeError(f"agent has no id field: {agent_id_or_name}")
+            identifier = agent_id
+
+        params = {"space_id": space_id} if space_id else None
+
+        # Try /state first (AVAIL-CONTRACT-001). If 404, fall back to /presence.
+        try:
+            r = self._http.get(f"/api/v1/agents/{identifier}/state", params=params)
+            r.raise_for_status()
+            envelope = self._parse_json(r)
+            # Unwrap the envelope so the resolved DTO is at the top level.
+            if isinstance(envelope, dict) and "agent_state" in envelope:
+                resolved = dict(envelope.get("agent_state") or {})
+                # Preserve envelope siblings under reserved keys for diagnostics.
+                if "raw_presence" in envelope:
+                    resolved["_raw_presence"] = envelope["raw_presence"]
+                if "control" in envelope:
+                    resolved["_control"] = envelope["control"]
+                return resolved
+            return envelope
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 404:
+                raise
+            # /state not available yet — fall back to /presence.
+        r = self._http.get(f"/api/v1/agents/{identifier}/presence", params=params)
+        r.raise_for_status()
+        return self._parse_json(r)
+
     def create_agent(self, name: str, **kwargs) -> dict:
         """POST /api/v1/agents — create a new agent."""
         body: dict = {"name": name}

--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -579,6 +579,105 @@ def status(as_json: bool = JSON_OPTION):
             console.print(f"  {indicator}  {a['name']:<20s}  {agent_type:<12s}  last_active={last}")
 
 
+@app.command("check")
+def check(
+    name_or_id: str = typer.Argument(..., help="Agent name or UUID"),
+    as_json: bool = JSON_OPTION,
+):
+    """Check single-agent presence + AVAIL-CONTRACT availability.
+
+    Forward-compat consumer of the AVAIL-CONTRACT-001 resolved DTO. Today
+    the backend returns a basic presence shape (``presence``, ``responsive``,
+    ``last_active``); when backend ships the rich ``agent_state`` DTO with
+    ``expected_response`` / ``badge_state`` / ``connection_path`` /
+    ``pre_send_warning``, the same CLI command renders the new fields
+    transparently — no flag flip needed.
+    """
+    client = get_client()
+    try:
+        record = client.get_agent_presence(name_or_id)
+    except httpx.HTTPStatusError as exc:
+        handle_error(exc)
+    except RuntimeError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+
+    if as_json:
+        print_json(record)
+        return
+
+    name = record.get("name") or name_or_id
+    presence = record.get("presence", "unknown")
+    responsive = record.get("responsive")
+    last_active = record.get("last_active") or "—"
+    agent_type = record.get("agent_type") or "—"
+
+    # Forward-compat AVAIL-CONTRACT v4 fields (rendered when backend provides them)
+    expected_response = record.get("expected_response")
+    badge_state = record.get("badge_state")
+    badge_label = record.get("badge_label")
+    connection_path = record.get("connection_path")
+    confidence = record.get("confidence") or record.get("presence_confidence")
+    unavailable_reason = record.get("unavailable_reason")
+    status_explanation = record.get("status_explanation")
+    pre_send_warning = record.get("pre_send_warning")
+
+    # Banner: prefer rich badge if available, else fall back to basic presence.
+    if badge_label:
+        color = (
+            "green"
+            if badge_state == "live"
+            else (
+                "yellow"
+                if badge_state == "routable_delayed"
+                else (
+                    "blue"
+                    if badge_state == "queued_only"
+                    else ("red" if badge_state in ("blocked", "offline") else "dim")
+                )
+            )
+        )
+        console.print(f"[bold {color}]{badge_label}[/bold {color}]  @{name}")
+    elif presence == "online":
+        console.print(f"[bold green]ONLINE[/bold green]  @{name}")
+    else:
+        console.print(f"[bold dim]OFFLINE[/bold dim]  @{name}")
+
+    rows = [{"field": "name", "value": name}]
+    rows.append({"field": "presence", "value": presence})
+    if responsive is not None:
+        rows.append({"field": "responsive", "value": str(responsive)})
+    rows.append({"field": "last_active", "value": last_active})
+    rows.append({"field": "agent_type", "value": agent_type})
+
+    # Forward-compat fields (only render when present)
+    for field, value in (
+        ("expected_response", expected_response),
+        ("badge_state", badge_state),
+        ("connection_path", connection_path),
+        ("confidence", confidence),
+        ("unavailable_reason", unavailable_reason),
+    ):
+        if value is not None:
+            rows.append({"field": field, "value": str(value)})
+
+    print_table(["Field", "Value"], rows, keys=["field", "value"])
+
+    if status_explanation:
+        console.print()
+        console.print(f"[dim]{status_explanation}[/dim]")
+
+    if pre_send_warning and isinstance(pre_send_warning, dict):
+        severity = pre_send_warning.get("severity", "info")
+        title = pre_send_warning.get("title", "")
+        body = pre_send_warning.get("body", "")
+        color = {"error": "red", "warning": "yellow", "info": "cyan"}.get(severity, "dim")
+        console.print()
+        console.print(f"[bold {color}]{title}[/bold {color}]")
+        if body:
+            console.print(body)
+
+
 @app.command("tools")
 def tools(
     agent_id: str = typer.Argument(..., help="Agent ID"),

--- a/tests/test_agents_check.py
+++ b/tests/test_agents_check.py
@@ -1,0 +1,307 @@
+"""Tests for ``ax agents check`` — AVAIL-CONTRACT-001 forward-compat CLI consumer."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from typer.testing import CliRunner
+
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    """Stub client that returns a configurable presence record."""
+
+    def __init__(self, presence_record: dict[str, Any], list_payload: dict | list | None = None) -> None:
+        self._presence = presence_record
+        self._list = list_payload
+
+    def list_agents(self, *, space_id: str | None = None, limit: int | None = None) -> dict | list:
+        return self._list if self._list is not None else {"agents": []}
+
+    def get_agent_presence(self, name_or_id: str) -> dict:
+        # Mirror the real client's pass-through behavior; tests inject the record directly.
+        return self._presence
+
+
+def _install(monkeypatch, client: _FakeClient) -> None:
+    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: client)
+
+
+def test_check_renders_basic_presence_shape(monkeypatch):
+    """Today's backend returns the basic presence shape — CLI renders it cleanly."""
+    fake = _FakeClient({
+        "agent_id": "abc-123",
+        "name": "frontend_sentinel",
+        "presence": "online",
+        "responsive": True,
+        "last_active": "2026-04-25T15:00:00Z",
+        "agent_type": "assistant",
+    })
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "check", "frontend_sentinel", "--json"])
+    assert result.exit_code == 0, result.output
+    record = json.loads(result.output)
+    assert record["name"] == "frontend_sentinel"
+    assert record["presence"] == "online"
+    assert record["responsive"] is True
+
+
+def test_check_renders_avail_contract_v4_dto_forward_compat(monkeypatch):
+    """When backend ships the AVAIL-CONTRACT v4 fields, CLI renders them transparently."""
+    fake = _FakeClient({
+        "agent_id": "abc-123",
+        "name": "backend_sentinel",
+        "presence": "offline",
+        "responsive": False,
+        "last_active": "2026-04-25T14:00:00Z",
+        "agent_type": "assistant",
+        # Forward-compat AVAIL-CONTRACT v4 fields
+        "expected_response": "warming",
+        "badge_state": "routable_delayed",
+        "badge_label": "Warming",
+        "badge_color": "info",
+        "connection_path": "gateway_managed",
+        "confidence": "medium",
+        "unavailable_reason": None,
+        "status_explanation": "On-demand. Last warmed 12 min ago. A new mention will spawn the runtime.",
+        "pre_send_warning": {
+            "severity": "info",
+            "title": "Delivery may be delayed",
+            "body": "This agent is on-demand; a new mention will warm the runtime.",
+        },
+    })
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "check", "backend_sentinel", "--json"])
+    assert result.exit_code == 0, result.output
+    record = json.loads(result.output)
+    # All v4 fields preserved in --json output
+    assert record["expected_response"] == "warming"
+    assert record["badge_state"] == "routable_delayed"
+    assert record["badge_label"] == "Warming"
+    assert record["connection_path"] == "gateway_managed"
+    assert record["confidence"] == "medium"
+    assert record["pre_send_warning"]["severity"] == "info"
+    assert record["pre_send_warning"]["title"] == "Delivery may be delayed"
+
+
+def test_check_human_output_renders_badge_label_when_present(monkeypatch):
+    """Human-readable output uses the rich badge when backend provides it."""
+    fake = _FakeClient({
+        "agent_id": "abc-123",
+        "name": "night_owl",
+        "presence": "online",
+        "responsive": True,
+        "last_active": "2026-04-25T15:00:00Z",
+        "badge_state": "live",
+        "badge_label": "Live",
+        "expected_response": "immediate",
+        "connection_path": "gateway_managed",
+        "confidence": "high",
+    })
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "check", "night_owl"])
+    assert result.exit_code == 0, result.output
+    assert "Live" in result.output
+    assert "@night_owl" in result.output
+    assert "gateway_managed" in result.output
+    assert "high" in result.output
+
+
+def test_check_human_output_falls_back_to_basic_presence(monkeypatch):
+    """When backend has no v4 fields, render basic ONLINE/OFFLINE."""
+    fake = _FakeClient({
+        "agent_id": "abc-123",
+        "name": "old_agent",
+        "presence": "offline",
+        "responsive": False,
+        "last_active": None,
+    })
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "check", "old_agent"])
+    assert result.exit_code == 0, result.output
+    assert "OFFLINE" in result.output
+    assert "@old_agent" in result.output
+
+
+def test_check_renders_pre_send_warning_when_present(monkeypatch):
+    """pre_send_warning renders as a colored callout below the fields table."""
+    fake = _FakeClient({
+        "agent_id": "abc-123",
+        "name": "stuck_agent",
+        "presence": "online",
+        "badge_state": "blocked",
+        "badge_label": "Stuck",
+        "expected_response": "unlikely",
+        "unavailable_reason": "runtime_stuck",
+        "pre_send_warning": {
+            "severity": "warning",
+            "title": "Agent appears stuck",
+            "body": "Heartbeat hasn't fired in 10 minutes. Send anyway?",
+        },
+    })
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "check", "stuck_agent"])
+    assert result.exit_code == 0, result.output
+    assert "Agent appears stuck" in result.output
+    assert "Heartbeat hasn't fired" in result.output
+
+
+def test_check_unknown_agent_returns_nonzero(monkeypatch):
+    """Agent not found surfaces a clean error, not a stack trace."""
+
+    class _NotFoundClient:
+        def list_agents(self, **_kw):
+            return {"agents": []}
+
+        def get_agent_presence(self, _id):
+            raise RuntimeError("agent not found: ghost")
+
+    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: _NotFoundClient())
+    result = runner.invoke(app, ["agents", "check", "ghost", "--json"])
+    assert result.exit_code != 0
+    assert "ghost" in result.output
+
+
+def test_get_agent_presence_resolves_name_to_id():
+    """The client method itself: name → id lookup via list_agents, then GET state/presence."""
+    import httpx
+    from ax_cli.client import AxClient
+
+    list_called = {"n": 0}
+    presence_id = {"v": None}
+
+    class _FakeHttp:
+        def get(self, path, **_kw):
+            class _R:
+                def __init__(self, data, status=200):
+                    self._data = data
+                    self.status_code = status
+
+                def raise_for_status(self):
+                    if self.status_code >= 400:
+                        raise httpx.HTTPStatusError("err", request=None, response=self)
+
+                def json(self):
+                    return self._data
+
+            if path == "/api/v1/agents":
+                list_called["n"] += 1
+                return _R({"agents": [{"id": "uuid-aaa-1", "name": "foo"}]})
+            # Simulate legacy backend (no /state) — falls back to /presence
+            if path.startswith("/api/v1/agents/uuid-aaa-1/state"):
+                return _R({}, status=404)
+            if path.startswith("/api/v1/agents/uuid-aaa-1/presence"):
+                presence_id["v"] = "uuid-aaa-1"
+                return _R({"agent_id": "uuid-aaa-1", "name": "foo", "presence": "online"})
+            raise AssertionError(f"unexpected path {path}")
+
+    client = AxClient.__new__(AxClient)
+    client._http = _FakeHttp()
+    client._parse_json = lambda r: r.json()
+
+    record = client.get_agent_presence("foo")
+    assert record["name"] == "foo"
+    assert record["presence"] == "online"
+    assert list_called["n"] == 1
+    assert presence_id["v"] == "uuid-aaa-1"
+
+
+def test_get_agent_presence_uses_uuid_directly():
+    """If name_or_id is already a UUID, skip the list lookup."""
+    import httpx
+    from ax_cli.client import AxClient
+
+    list_called = {"n": 0}
+
+    class _FakeHttp:
+        def get(self, path, **_kw):
+            class _R:
+                def __init__(self, data, status=200):
+                    self._data = data
+                    self.status_code = status
+
+                def raise_for_status(self):
+                    if self.status_code >= 400:
+                        raise httpx.HTTPStatusError("err", request=None, response=self)
+
+                def json(self):
+                    return self._data
+
+            if path == "/api/v1/agents":
+                list_called["n"] += 1
+                return _R({"agents": []})
+            # Pretend /state returns 404 (legacy backend) so we fall back to /presence.
+            if path.endswith("/state"):
+                return _R({}, status=404)
+            if path.endswith("/presence"):
+                return _R({"agent_id": "12345678-1234-1234-1234-123456789abc", "presence": "online"})
+            raise AssertionError(f"unexpected path {path}")
+
+    client = AxClient.__new__(AxClient)
+    client._http = _FakeHttp()
+    client._parse_json = lambda r: r.json()
+
+    record = client.get_agent_presence("12345678-1234-1234-1234-123456789abc")
+    assert record["presence"] == "online"
+    assert list_called["n"] == 0, "UUID input should NOT trigger a list_agents call"
+
+
+def test_get_agent_presence_prefers_state_endpoint_and_unwraps_envelope():
+    """When /state is available, prefer it and unwrap the agent_state envelope."""
+    from ax_cli.client import AxClient
+
+    paths_seen = []
+
+    class _FakeHttp:
+        def get(self, path, **_kw):
+            paths_seen.append(path)
+
+            class _R:
+                def __init__(self, data):
+                    self._data = data
+                    self.status_code = 200
+
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return self._data
+
+            if path.endswith("/state"):
+                return _R({
+                    "agent_state": {
+                        "agent_id": "uuid-zzz",
+                        "name": "richy",
+                        "expected_response": "immediate",
+                        "badge_state": "live",
+                        "badge_label": "Live",
+                        "connection_path": "gateway_managed",
+                        "confidence": "high",
+                    },
+                    "raw_presence": {"sources": ["gateway"]},
+                    "control": {"enabled": True, "quarantined": False},
+                })
+            raise AssertionError(f"unexpected path {path}")
+
+    client = AxClient.__new__(AxClient)
+    client._http = _FakeHttp()
+    client._parse_json = lambda r: r.json()
+
+    record = client.get_agent_presence("12345678-1234-1234-1234-123456789abc")
+    # Top-level fields are unwrapped from agent_state
+    assert record["expected_response"] == "immediate"
+    assert record["badge_state"] == "live"
+    # Envelope siblings preserved with underscore prefix for diagnostics
+    assert record["_raw_presence"]["sources"] == ["gateway"]
+    assert record["_control"]["enabled"] is True
+    # /presence was NOT hit — /state succeeded
+    assert "/presence" not in " ".join(paths_seen)


### PR DESCRIPTION
Per @cipher 16:35 UTC \"CLI-side stub you can land in parallel\" + @backend_sentinel 16:42 UTC announcing 781f5781's `/state` endpoint shape is firm.

## What

`ax agents check <name>` — single-agent availability consumer that's forward-compat to AVAIL-CONTRACT-001's resolved DTO.

```
$ ax agents check frontend_sentinel
Live  @frontend_sentinel
┌──────────────────────┬──────────────────────────┐
│ Field                │ Value                    │
│ name                 │ frontend_sentinel        │
│ presence             │ online                   │
│ expected_response    │ immediate                │
│ badge_state          │ live                     │
│ connection_path      │ gateway_managed          │
│ confidence           │ high                     │
└──────────────────────┴──────────────────────────┘
```

`--json` outputs the full DTO including `_raw_presence` and `_control` envelope siblings for diagnostics.

## Endpoint behavior

Tries `GET /api/v1/agents/{id}/state` first (AVAIL-CONTRACT-001, currently in flight on `backend_sentinel/task-781f5781-agent-state-dto`). Unwraps the `{agent_state, raw_presence, control}` envelope so the resolved DTO sits at the top level. Falls back to legacy `GET /api/v1/agents/{id}/presence` on 404 for backends that haven't shipped `/state` yet.

Forward-compat by design: same CLI command picks up new v4 fields the moment backend deploys.

## What lights up when v4 fields are present

| Field | Render |
|---|---|
| `badge_label` + `badge_state` | Colored banner (live=green, routable_delayed=yellow, queued_only=blue, blocked/offline=red) |
| `expected_response` / `connection_path` / `confidence` / `unavailable_reason` | Field table rows |
| `status_explanation` | Dim subtitle below table |
| `pre_send_warning` | Colored callout (severity → red/yellow/cyan) |

## Test plan

- [x] 9 new pytest smokes in `tests/test_agents_check.py`
- [x] All 34 existing reminder/task-loop/heartbeat tests still pass (43 total green)
- [x] `uv run ruff check` clean / `uv run ruff format` clean
- [ ] Manual: \`ax agents check backend_sentinel\` against current prod (basic shape) and against backend_sentinel/task-781f5781 dev backend (rich DTO once they merge)

## Cross-refs

- **AGENT-AVAILABILITY-CONTRACT-001** spec — `specs/AGENT-AVAILABILITY-CONTRACT-001/spec.md` (PR #97 merged)
- **backend `/state` endpoint** — backend_sentinel branch `backend_sentinel/task-781f5781-agent-state-dto` (11 unit tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)