### PR TITLE
feat(agents): ax agents list --availability — bulk AVAIL-CONTRACT v4 consumer

### DIFF
--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -711,6 +711,35 @@ class AxClient:
         r.raise_for_status()
         return self._parse_json(r)
 
+    def list_agents_availability(
+        self,
+        *,
+        space_id: str | None = None,
+        connection_path: str | None = None,
+        badge_state: str | None = None,
+        filter_: str | None = None,
+    ) -> dict | list:
+        """GET /api/v1/agents/availability — bulk resolved DTO list.
+
+        Per AVAIL-CONTRACT-001 spec: optimized for picker/widget rendering.
+        Each row is the resolved ``agent_state`` envelope. Optional query
+        filters: ``connection_path=gateway_managed|mcp_only|...``,
+        ``badge_state=live|routable_delayed|...``, ``filter=available_now|
+        gateway_connected|cloud_agent|disabled|recently_active``.
+        """
+        params: dict[str, str] = {}
+        if space_id:
+            params["space_id"] = space_id
+        if connection_path:
+            params["connection_path"] = connection_path
+        if badge_state:
+            params["badge_state"] = badge_state
+        if filter_:
+            params["filter"] = filter_
+        r = self._http.get("/api/v1/agents/availability", params=params or None)
+        r.raise_for_status()
+        return self._parse_json(r)
+
     def get_agent_presence(self, agent_id_or_name: str, *, space_id: str | None = None) -> dict:
         """GET single-agent availability record.
 

--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -222,24 +222,133 @@ def _discover_agent_row(agent: dict[str, Any], probe: dict[str, Any] | None = No
 def list_agents(
     space_id: str = typer.Option(None, "--space-id", help="Override default space"),
     limit: int = typer.Option(500, "--limit", help="Max agents to return"),
+    availability: bool = typer.Option(
+        False, "--availability", help="Include resolved AVAIL-CONTRACT v4 fields per row"
+    ),
+    filter_: str = typer.Option(
+        None,
+        "--filter",
+        help="Filter (with --availability): available_now | gateway_connected | cloud_agent | disabled | recently_active",
+    ),
     as_json: bool = JSON_OPTION,
 ):
-    """List agents in the current space."""
+    """List agents in the current space.
+
+    With ``--availability``, calls ``/api/v1/agents/availability`` (the
+    AVAIL-CONTRACT-001 bulk endpoint) and renders the resolved ``agent_state``
+    DTO per row: badge_state, badge_label, connection_path, expected_response,
+    confidence, last_seen. Falls back gracefully to the legacy ``/agents`` shape
+    if ``/availability`` returns 404.
+    """
     client = get_client()
     sid = resolve_space_id(client, explicit=space_id)
-    try:
-        data = client.list_agents(space_id=sid, limit=limit)
-    except httpx.HTTPStatusError as e:
-        handle_error(e)
-    agents = data if isinstance(data, list) else data.get("agents", [])
+
+    if availability:
+        try:
+            data = client.list_agents_availability(space_id=sid, filter_=filter_)
+            agents = _normalize_availability_rows(data)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code != 404:
+                handle_error(e)
+            # Fallback: backend hasn't shipped /availability yet.
+            try:
+                fallback = client.list_agents(space_id=sid, limit=limit)
+            except httpx.HTTPStatusError as e2:
+                handle_error(e2)
+            agents = fallback if isinstance(fallback, list) else fallback.get("agents", [])
+            for row in agents:
+                row.setdefault("_legacy", True)
+    else:
+        if filter_:
+            raise typer.BadParameter("--filter requires --availability")
+        try:
+            data = client.list_agents(space_id=sid, limit=limit)
+        except httpx.HTTPStatusError as e:
+            handle_error(e)
+        agents = data if isinstance(data, list) else data.get("agents", [])
+
     if as_json:
         print_json(agents)
+        return
+
+    if availability:
+        rows = []
+        for a in agents:
+            rows.append(
+                {
+                    "name": a.get("name") or a.get("agent_name") or "",
+                    "badge": a.get("badge_label") or _legacy_badge(a),
+                    "path": _short_path(a.get("connection_path")),
+                    "expected": a.get("expected_response") or "—",
+                    "confidence": a.get("confidence") or a.get("presence_confidence") or "—",
+                    "last_seen": a.get("last_seen_at") or a.get("last_seen") or a.get("last_active") or "—",
+                }
+            )
+        print_table(
+            ["Name", "Badge", "Path", "Expected", "Confidence", "Last seen"],
+            rows,
+            keys=["name", "badge", "path", "expected", "confidence", "last_seen"],
+        )
     else:
         print_table(
             ["ID", "Name", "Status"],
             agents,
             keys=["id", "name", "status"],
         )
+
+
+def _normalize_availability_rows(payload) -> list[dict]:
+    """Unwrap the availability bulk response into a list of flat rows.
+
+    The bulk endpoint returns either a list of agent_state envelopes or a
+    dict like ``{agents: [...], availability: [...]}`` per the spec — we
+    accept both shapes and unwrap each item's ``agent_state`` sub-object
+    if present so downstream rendering sees the v4 fields at top level.
+    """
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        items = payload.get("agents") or payload.get("availability") or payload.get("items") or []
+    else:
+        return []
+    rows = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if "agent_state" in item:
+            row = dict(item.get("agent_state") or {})
+            if "raw_presence" in item:
+                row["_raw_presence"] = item["raw_presence"]
+            if "control" in item:
+                row["_control"] = item["control"]
+        else:
+            row = dict(item)
+        rows.append(row)
+    return rows
+
+
+def _short_path(connection_path: str | None) -> str:
+    """Map connection_path enum to compact column label."""
+    return {
+        "gateway_managed": "Gateway",
+        "mcp_only": "Cloud",
+        "direct_cli": "CLI",
+        "direct_sse": "SSE",
+        "unknown": "—",
+    }.get(connection_path or "", "—")
+
+
+def _legacy_badge(row: dict) -> str:
+    """Synthesize a coarse badge label when the backend hasn't shipped v4 fields yet."""
+    if row.get("_legacy"):
+        # Pure legacy /agents response — no presence info at all on the row.
+        return row.get("status") or "—"
+    presence = (row.get("presence") or "").lower()
+    if presence == "online":
+        return "Live"
+    if presence == "offline":
+        return "Offline"
+    return presence or "—"
 
 
 @app.command("ping")

