### PR TITLE
Improve active-agent discovery coordination guidance

### DIFF
--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -247,7 +247,76 @@ def _probe_agent_contact(
     }
 
 
-def _discover_agent_row(agent: dict[str, Any], probe: dict[str, Any] | None = None) -> dict[str, Any]:
+def _shell_quote(value: str) -> str:
+    """Small single-quote shell escaper for command examples."""
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _coordination_commands(agent_name: str, space_id: str | None = None) -> dict[str, str]:
+    mention = "@" + agent_name.removeprefix("@")
+    task_title = f"Follow-up for {mention}"
+    space_arg = f" --space-id {space_id}" if space_id else ""
+    return {
+        "ping": f"axctl agents ping {mention} --timeout 10{space_arg}",
+        "handoff": f"axctl handoff {mention} {_shell_quote('Describe the work, expected output, and completion promise.')} --probe-timeout 10{space_arg}",
+        "task": f"axctl tasks create {_shell_quote(task_title)} --assign-to {mention} --priority high{space_arg}",
+        "reminder": f"axctl reminders add <task-id> --target {mention} --first-in-minutes 30 --reason {_shell_quote('Please post status, blocker, or completion note.')}{space_arg}",
+    }
+
+
+def _coordination_next_step(contact_mode: str, listener_status: str, control_status: str) -> str:
+    if control_status != "active":
+        return "clear_control_state_before_contact"
+    if contact_mode == "event_listener":
+        return "handoff_now"
+    if contact_mode == "space_agent":
+        return "ask_product_or_route_request"
+    if contact_mode == "on_demand":
+        return "create_task_then_ping_or_handoff"
+    if listener_status == "no_reply":
+        return "leave_task_and_reminder"
+    return "ping_before_handoff"
+
+
+def _coordination_checklist(rows: list[dict[str, Any]], *, space_id: str | None = None) -> list[str]:
+    live = [row["name"] for row in rows if row.get("contact_mode") == "event_listener"]
+    no_reply = [
+        row["name"]
+        for row in rows
+        if row.get("listener_status") == "no_reply" and row.get("contact_mode") != "blocked_by_control"
+    ]
+    blocked = [row["name"] for row in rows if row.get("contact_mode") == "blocked_by_control"]
+    first_live = live[0] if live else None
+    first_no_reply = no_reply[0] if no_reply else None
+    space_arg = f" --space-id {space_id}" if space_id else ""
+    checklist = [
+        "1. Pick a live listener for urgent synchronous work; otherwise create an assigned task.",
+        "2. Put the desired output, branch/worktree path, validation, and completion promise in the handoff/task.",
+        "3. Add a reminder when the owner is no-reply, on-demand, blocked, or the task should not be forgotten.",
+        "4. Keep durable notes in the repo/agent notes path and close or update tasks when done, blocked, or taking a break.",
+    ]
+    if first_live:
+        checklist.append(
+            f"Live-listener fast path: axctl handoff @{first_live} 'Status/implement ...' --probe-timeout 10{space_arg}"
+        )
+    if first_no_reply:
+        checklist.append(
+            f"No-reply fallback: axctl tasks create 'Follow-up for @{first_no_reply}' --assign-to @{first_no_reply} --priority high{space_arg}"
+        )
+    if blocked:
+        checklist.append(
+            "Blocked agents: clear enable/break/DND control state before expecting delivery: "
+            + ", ".join(f"@{name}" for name in blocked[:5])
+        )
+    return checklist
+
+
+def _discover_agent_row(
+    agent: dict[str, Any],
+    probe: dict[str, Any] | None = None,
+    *,
+    space_id: str | None = None,
+) -> dict[str, Any]:
     mesh_role = _agent_mesh_role(agent)
     control_status = _agent_control_status(agent)
     control_reason = _agent_control_reason(agent)
