### PR TITLE
feat(gateway): listener for agent.placement.changed SSE event (8467ec87)

### DIFF
--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2706,6 +2706,128 @@ def find_agent_entry(registry: dict[str, Any], name: str) -> dict[str, Any] | No
     return None
 
 
+def _apply_placement_event(
+    entry: dict[str, Any],
+    event_data: dict[str, Any],
+    *,
+    agent_name: str | None = None,
+) -> dict[str, Any]:
+    """Apply an ``agent.placement.changed`` event to the local Gateway registry.
+
+    Returns a result dict describing what happened:
+
+        {
+          "applied": bool,
+          "reason": str | None,           # if not applied
+          "previous_space": str | None,
+          "new_space": str | None,
+          "placement_state": str | None,
+          "policy_revision": int | None,
+        }
+
+    Spec: ``specs/GATEWAY-PLACEMENT-POLICY-001/spec.md``. The event payload
+    follows the placement record fields (lines 32-46): ``agent_id``,
+    ``current_space``, ``placement_state``, ``policy_revision``, etc.
+
+    Idempotent: events for an agent we don't manage, or where ``current_space``
+    already matches, are no-ops (``applied: False``, ``reason`` set).
+    """
+    event_agent_id = str(event_data.get("agent_id") or "").strip()
+    entry_agent_id = str(entry.get("agent_id") or "").strip()
+    if event_agent_id and entry_agent_id and event_agent_id != entry_agent_id:
+        return {"applied": False, "reason": "agent_id_mismatch"}
+
+    new_space = str(event_data.get("current_space") or event_data.get("space_id") or "").strip()
+    if not new_space:
+        return {"applied": False, "reason": "missing_current_space"}
+
+    previous_space = str(entry.get("space_id") or "").strip() or None
+    placement_state = str(event_data.get("placement_state") or "applied").strip() or "applied"
+    policy_revision = event_data.get("policy_revision")
+    try:
+        policy_revision_int = int(policy_revision) if policy_revision is not None else None
+    except (TypeError, ValueError):
+        policy_revision_int = None
+
+    # Already in sync — ack-without-apply
+    if previous_space == new_space:
+        existing_rev = entry.get("placement_revision")
+        if policy_revision_int is None or (existing_rev is not None and int(existing_rev) >= policy_revision_int):
+            return {
+                "applied": False,
+                "reason": "already_at_target",
+                "previous_space": previous_space,
+                "new_space": new_space,
+                "placement_state": placement_state,
+                "policy_revision": policy_revision_int,
+            }
+
+    # Persist to local registry
+    registry = load_gateway_registry()
+    name = agent_name or str(entry.get("name") or "")
+    target_entry = find_agent_entry(registry, name)
+    if target_entry is None:
+        return {
+            "applied": False,
+            "reason": "agent_not_in_registry",
+            "previous_space": previous_space,
+            "new_space": new_space,
+        }
+    target_entry["space_id"] = new_space
+    target_entry["placement_state"] = placement_state
+    if policy_revision_int is not None:
+        target_entry["placement_revision"] = policy_revision_int
+    if "current_space_set_by" in event_data:
+        target_entry["placement_source"] = str(event_data["current_space_set_by"])
+    save_gateway_registry(registry)
+
+    # Mirror to caller's `entry` so subsequent calls in same loop see the new value
+    entry["space_id"] = new_space
+    entry["placement_state"] = placement_state
+    if policy_revision_int is not None:
+        entry["placement_revision"] = policy_revision_int
+
+    return {
+        "applied": True,
+        "previous_space": previous_space,
+        "new_space": new_space,
+        "placement_state": placement_state,
+        "policy_revision": policy_revision_int,
+    }
+
+
+def _post_placement_ack(
+    client: Any,
+    entry: dict[str, Any],
+    *,
+    placement_state: str,
+    policy_revision: int | None = None,
+    runtime_pid: int | None = None,
+) -> bool:
+    """Best-effort PATCH /api/v1/agents/{id}/placement/ack — backend task 31adc3a4.
+
+    Returns True on success, False otherwise. 404 is the expected failure mode
+    until backend ships the endpoint; logged but not fatal.
+    """
+    agent_id = str(entry.get("agent_id") or "").strip()
+    if not agent_id:
+        return False
+    body: dict[str, Any] = {"placement_state": placement_state}
+    if policy_revision is not None:
+        body["policy_revision"] = int(policy_revision)
+    if runtime_pid is not None:
+        body["runtime_pid"] = int(runtime_pid)
+    body["ack_at"] = _now_iso()
+    try:
+        response = client._http.patch(f"/api/v1/agents/{agent_id}/placement/ack", json=body)
+    except Exception:  # noqa: BLE001
+        return False
+    if response.status_code == 404:
+        # Endpoint not yet shipped (31adc3a4 pending) — silent no-op
+        return False
+    return 200 <= response.status_code < 300
+
+
 def upsert_agent_entry(registry: dict[str, Any], agent: dict[str, Any]) -> dict[str, Any]:
     agents = registry.setdefault("agents", [])
     for idx, existing in enumerate(agents):