--- a/tests/test_agents_list_availability.py
+++ b/tests/test_agents_list_availability.py
@@ -1,0 +1,222 @@
+"""Tests for ``ax agents list --availability`` — bulk AVAIL-CONTRACT consumer."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from typer.testing import CliRunner
+
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    def __init__(self, availability_payload=None, list_payload=None, raise_404_on_availability=False):
+        self._availability = availability_payload
+        self._list = list_payload or {"agents": []}
+        self._raise_404 = raise_404_on_availability
+
+    def list_agents_availability(self, **_kw):
+        if self._raise_404:
+            class _Resp:
+                status_code = 404
+                text = "not found"
+
+            raise httpx.HTTPStatusError("not found", request=None, response=_Resp())
+        return self._availability
+
+    def list_agents(self, **_kw):
+        return self._list
+
+
+def _install(monkeypatch, client):
+    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda c, explicit=None: explicit or "space-abc")
+
+
+def test_list_default_path_uses_legacy_endpoint(monkeypatch):
+    """No --availability: hits /agents and renders the legacy 3-column table."""
+    fake = _FakeClient(list_payload={"agents": [
+        {"id": "a-1", "name": "frontend_sentinel", "status": "active"},
+    ]})
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    assert rows[0]["name"] == "frontend_sentinel"
+
+
+def test_list_availability_renders_v4_fields(monkeypatch):
+    """--availability: hits /availability, unwraps agent_state envelopes, renders v4 columns."""
+    fake = _FakeClient(availability_payload=[
+        {
+            "agent_state": {
+                "agent_id": "a-1",
+                "name": "frontend_sentinel",
+                "badge_state": "live",
+                "badge_label": "Live",
+                "connection_path": "gateway_managed",
+                "expected_response": "immediate",
+                "confidence": "high",
+                "last_seen_at": "2026-04-25T17:00:00Z",
+            },
+            "raw_presence": {"sources": ["gateway"]},
+            "control": {"enabled": True},
+        },
+        {
+            "agent_state": {
+                "agent_id": "a-2",
+                "name": "backend_sentinel",
+                "badge_state": "routable_delayed",
+                "badge_label": "Warming",
+                "connection_path": "gateway_managed",
+                "expected_response": "warming",
+                "confidence": "medium",
+                "last_seen_at": "2026-04-25T16:55:00Z",
+            },
+        },
+    ])
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "list", "--availability", "--json"])
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    assert len(rows) == 2
+    assert rows[0]["name"] == "frontend_sentinel"
+    assert rows[0]["badge_label"] == "Live"
+    assert rows[0]["connection_path"] == "gateway_managed"
+    assert rows[0]["_raw_presence"]["sources"] == ["gateway"]
+    assert rows[0]["_control"]["enabled"] is True
+    assert rows[1]["badge_label"] == "Warming"
+
+
+def test_list_availability_human_output_renders_columns(monkeypatch):
+    """Human-readable --availability output includes badge + path columns."""
+    fake = _FakeClient(availability_payload=[
+        {
+            "agent_state": {
+                "agent_id": "a-1",
+                "name": "night_owl",
+                "badge_state": "live",
+                "badge_label": "Live",
+                "connection_path": "gateway_managed",
+                "expected_response": "immediate",
+                "confidence": "high",
+            },
+        },
+        {
+            "agent_state": {
+                "agent_id": "a-2",
+                "name": "ax_concierge",
+                "badge_state": "routable_delayed",
+                "badge_label": "Dispatch",
+                "connection_path": "mcp_only",
+                "expected_response": "dispatch_delayed",
+                "confidence": "medium",
+            },
+        },
+    ])
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "list", "--availability"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Live" in out
+    assert "Dispatch" in out
+    assert "Gateway" in out  # short-form connection_path
+    assert "Cloud" in out  # mcp_only short-form
+    assert "night_owl" in out
+    assert "ax_concierge" in out
+
+
+def test_list_availability_falls_back_to_legacy_on_404(monkeypatch):
+    """When /availability returns 404, fall back to /agents and mark rows _legacy."""
+    fake = _FakeClient(
+        raise_404_on_availability=True,
+        list_payload={"agents": [{"id": "a-1", "name": "old_school", "status": "active"}]},
+    )
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "list", "--availability", "--json"])
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    assert rows[0]["name"] == "old_school"
+    # Fallback path marks the row legacy so downstream renderers know to use status
+    assert rows[0]["_legacy"] is True
+
+
+def test_list_availability_filter_requires_availability_flag(monkeypatch):
+    """--filter without --availability fails fast with a clear error."""
+    fake = _FakeClient()
+    _install(monkeypatch, fake)
+
+    result = runner.invoke(app, ["agents", "list", "--filter", "available_now"])
+    assert result.exit_code != 0
+    assert "filter" in result.output.lower()
+
+
+def test_list_agents_availability_passes_filter_query_params():
+    """The client method itself: filter parameter goes into query string."""
+    from ax_cli.client import AxClient
+
+    captured = {}
+
+    class _FakeHttp:
+        def get(self, path, params=None, **_kw):
+            captured["path"] = path
+            captured["params"] = params
+
+            class _R:
+                status_code = 200
+
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return []
+
+            return _R()
+
+    client = AxClient.__new__(AxClient)
+    client._http = _FakeHttp()
+    client._parse_json = lambda r: r.json()
+
+    client.list_agents_availability(
+        space_id="s-1",
+        connection_path="gateway_managed",
+        filter_="available_now",
+    )
+    assert captured["path"] == "/api/v1/agents/availability"
+    assert captured["params"]["space_id"] == "s-1"
+    assert captured["params"]["connection_path"] == "gateway_managed"
+    assert captured["params"]["filter"] == "available_now"
+
+
+def test_normalize_availability_handles_flat_list_without_envelope(monkeypatch):
+    """Backward-compat: if backend returns flat agent_state objects directly (no envelope)."""
+    from ax_cli.commands.agents import _normalize_availability_rows
+
+    payload = [
+        {"name": "flat", "badge_state": "live", "badge_label": "Live"},
+    ]
+    rows = _normalize_availability_rows(payload)
+    assert len(rows) == 1
+    assert rows[0]["name"] == "flat"
+    assert rows[0]["badge_label"] == "Live"
+    assert "_raw_presence" not in rows[0]
+
+
+def test_normalize_availability_handles_dict_wrapped_payload():
+    """Backward-compat: backend may return ``{agents: [...]}`` or ``{availability: [...]}``."""
+    from ax_cli.commands.agents import _normalize_availability_rows
+
+    rows = _normalize_availability_rows({"availability": [{"name": "x"}]})
+    assert len(rows) == 1
+    assert rows[0]["name"] == "x"
+
+    rows = _normalize_availability_rows({"agents": [{"name": "y"}]})
+    assert len(rows) == 1
+    assert rows[0]["name"] == "y"


### PR DESCRIPTION
Per orion's CLI roadmap (PR #102 inventory item 2). Lands the bulk counterpart to PR #101's single-agent check.

## What

\`ax agents list --availability\` calls \`GET /api/v1/agents/availability\` (AVAIL-CONTRACT-001 spec §API shape) and renders the resolved \`agent_state\` DTO per row:

\`\`\`
$ ax agents list --availability
┌──────────────────┬──────────┬─────────┬──────────────────┬────────────┬──────────────────────┐
│ Name             │ Badge    │ Path    │ Expected         │ Confidence │ Last seen            │
│ frontend_sentinel│ Live     │ Gateway │ immediate        │ high       │ 2026-04-25T17:00:00Z │
│ ax_concierge     │ Dispatch │ Cloud   │ dispatch_delayed │ medium     │ 2026-04-25T16:55:00Z │
└──────────────────┴──────────┴─────────┴──────────────────┴────────────┴──────────────────────┘
\`\`\`

## Filters

\`--filter\` passes through to backend query string:

| Value | Meaning |
|---|---|
| \`available_now\` | badge_state in {live, routable_delayed, queued_only} |
| \`gateway_connected\` | connection_path == gateway_managed |
| \`cloud_agent\` | connection_path == mcp_only |
| \`disabled\` | control state disabled |
| \`recently_active\` | replied within last hour |

\`--filter\` requires \`--availability\` (fails fast otherwise).

## Forward-compat

- Tries \`/availability\` first; on 404, falls back to legacy \`/agents\` and synthesizes badge from \`presence\` field. Rows marked \`_legacy=true\`.
- Unwraps \`{agent_state, raw_presence, control}\` envelope per row, preserving siblings as \`_raw_presence\` / \`_control\` for diagnostics.
- Handles three backend response shapes: flat list, \`{agents: [...]}\`, \`{availability: [...]}\`.

## Test plan

- [x] 8 new pytest smokes
- [x] 43 existing tests still pass (51 total green)
- [x] \`uv run ruff check\` clean
- [ ] Manual smoke against backend_sentinel/task-781f5781-agent-state-dto branch once deployed to dev

## Cross-refs

- \`specs/AGENT-AVAILABILITY-CONTRACT-001/spec.md\` §API shape — \`GET /api/v1/agents/availability\` endpoint definition
- \`specs/CLI-SURFACE-INVENTORY-001/inventory.md\` — implementation item 2 of CLI roadmap
- PR #101 — single-agent \`ax agents check\` (forward-compat companion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)