@@ -262,8 +331,13 @@ def _discover_agent_row(agent: dict[str, Any], probe: dict[str, Any] | None = No
         warning = "supervisor_candidate_not_live"
     if control_status != "active":
         warning = "agent_control_blocks_delivery"
+    name = _agent_mention_name(agent, str(agent.get("name") or "agent"))
+    commands = _coordination_commands(name, space_id=space_id)
+    recommended_contact = (
+        "reenable_before_contact" if control_status != "active" else _recommended_contact(contact_mode, mesh_role)
+    )
     return {
-        "name": _agent_mention_name(agent, str(agent.get("name") or "agent")),
+        "name": name,
         "agent_id": agent.get("id"),
         "origin": agent.get("origin"),
         "agent_type": agent.get("agent_type"),
@@ -273,9 +347,12 @@ def _discover_agent_row(agent: dict[str, Any], probe: dict[str, Any] | None = No
         "mesh_role": mesh_role,
         "listener_status": listener_status,
         "contact_mode": contact_mode,
-        "recommended_contact": "reenable_before_contact"
-        if control_status != "active"
-        else _recommended_contact(contact_mode, mesh_role),
+        "recommended_contact": recommended_contact,
+        "next_step": _coordination_next_step(contact_mode, listener_status, control_status),
+        "commands": commands,
+        "handoff_command": commands["handoff"],
+        "task_command": commands["task"],
+        "reminder_command": commands["reminder"],
         "sent_message_id": probe.get("sent_message_id") if probe else None,
         "ping_token": probe.get("ping_token") if probe else None,
         "warning": warning,
@@ -574,36 +651,58 @@ def discover_agents(
                 )
             except httpx.HTTPStatusError as exc:
                 handle_error(exc)
-        rows.append(_discover_agent_row(target, probe))
+        rows.append(_discover_agent_row(target, probe, space_id=sid))
 
     summary = {
         "total": len(rows),
         "event_listeners": sum(1 for row in rows if row["contact_mode"] == "event_listener"),
         "unknown_or_not_listening": sum(1 for row in rows if row["contact_mode"] == "unknown_or_not_listening"),
+        "no_reply_or_stale": sum(
+            1
+            for row in rows
+            if row["listener_status"] == "no_reply" or row["contact_mode"] in {"unknown", "unknown_or_not_listening"}
+        ),
         "supervisor_candidates": sum(1 for row in rows if row["mesh_role"] == "supervisor_candidate"),
         "supervisor_candidates_not_live": sum(1 for row in rows if row["warning"] == "supervisor_candidate_not_live"),
         "blocked_by_control": sum(1 for row in rows if row["contact_mode"] == "blocked_by_control"),
         "pinged": ping,
     }
-    result = {"space_id": sid, "summary": summary, "agents": rows}
+    result = {
+        "space_id": sid,
+        "summary": summary,
+        "coordination_checklist": _coordination_checklist(rows, space_id=sid),
+        "agents": rows,
+    }
 
     if as_json:
         print_json(result)
         return
 
     print_table(
-        ["Name", "Role", "Roster", "Listener", "Contact Mode", "Recommended", "Warning"],
+        ["Name", "Role", "Roster", "Control", "Listener", "Contact Mode", "Next Step", "Recommended", "Warning"],
         rows,
         keys=[
             "name",
             "mesh_role",
             "roster_status",
+            "control_status",
             "listener_status",
             "contact_mode",
+            "next_step",
             "recommended_contact",
             "warning",
         ],
     )
+    console.print()
+    console.print("[bold]Coordination checklist[/bold]")
+    for item in result["coordination_checklist"]:
+        console.print(f"  {item}")
+    console.print()
+    console.print("[bold]Command examples[/bold]")
+    for row in rows[:5]:
+        console.print(f"  @{row['name']}: {row['handoff_command']}")
+        if row.get("listener_status") == "no_reply" or row.get("contact_mode") != "event_listener":
+            console.print(f"    fallback: {row['task_command']}")
 
 
 @app.command("create")

--- a/tests/test_agents_commands.py
+++ b/tests/test_agents_commands.py
@@ -207,8 +207,19 @@ def test_agents_discover_infers_roles_without_ping(monkeypatch):
     assert rows["supervisor_sentinel"]["mesh_role"] == "supervisor_candidate"
     assert rows["supervisor_sentinel"]["contact_mode"] == "unknown"
     assert rows["supervisor_sentinel"]["warning"] == "supervisor_candidate_not_live"
+    assert rows["supervisor_sentinel"]["next_step"] == "ping_before_handoff"
+    assert rows["supervisor_sentinel"]["commands"]["handoff"].startswith("axctl handoff @supervisor_sentinel")
+    assert rows["supervisor_sentinel"]["commands"]["handoff"].endswith("--space-id space-1")
+    assert rows["supervisor_sentinel"]["task_command"] == (
+        "axctl tasks create 'Follow-up for @supervisor_sentinel' "
+        "--assign-to @supervisor_sentinel --priority high --space-id space-1"
+    )
+    assert "axctl reminders add <task-id>" in rows["supervisor_sentinel"]["reminder_command"]
+    assert rows["supervisor_sentinel"]["reminder_command"].endswith("--space-id space-1")
     assert rows["aX"]["contact_mode"] == "space_agent"
     assert rows["night_owl"]["contact_mode"] == "on_demand"
+    assert data["summary"]["no_reply_or_stale"] == 1
+    assert any("Pick a live listener" in item for item in data["coordination_checklist"])
 
 
 def test_agents_discover_marks_control_blocked_agents_without_ping(monkeypatch):
@@ -247,6 +258,8 @@ def test_agents_discover_marks_control_blocked_agents_without_ping(monkeypatch):
     assert row["contact_mode"] == "blocked_by_control"
     assert row["recommended_contact"] == "reenable_before_contact"
     assert row["warning"] == "agent_control_blocks_delivery"
+    assert any("Blocked agents" in item for item in data["coordination_checklist"])
+    assert not any("No-reply fallback" in item for item in data["coordination_checklist"])
 
 
 def test_agents_discover_with_ping_classifies_listener(monkeypatch):
@@ -289,4 +302,10 @@ def test_agents_discover_with_ping_classifies_listener(monkeypatch):
     assert row["listener_status"] == "replied"
     assert row["contact_mode"] == "event_listener"
     assert row["recommended_contact"] == "handoff_or_send_wait"
+    assert row["next_step"] == "handoff_now"
+    assert row["commands"]["ping"] == "axctl agents ping @backend_sentinel --timeout 10 --space-id space-1"
+    assert any(
+        "Live-listener fast path" in item and "--space-id space-1" in item
+        for item in data["coordination_checklist"]
+    )
     assert calls["messages"][0]["content"].startswith("@backend_sentinel Contact-mode ping")


### PR DESCRIPTION
## Summary
- Adds actionable coordination metadata to `axctl agents discover`: next_step, no-reply/stale summary, command templates, and a concise checklist.
- Human output now shows next steps and per-agent handoff/task fallback examples.
- Covers live-listener and no-reply paths in tests.

## Validation
- `pytest -q` (224 passed)
- pre-commit hooks on commit: ruff check, ruff format, pytest hook passed
- local smoke: `PYTHONPATH=. python3 -c 'from ax_cli.main import main; main()' agents discover dev_sentinel supervisor_sentinel_dev --ping --timeout 3 --json`

## Coordination finding
- dev_sentinel and supervisor_sentinel_dev were pinged; neither replied within the smoke timeout, so the new output correctly surfaced no_reply_or_stale=2 and task/reminder fallback commands.