### PR TITLE
feat(messages): ax send post-send delivery_context chip — closes AVAIL-CONTRACT v4 send-time UX

### DIFF
--- a/ax_cli/commands/messages.py
+++ b/ax_cli/commands/messages.py
@@ -331,6 +331,110 @@ def _sender_label(message: dict) -> str | None:
     return None
 
 
+def _extract_delivery_context(data: dict | None) -> dict | None:
+    """Pull AVAIL-CONTRACT-001 ``delivery_context`` out of a send response.
+
+    Looks in three places per the spec — top-level, metadata, and nested
+    message.metadata — so the CLI doesn't care which envelope wrapping the
+    backend uses. Returns the dict or ``None`` if not present.
+    """
+    if not isinstance(data, dict):
+        return None
+    direct = data.get("delivery_context")
+    if isinstance(direct, dict):
+        return direct
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        nested = metadata.get("delivery_context")
+        if isinstance(nested, dict):
+            return nested
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        msg_meta = msg.get("metadata")
+        if isinstance(msg_meta, dict):
+            inner = msg_meta.get("delivery_context")
+            if isinstance(inner, dict):
+                return inner
+    return None
+
+
+_DELIVERY_PATH_LABEL = {
+    "live_session": "delivered live",
+    "warm_wake": "warming target",
+    "inbox_queue": "queued",
+    "blocked_unroutable": "blocked (unroutable)",
+    "failed_no_route": "failed (no route)",
+}
+
+_EXPECTED_RESPONSE_LABEL = {
+    "immediate": "Immediate",
+    "warming": "Warming",
+    "dispatch_delayed": "Dispatch",
+    "queued": "Queued",
+    "unlikely": "Unlikely",
+    "unavailable": "Unavailable",
+    "unknown": "Unknown",
+}
+
+
+def _delivery_context_chip(ctx: dict) -> str | None:
+    """Format delivery_context as a one-line chip for human output.
+
+    Returns ``None`` when the context is empty / has no useful fields.
+    Renders disagreement signal when ``delivery_path`` doesn't match the
+    ``expected_response_at_send`` prediction (per the spec's "predicted
+    warming, actually live" debugging gold).
+    """
+    if not isinstance(ctx, dict):
+        return None
+    delivery_path = str(ctx.get("delivery_path") or "").strip()
+    expected = str(ctx.get("expected_response_at_send") or "").strip()
+    warning = str(ctx.get("warning") or "").strip()
+
+    if not delivery_path and not expected and not warning:
+        return None
+
+    parts: list[str] = []
+    if delivery_path:
+        label = _DELIVERY_PATH_LABEL.get(delivery_path, delivery_path)
+        parts.append(label)
+
+    # Disagreement signal: predicted X, actually Y
+    if delivery_path and expected and not _delivery_matches_expectation(delivery_path, expected):
+        expected_label = _EXPECTED_RESPONSE_LABEL.get(expected, expected)
+        parts.append(f"predicted {expected_label}, actually {_DELIVERY_PATH_LABEL.get(delivery_path, delivery_path)}")
+    elif expected and not delivery_path:
+        # No actual path yet (offline send?), show the prediction alone
+        parts.append(_EXPECTED_RESPONSE_LABEL.get(expected, expected))
+
+    if warning:
+        parts.append(f"warning: {warning}")
+
+    return " · ".join(parts) if parts else None
+
+
+def _delivery_matches_expectation(delivery_path: str, expected: str) -> bool:
+    """Whether the actual delivery_path agrees with expected_response_at_send.
+
+    Mapping per AVAIL-CONTRACT-001 §"Pre-send / Post-send UX":
+    - immediate ↔ live_session
+    - warming ↔ warm_wake
+    - dispatch_delayed ↔ warm_wake (cloud-agent dispatch is also a "warm wake" path)
+    - queued ↔ inbox_queue
+    - unlikely / unavailable ↔ blocked_unroutable / failed_no_route
+    """
+    pairs = {
+        "immediate": {"live_session"},
+        "warming": {"warm_wake"},
+        "dispatch_delayed": {"warm_wake"},
+        "queued": {"inbox_queue"},
+        "unlikely": {"blocked_unroutable", "failed_no_route", "live_session"},
+        "unavailable": {"blocked_unroutable", "failed_no_route"},
+        "unknown": {"live_session", "warm_wake", "inbox_queue", "blocked_unroutable", "failed_no_route"},
+    }
+    return delivery_path in pairs.get(expected, set())
+
+
 def _gateway_reply_note(message: dict) -> str | None:
     metadata = message.get("metadata")
     if not isinstance(metadata, dict) or metadata.get("control_plane") != "gateway":