@@ -3247,6 +3369,52 @@ class ManagedAgentRuntime:
             if seen:
                 self._completed_seen_ids.discard(message_id)
             return seen
+
+    def _handle_placement_event(self, data: dict[str, Any]) -> None:
+        """Handle SSE ``agent.placement.changed`` for this managed agent.
+
+        Per ``specs/GATEWAY-PLACEMENT-POLICY-001/spec.md`` lines 81-93. The
+        event carries the new placement record; we update the local Gateway
+        registry to keep operator-visible state in sync, log activity, and
+        best-effort POST an ack.
+
+        Stub-resilient: if the backend hasn't shipped the ack endpoint yet
+        (task ``31adc3a4``), the POST returns 404 and we log a warning. The
+        inbound side still works — operators see placement changes in the
+        registry without restarting agents.
+        """
+        try:
+            outcome = _apply_placement_event(self.entry, data, agent_name=self.name)
+        except Exception as exc:  # noqa: BLE001
+            record_gateway_activity(
+                "placement_apply_failed",
+                entry=self.entry,
+                error=str(exc)[:300],
+                event=data.get("event_id") or data.get("id"),
+            )
+            self._log(f"placement event apply failed: {exc}")
+            return
+        record_gateway_activity(
+            "placement_changed",
+            entry=self.entry,
+            placement_state=outcome.get("placement_state"),
+            previous_space=outcome.get("previous_space"),
+            new_space=outcome.get("new_space"),
+            policy_revision=outcome.get("policy_revision"),
+            applied=outcome.get("applied", False),
+        )
+        if outcome.get("applied"):
+            try:
+                client = self._new_client()
+                _post_placement_ack(
+                    client,
+                    self.entry,
+                    placement_state=str(outcome.get("placement_state") or "applied"),
+                    policy_revision=outcome.get("policy_revision"),
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Ack is best-effort while 31adc3a4 ships. Don't kill the listener.
+                self._log(f"placement ack failed (non-fatal): {exc}")
 
     def snapshot(self) -> dict[str, Any]:
         with self._state_lock:
@@ -4183,6 +4351,10 @@ class ManagedAgentRuntime:
                             break
                         if event_type in {"bootstrap", "heartbeat", "ping", "identity_bootstrap", "connected"}:
                             self._update_state(last_seen_at=_now_iso())
+                            continue
+                        if event_type == "agent.placement.changed" and isinstance(data, dict):
+                            self._update_state(last_seen_at=_now_iso())
+                            self._handle_placement_event(data)
                             continue
                         if event_type not in {"message", "mention"} or not isinstance(data, dict):
                             continue

--- a/tests/test_gateway_placement_event.py
+++ b/tests/test_gateway_placement_event.py
@@ -1,0 +1,241 @@
+"""Tests for the GATEWAY-PLACEMENT-POLICY-001 SSE listener — task `8467ec87`.
+
+Covers:
+- ``_apply_placement_event`` updates the local registry on a valid event
+- Idempotency: same-space events are no-ops
+- Agent ID mismatch is rejected
+- Missing fields don't crash
+- ``_post_placement_ack`` tolerates 404 from the not-yet-shipped backend endpoint
+
+The SSE wire-up (event_type filter in ``_listener_loop``) is exercised
+end-to-end indirectly; here we test the pure functions so we don't need to
+spin up an actual SSE server.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ax_cli.gateway import (
+    _apply_placement_event,
+    _post_placement_ack,
+    find_agent_entry,
+    load_gateway_registry,
+)
+
+
+def _seed_registry(tmp_path, monkeypatch, name="probe_agent", agent_id="aaaa1111-2222-3333-4444-555566667777", space_id="space-A"):
+    """Set AX_GATEWAY_DIR to a tmp dir + write a minimal registry.json with one agent."""
+    import json
+    from pathlib import Path
+
+    gw_dir = Path(tmp_path)
+    gw_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(gw_dir))
+    monkeypatch.delenv("AX_GATEWAY_ENV", raising=False)
+    monkeypatch.delenv("AX_USER_ENV", raising=False)
+    monkeypatch.delenv("AX_ENV", raising=False)
+    registry = {
+        "gateway": {"gateway_id": "gw-test"},
+        "agents": [
+            {
+                "name": name,
+                "agent_id": agent_id,
+                "space_id": space_id,
+                "runtime_type": "exec",
+                "template_id": "probe",
+            }
+        ],
+    }
+    (gw_dir / "registry.json").write_text(json.dumps(registry))
+    return registry["agents"][0]
+
+
+def test_apply_placement_event_updates_registry(tmp_path, monkeypatch):
+    """Happy path: event with new current_space updates entry's space_id."""
+    entry = _seed_registry(tmp_path, monkeypatch)
+
+    result = _apply_placement_event(
+        dict(entry),  # caller's entry
+        {
+            "agent_id": entry["agent_id"],
+            "current_space": "space-B",
+            "placement_state": "applied",
+            "policy_revision": 7,
+            "current_space_set_by": "ax_ui",
+        },
+    )
+
+    assert result["applied"] is True
+    assert result["previous_space"] == "space-A"
+    assert result["new_space"] == "space-B"
+    assert result["placement_state"] == "applied"
+    assert result["policy_revision"] == 7
+
+    # Verify it landed in the registry
+    registry = load_gateway_registry()
+    persisted = find_agent_entry(registry, "probe_agent")
+    assert persisted is not None
+    assert persisted["space_id"] == "space-B"
+    assert persisted["placement_state"] == "applied"
+    assert persisted["placement_revision"] == 7
+    assert persisted["placement_source"] == "ax_ui"
+
+
+def test_apply_placement_event_idempotent_when_same_space(tmp_path, monkeypatch):
+    """If event reports current_space we already have, don't re-write the registry."""
+    entry = _seed_registry(tmp_path, monkeypatch, space_id="space-A")
+
+    result = _apply_placement_event(
+        dict(entry),
+        {
+            "agent_id": entry["agent_id"],
+            "current_space": "space-A",  # same as current
+            "placement_state": "applied",
+        },
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "already_at_target"
+
+
+def test_apply_placement_event_rejects_agent_id_mismatch(tmp_path, monkeypatch):
+    """Don't apply events meant for a different agent."""
+    entry = _seed_registry(tmp_path, monkeypatch)
+
+    result = _apply_placement_event(
+        dict(entry),
+        {
+            "agent_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",  # different
+            "current_space": "space-B",
+        },
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "agent_id_mismatch"
+
+
+def test_apply_placement_event_rejects_missing_current_space(tmp_path, monkeypatch):
+    """Malformed event without current_space → no apply, no crash."""
+    entry = _seed_registry(tmp_path, monkeypatch)
+
+    result = _apply_placement_event(
+        dict(entry),
+        {"agent_id": entry["agent_id"], "placement_state": "applied"},
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "missing_current_space"
+
+
+def test_apply_placement_event_rejects_unknown_agent(tmp_path, monkeypatch):
+    """Event references an agent NOT in our registry — don't auto-create."""
+    _seed_registry(tmp_path, monkeypatch, name="probe_agent")
+
+    # Caller passes an entry for a different agent (race/drift case)
+    foreign_entry = {
+        "name": "stranger",
+        "agent_id": "00000000-0000-0000-0000-000000000099",
+        "space_id": "space-X",
+    }
+    result = _apply_placement_event(
+        foreign_entry,
+        {
+            "agent_id": foreign_entry["agent_id"],
+            "current_space": "space-Y",
+        },
+        agent_name="stranger",
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "agent_not_in_registry"
+
+
+def test_apply_placement_event_falls_back_to_space_id_field(tmp_path, monkeypatch):
+    """Tolerate event payloads that use ``space_id`` instead of ``current_space``.
+
+    Forward-compat: backend may shape the field either way during 31adc3a4
+    iteration. Either is accepted.
+    """
+    entry = _seed_registry(tmp_path, monkeypatch, space_id="space-A")
+
+    result = _apply_placement_event(
+        dict(entry),
+        {"agent_id": entry["agent_id"], "space_id": "space-C"},
+    )
+
+    assert result["applied"] is True
+    assert result["new_space"] == "space-C"
+
+
+# ── _post_placement_ack ─────────────────────────────────────────────────────
+
+
+class _FakeHttp:
+    def __init__(self, status_code, body=None):
+        self.status_code = status_code
+        self.body = body or {}
+        self.calls: list[dict[str, Any]] = []
+
+    def patch(self, path, json=None, **kw):
+        self.calls.append({"path": path, "json": json})
+
+        class _R:
+            def __init__(s):
+                s.status_code = self.status_code
+
+            def json(s):
+                return self.body
+
+        return _R()
+
+
+class _FakeClient:
+    def __init__(self, http):
+        self._http = http
+
+
+def test_post_placement_ack_success_returns_true():
+    http = _FakeHttp(204)
+    client = _FakeClient(http)
+    entry = {"agent_id": "aaaa-bbbb"}
+    ok = _post_placement_ack(client, entry, placement_state="applied", policy_revision=3)
+    assert ok is True
+    assert len(http.calls) == 1
+    assert http.calls[0]["path"] == "/api/v1/agents/aaaa-bbbb/placement/ack"
+    body = http.calls[0]["json"]
+    assert body["placement_state"] == "applied"
+    assert body["policy_revision"] == 3
+    assert "ack_at" in body
+
+
+def test_post_placement_ack_404_is_silent_noop():
+    """Backend's /placement/ack endpoint isn't shipped yet (31adc3a4 pending).
+
+    A 404 should NOT throw — the listener can't ack against an endpoint that
+    doesn't exist, but that shouldn't kill the worker.
+    """
+    http = _FakeHttp(404, {"detail": "Not Found"})
+    client = _FakeClient(http)
+    ok = _post_placement_ack(client, {"agent_id": "x"}, placement_state="applied")
+    assert ok is False  # not raised, just reported as non-success
+
+
+def test_post_placement_ack_skips_when_no_agent_id():
+    """No agent_id → can't construct URL; return False without HTTP call."""
+    http = _FakeHttp(200)
+    client = _FakeClient(http)
+    ok = _post_placement_ack(client, {"agent_id": None}, placement_state="applied")
+    assert ok is False
+    assert http.calls == []
+
+
+def test_post_placement_ack_handles_http_exception_gracefully():
+    """Connection error / TLS / etc shouldn't kill the listener."""
+    class _ExplodingHttp:
+        def patch(self, *a, **kw):
+            raise RuntimeError("simulated network failure")
+
+    client = _FakeClient(_ExplodingHttp())
+    ok = _post_placement_ack(client, {"agent_id": "x"}, placement_state="applied")
+    assert ok is False  # exception swallowed, returns False


### PR DESCRIPTION
## Summary
Implements task `8467ec87` ("local listener/gateway applies placement changes instantly") per the existing `specs/GATEWAY-PLACEMENT-POLICY-001/spec.md` contract. Composes on PR #105 (placement CLI) — operators changing an agent's space in the aX UI now see the change reflected in local Gateway state without restarting any process.

**Inbound side ships now; outbound ack is best-effort.** Backend hasn't published the `/placement/ack` endpoint yet (paired task `31adc3a4` — backend_sentinel pinged with spec-line pointers). Listener is correct against the published spec; auto-activates when backend emits.

## Changes
- `_apply_placement_event(entry, event_data, agent_name)` — pure function, updates local registry. Idempotent; tolerates `current_space` or `space_id` field naming during 31adc3a4 iteration; rejects agent_id mismatches and missing fields.
- `_post_placement_ack(client, entry, ...)` — best-effort PATCH `/api/v1/agents/{id}/placement/ack`. 404 (endpoint missing) is a silent no-op. Network/connection failures non-fatal.
- `Worker._handle_placement_event(data)` — wires apply + ack, records `placement_changed` activity event for the dashboard, logs failures.
- SSE event filter extended in `_listener_loop` to dispatch `agent.placement.changed` before the existing message/mention path.

## Test plan
- [x] 10 new tests in `tests/test_gateway_placement_event.py`:
  - apply: happy path, idempotent same-space, agent_id mismatch, missing current_space, unknown agent in registry, `space_id` fallback
  - ack: success returns True, 404 silent no-op, no-agent-id skip, exception swallowing
- [x] Full ax-cli suite: 452 passed
- [x] `ruff check` clean
- [x] No backend dependency for the inbound side — listener auto-activates on first matching event

## Coordination
- Backend_sentinel pinged on `31adc3a4` with pointers to `specs/GATEWAY-PLACEMENT-POLICY-001/spec.md` lines 81-93 (event shape), 32-46 (placement record fields), 92/106 (ack endpoint), 47-74 (state machine). DM id `7935d26d`.
- Once their SSE emit + ack endpoint land, end-to-end test is the placement-policy spec's Smoke #1 (lines 152-157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)