### PR TITLE
fix(bootstrap): ensure-agent semantics — 409 falls back to GET-by-name

### DIFF
--- a/ax_cli/commands/bootstrap.py
+++ b/ax_cli/commands/bootstrap.py
@@ -138,7 +138,15 @@ def _find_agent_in_space(client, name: str, space_id: str) -> Optional[dict]:
 def _create_agent_in_space(client, *, name: str, space_id: str, description: str | None, model: str | None) -> dict:
     """POST /api/v1/agents with X-Space-Id. This is the creation path proven
     to route through the ALB on prod (POST survives; PATCH/PUT to the same
-    prefix don't — see avatar-day PR)."""
+    prefix don't — see avatar-day PR).
+
+    On 409 ("agent already exists in this space"), fall back to GET-by-name —
+    the caller's intent is "ensure this agent exists"; if backend already has
+    one with our name in the target space, that's success-by-convergence, not
+    a hard error. Without this, ``ax gateway agents test`` crashes when its
+    auto-created switchboard sender agent already exists on the backend but
+    isn't in the local Gateway registry (drift after registry resets).
+    """
     body: dict = {"name": name}
     if description is not None:
         body["description"] = description
@@ -148,6 +156,13 @@ def _create_agent_in_space(client, *, name: str, space_id: str, description: str
         body["space_id"] = space_id
     headers = {"X-Space-Id": space_id} if space_id else None
     r = client._http.post("/api/v1/agents", json=body, headers=headers)
+    if r.status_code == 409:
+        existing = _find_agent_in_space(client, name, space_id)
+        if existing:
+            return existing
+        # 409 but we can't find the conflicting agent — surface the original
+        # error so caller sees what the backend reported, not a misleading 404.
+        r.raise_for_status()
     r.raise_for_status()
     return client._parse_json(r)
 

--- a/tests/test_bootstrap_agent.py
+++ b/tests/test_bootstrap_agent.py
@@ -449,3 +449,67 @@ def test_bootstrap_prints_effective_config(monkeypatch, tmp_path, user_pat, veri
     assert result.exit_code == 0, result.output
     assert "base_url=" in result.output
     assert "user_env=" in result.output
+
+
+# ── _create_agent_in_space 409 fallback (gateway agents test crash fix) ──────
+
+
+def test_create_agent_in_space_409_falls_back_to_existing(monkeypatch):
+    """If POST /api/v1/agents returns 409, look up the existing agent and return it.
+
+    Closes the ``ax gateway agents test`` crash where the auto-created
+    switchboard sender existed on the backend but not in the local Gateway
+    registry — caller's intent was "ensure agent exists," 409 is success-by-
+    convergence, not a failure to surface.
+    """
+    existing_agent = {"id": AGENT_ID, "name": "switchboard-12d6eafd", "space_id": SPACE_ID}
+    http = _FakeHttp(
+        {
+            ("POST", "/api/v1/agents"): (409, {"detail": "Agent 'switchboard-12d6eafd' already exists in this space"}, None),
+            ("GET", "/api/v1/agents"): (200, {"agents": [existing_agent]}, None),
+        }
+    )
+    client = _FakeClient(http)
+    result = bootstrap_cmd._create_agent_in_space(
+        client, name="switchboard-12d6eafd", space_id=SPACE_ID, description=None, model=None
+    )
+    assert result["id"] == AGENT_ID
+    assert result["name"] == "switchboard-12d6eafd"
+    # Sanity: we did make the POST attempt (not just immediate GET)
+    posts = [c for c in http.calls if c["method"] == "POST"]
+    assert len(posts) == 1
+
+
+def test_create_agent_in_space_409_with_no_match_re_raises(monkeypatch):
+    """409 + GET returns empty → re-raise the 409 so the user sees real backend error.
+
+    Avoids replacing one mystery ("409 already exists") with another ("404 not
+    found in space") when our lookup doesn't match what the backend rejected.
+    """
+    http = _FakeHttp(
+        {
+            ("POST", "/api/v1/agents"): (409, {"detail": "Agent 'mystery' already exists in this space"}, None),
+            ("GET", "/api/v1/agents"): (200, {"agents": []}, None),  # empty — couldn't find conflict
+        }
+    )
+    client = _FakeClient(http)
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        bootstrap_cmd._create_agent_in_space(
+            client, name="mystery", space_id=SPACE_ID, description=None, model=None
+        )
+    assert exc.value.response.status_code == 409
+
+
+def test_create_agent_in_space_other_errors_still_raise(monkeypatch):
+    """409 fallback must not swallow other status codes (401, 500, etc)."""
+    http = _FakeHttp(
+        {
+            ("POST", "/api/v1/agents"): (500, {"detail": "boom"}, None),
+        }
+    )
+    client = _FakeClient(http)
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        bootstrap_cmd._create_agent_in_space(
+            client, name="x", space_id=SPACE_ID, description=None, model=None
+        )
+    assert exc.value.response.status_code == 500


### PR DESCRIPTION
## Summary
- `ax gateway agents test` crashed with uncaught `HTTPStatusError 409` when its auto-created switchboard sender agent existed on the backend but not in the local Gateway registry. Found in yesterday's AUTOSETUP-001 demo dry-run.
- `_create_agent_in_space` now treats 409 as success-by-convergence: GET-by-name, return existing. Other status codes still raise.

## Why this is the right fix
The caller's contract is "ensure this agent exists in the target space," not "create-or-die." Backend's 409 means the agent is already there — converging on caller's intent, not failing it. This matches the existing `_find_agent_in_space` early-return pattern further up the bootstrap flow.

## Behavior matrix
| POST status | GET result | Outcome |
|---|---|---|
| 409 | finds match | return existing agent (success) |
| 409 | no match | re-raise original 409 (don't replace one mystery with another) |
| 401 / 403 / 5xx | n/a | re-raise unchanged |
| 201 | n/a | normal create path |

## Test plan
- [x] 3 new tests covering each branch above (`test_create_agent_in_space_409_*`)
- [x] All 17 bootstrap tests pass
- [x] Full ax-cli suite: 442 passed
- [x] `ruff check` clean

## Operator impact
After this PR, running `ax gateway agents test gateway_probe_orion` no longer crashes when the switchboard sender drifts between local Gateway registry and backend. The auto-creation path becomes idempotent in the way the caller already assumed it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)