@@ -608,6 +712,8 @@ def send(
     if processing_watcher and msg_id:
         processing_watcher.set_message_id(str(msg_id))
 
+    delivery_chip = _delivery_context_chip(_extract_delivery_context(data) or {})
+
     if not wait or not msg_id:
         if processing_watcher:
             processing_watcher.close()
@@ -619,6 +725,8 @@ def send(
             if sender:
                 sent_line += f" as {sender}"
             console.print(sent_line)
+            if delivery_chip:
+                console.print(f"[dim]{delivery_chip}[/dim]")
         return
 
     sent_line = f"[green]Sent.[/green] id={msg_id}"
@@ -626,6 +734,8 @@ def send(
     if sender:
         sent_line += f" as {sender}"
     console.print(sent_line)
+    if delivery_chip:
+        console.print(f"[dim]{delivery_chip}[/dim]")
     wait_label = _target_mention("aX") if ask_ax else (_target_mention(to) if to else "reply")
     reply = _wait_for_reply(
         client,

--- a/tests/test_send_delivery_context.py
+++ b/tests/test_send_delivery_context.py
@@ -1,0 +1,127 @@
+"""Tests for ``ax send`` post-send delivery_context rendering.
+
+AVAIL-CONTRACT-001 §Post-send UX: when the send response carries
+``delivery_context`` in its metadata, the CLI surfaces:
+- ``delivery_path`` (live_session / warm_wake / inbox_queue / blocked_unroutable / failed_no_route)
+- Disagreement signal when ``delivery_path != expected_response_at_send``
+- ``warning`` (target_offline / target_stuck / target_quarantined / low_confidence)
+"""
+
+from __future__ import annotations
+
+from ax_cli.commands.messages import (
+    _delivery_context_chip,
+    _delivery_matches_expectation,
+    _extract_delivery_context,
+)
+
+
+def test_extract_finds_top_level_delivery_context():
+    data = {"delivery_context": {"delivery_path": "live_session"}}
+    assert _extract_delivery_context(data) == {"delivery_path": "live_session"}
+
+
+def test_extract_finds_metadata_nested_delivery_context():
+    data = {"metadata": {"delivery_context": {"delivery_path": "warm_wake"}}}
+    assert _extract_delivery_context(data)["delivery_path"] == "warm_wake"
+
+
+def test_extract_finds_message_metadata_nested_delivery_context():
+    data = {"message": {"metadata": {"delivery_context": {"delivery_path": "inbox_queue"}}}}
+    assert _extract_delivery_context(data)["delivery_path"] == "inbox_queue"
+
+
+def test_extract_returns_none_when_absent():
+    assert _extract_delivery_context({"id": "msg-1"}) is None
+    assert _extract_delivery_context(None) is None
+    assert _extract_delivery_context({"delivery_context": "not a dict"}) is None
+
+
+def test_chip_renders_delivery_path_label():
+    chip = _delivery_context_chip({"delivery_path": "live_session"})
+    assert chip is not None
+    assert "delivered live" in chip
+
+
+def test_chip_renders_warm_wake_as_warming():
+    chip = _delivery_context_chip({"delivery_path": "warm_wake"})
+    assert "warming target" in chip
+
+
+def test_chip_renders_blocked_path_with_warning():
+    chip = _delivery_context_chip({
+        "delivery_path": "blocked_unroutable",
+        "warning": "target_quarantined",
+    })
+    assert "blocked (unroutable)" in chip
+    assert "warning: target_quarantined" in chip
+
+
+def test_chip_renders_disagreement_signal():
+    """Predicted vs actual mismatch is surfaced explicitly (debugging gold)."""
+    chip = _delivery_context_chip({
+        "expected_response_at_send": "warming",
+        "delivery_path": "live_session",
+    })
+    assert chip is not None
+    assert "predicted Warming" in chip
+    assert "actually delivered live" in chip
+
+
+def test_chip_no_disagreement_when_paths_align():
+    """When delivery_path matches expected_response_at_send, no predicted/actually banner."""
+    chip = _delivery_context_chip({
+        "expected_response_at_send": "immediate",
+        "delivery_path": "live_session",
+    })
+    assert "predicted" not in chip
+    assert "delivered live" in chip
+
+
+def test_chip_renders_expected_alone_when_no_actual_path():
+    """If only expected_response is present (offline send?), show the prediction."""
+    chip = _delivery_context_chip({"expected_response_at_send": "queued"})
+    assert chip is not None
+    assert "Queued" in chip
+
+
+def test_chip_returns_none_for_empty_context():
+    assert _delivery_context_chip({}) is None
+    assert _delivery_context_chip(None) is None
+
+
+def test_chip_renders_dispatch_delayed_label():
+    """The new v4 dispatch_delayed value renders distinctly from warming."""
+    chip = _delivery_context_chip({
+        "expected_response_at_send": "dispatch_delayed",
+        "delivery_path": "warm_wake",
+    })
+    # dispatch_delayed maps to warm_wake → no disagreement
+    assert "predicted" not in chip
+    assert "warming target" in chip
+
+
+def test_matches_expectation_table():
+    """The expectation/path mapping covers AVAIL-CONTRACT v4 vocabulary."""
+    # Direct matches
+    assert _delivery_matches_expectation("live_session", "immediate")
+    assert _delivery_matches_expectation("warm_wake", "warming")
+    assert _delivery_matches_expectation("warm_wake", "dispatch_delayed")
+    assert _delivery_matches_expectation("inbox_queue", "queued")
+    assert _delivery_matches_expectation("blocked_unroutable", "unavailable")
+    # Mismatches
+    assert not _delivery_matches_expectation("live_session", "warming")
+    assert not _delivery_matches_expectation("inbox_queue", "immediate")
+    # Unknown is permissive (any path is acceptable)
+    assert _delivery_matches_expectation("live_session", "unknown")
+    assert _delivery_matches_expectation("blocked_unroutable", "unknown")
+
+
+def test_chip_handles_unknown_enum_values_gracefully():
+    """Unknown delivery_path / expected values pass through as raw strings, no crash."""
+    chip = _delivery_context_chip({
+        "delivery_path": "future_path_xyz",
+        "expected_response_at_send": "future_value",
+    })
+    assert chip is not None
+    assert "future_path_xyz" in chip


### PR DESCRIPTION
Per orion's CLI roadmap (PR #102 item 4) + @cipher 17:35 UTC. Lands the post-send half of AVAIL-CONTRACT-001 §\"Post-send UX requirements\".

## What

When the send response carries \`delivery_context\`, \`ax send\` surfaces a one-line chip below the \"Sent.\" output:

\`\`\`
$ ax send "@frontend_sentinel are you there?"
Sent. id=msg-abc as @orion
warming target
\`\`\`

When the prediction differs from reality:

\`\`\`
Sent. id=msg-abc
predicted Warming, actually delivered live
\`\`\`

When delivery is blocked:

\`\`\`
Sent. id=msg-abc
blocked (unroutable) · warning: target_quarantined
\`\`\`

## delivery_path → label

| Backend value | Chip label |
|---|---|
| \`live_session\` | delivered live |
| \`warm_wake\` | warming target |
| \`inbox_queue\` | queued |
| \`blocked_unroutable\` | blocked (unroutable) |
| \`failed_no_route\` | failed (no route) |

## Disagreement signal (debugging gold)

The spec calls it \"debugging gold for tuning the resolution algorithm\" — the chip surfaces \`predicted X, actually Y\` whenever \`delivery_path\` doesn't match \`expected_response_at_send\`. Mapping per AVAIL-CONTRACT v4:

- \`immediate\` ↔ \`live_session\`
- \`warming\` / \`dispatch_delayed\` ↔ \`warm_wake\`
- \`queued\` ↔ \`inbox_queue\`
- \`unlikely\` / \`unavailable\` ↔ \`blocked_unroutable\` / \`failed_no_route\`
- \`unknown\` is permissive (any path acceptable)

## Forward-compat

Today's backend doesn't send \`delivery_context\`; chip is \`None\`, output unchanged. When backend's \`POST /messages\` response gains the envelope, CLI surface lights up automatically. Same pattern as \`ax agents check\` (PR #101) and \`ax agents list --availability\` (PR #103).

## Test plan

- [x] 14 new pytest smokes covering envelope extraction, label rendering, disagreement signal, warning passthrough, dispatch_delayed handling, unknown enum graceful pass-through
- [x] 51 existing tests still pass (65 total)
- [x] \`uv run ruff check\` clean

## Cross-refs

- \`specs/AGENT-AVAILABILITY-CONTRACT-001/spec.md\` §\"Pre-send / Post-send UX\" — the contract this implements
- \`specs/CLI-SURFACE-INVENTORY-001/inventory.md\` item 4 in CLI roadmap (PR #102)
- @backend_sentinel: when \`POST /messages\` response carries \`delivery_context\` from `/state` integration, this chip lights up
- @mcp_sentinel: parity ask — \`messages(action='send')\` should pass through \`delivery_context\` so cloud agents can read disagreement signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)