### PR TITLE
Add reminder pause/resume and grooming workflow

### DIFF
--- a/ax_cli/commands/reminders.py
+++ b/ax_cli/commands/reminders.py
@@ -33,6 +33,8 @@ from .alerts import (
 
 app = typer.Typer(name="reminders", help="Local task reminder policy runner", no_args_is_help=True)
 
+STALE_AFTER_DAYS = 7
+
 
 def _now() -> _dt.datetime:
     return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0)
@@ -144,32 +146,116 @@ def _find_policy(store: dict[str, Any], policy_id: str) -> dict[str, Any]:
     return matches[0]
 
 
-def _policy_sort_key(policy: dict[str, Any]) -> tuple:
-    """Priority queue order: priority asc (lower = higher), then next_fire asc, then id."""
+def _parse_optional_iso(value: Any) -> _dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return _parse_iso(value)
+    except Exception:
+        return None
+
+
+def _pause_until(first_at: str | None, minutes: int | None) -> str | None:
+    if first_at:
+        return _validate_timestamp(first_at, flag="--resume-at")
+    if minutes is not None:
+        if minutes < 1:
+            raise typer.BadParameter("--minutes must be at least 1")
+        return _iso(_now() + _dt.timedelta(minutes=minutes))
+    return None
+
+
+def _is_completed(policy: dict[str, Any]) -> bool:
+    try:
+        return int(policy.get("fired_count", 0)) >= int(policy.get("max_fires", 1))
+    except Exception:
+        return False
+
+
+def _is_paused(policy: dict[str, Any], *, now: _dt.datetime | None = None) -> bool:
+    if not policy.get("paused", False):
+        return False
+    resume_at = _parse_optional_iso(policy.get("resume_at") or policy.get("snooze_until"))
+    if now is not None and resume_at and resume_at <= now:
+        _resume_policy(policy, now=now, automatic=True)
+        return False
+    return True
+
+
+def _resume_policy(policy: dict[str, Any], *, now: _dt.datetime, automatic: bool = False) -> None:
+    policy["paused"] = False
+    policy["paused_reason"] = None
+    policy["resume_at"] = None
+    policy["snooze_until"] = None
+    policy["resumed_at"] = _iso(now)
+    policy["resumed_by"] = "auto_resume_at" if automatic else "operator"
+    policy["updated_at"] = _iso(now)
+
+
+def _policy_state(policy: dict[str, Any], *, now: _dt.datetime) -> str:
+    if _is_paused(policy, now=now):
+        return "paused"
+    if _is_completed(policy):
+        return "completed"
+    if not policy.get("enabled", True):
+        return "disabled"
+    next_fire = _parse_optional_iso(policy.get("next_fire_at"))
+    if next_fire and next_fire < now - _dt.timedelta(days=STALE_AFTER_DAYS):
+        return "stale"
+    if next_fire and next_fire <= now:
+        return "due"
+    return "active"
+
+
+def _policy_sort_key(policy: dict[str, Any], *, now: _dt.datetime | None = None) -> tuple[int, int, _dt.datetime, str]:
+    state_rank = {"due": 0, "active": 1, "paused": 2, "stale": 3, "disabled": 4, "completed": 5}
+    now = now or _now()
+    state = _policy_state(policy, now=now)
     priority = int(policy.get("priority", _DEFAULT_PRIORITY))
-    next_fire = str(policy.get("next_fire_at") or "")
-    pol_id = str(policy.get("id") or "")
-    return (priority, next_fire, pol_id)
+    next_fire = _parse_optional_iso(policy.get("next_fire_at")) or _dt.datetime.max.replace(tzinfo=_dt.timezone.utc)
+    if state == "paused":
+        next_fire = _parse_optional_iso(policy.get("resume_at") or policy.get("snooze_until")) or next_fire
+    return (state_rank.get(state, 99), priority, next_fire, str(policy.get("id") or ""))
 
 
-def _policy_rows(store: dict[str, Any]) -> list[dict[str, Any]]:
+def _grouped_policy_payload(store: dict[str, Any], *, now: _dt.datetime) -> dict[str, Any]:
+    policies = [p for p in store.get("policies", []) if isinstance(p, dict)]
+    ordered = sorted(policies, key=lambda p: _policy_sort_key(p, now=now))
+    groups: dict[str, list[dict[str, Any]]] = {
+        "due": [],
+        "active": [],
+        "paused": [],
+        "disabled": [],
+        "completed": [],
+        "stale": [],
+    }
+    for policy in ordered:
+        state = _policy_state(policy, now=now)
+        view = dict(policy)
+        view["state"] = state
+        groups.setdefault(state, []).append(view)
+    return {"policies": ordered, "groups": groups, "summary": {k: len(v) for k, v in groups.items()}}
+
+
+def _policy_rows(store: dict[str, Any], *, now: _dt.datetime | None = None) -> list[dict[str, Any]]:
     rows = []
-    sorted_policies = sorted(
-        (p for p in store.get("policies", []) if isinstance(p, dict)),
-        key=_policy_sort_key,
-    )
-    for policy in sorted_policies:
+    now = now or _now()
+    policies = [p for p in store.get("policies", []) if isinstance(p, dict)]
+    for policy in sorted(policies, key=lambda p: _policy_sort_key(p, now=now)):
+        state = _policy_state(policy, now=now)
         rows.append(
             {
                 "id": policy.get("id", ""),
+                "state": state,
                 "priority": int(policy.get("priority", _DEFAULT_PRIORITY)),
                 "mode": str(policy.get("mode", "auto")),
                 "enabled": policy.get("enabled", True),
                 "task": policy.get("source_task_id", ""),
                 "target": policy.get("target") or "(task default)",
                 "next_fire": policy.get("next_fire_at", ""),
+                "resume_at": policy.get("resume_at") or policy.get("snooze_until") or "",
                 "fires": f"{policy.get('fired_count', 0)}/{policy.get('max_fires', '-')}",
-                "reason": policy.get("reason", ""),
+                "reason": policy.get("paused_reason") if state == "paused" else policy.get("reason", ""),
             }
         )
     return rows
@@ -269,17 +355,34 @@ def list_policies(
     """List local reminder policies."""
     path = _policy_file(policy_file)
     store = _load_store(path)
+    now = _now()
+    payload = _grouped_policy_payload(store, now=now)
     if as_json:
-        print_json({"file": str(path), "policies": store.get("policies", [])})
+        print_json({"file": str(path), **payload})
         return
-    rows = _policy_rows(store)
+    rows = _policy_rows(store, now=now)
     if not rows:
         console.print(f"No reminder policies in {path}")
         return
+    console.print(
+        "Reminder policy groups: " + ", ".join(f"{key}={value}" for key, value in payload["summary"].items() if value)
+    )
     print_table(
-        ["ID", "Pri", "Mode", "Enabled", "Task", "Target", "Next Fire", "Fires", "Reason"],
+        ["ID", "Pri", "Mode", "State", "Enabled", "Task", "Target", "Next Fire", "Resume At", "Fires", "Reason"],
         rows,
-        keys=["id", "priority", "mode", "enabled", "task", "target", "next_fire", "fires", "reason"],
+        keys=[
+            "id",
+            "priority",
+            "mode",
+            "state",
+            "enabled",
+            "task",
+            "target",
+            "next_fire",
+            "resume_at",
+            "fires",
+            "reason",
+        ],
     )
 
 
@@ -302,10 +405,201 @@ def disable(
     console.print(f"Disabled reminder policy {policy['id']}")
 
 
+@app.command("pause")
+def pause(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    reason: str = typer.Option("Paused by operator.", "--reason", "-r", help="Why this reminder is not actionable"),
+    resume_at: Optional[str] = typer.Option(None, "--resume-at", help="Optional ISO-8601 auto-resume time"),
+    minutes: Optional[int] = typer.Option(None, "--minutes", help="Snooze/pause for N minutes"),
+    paused_by: Optional[str] = typer.Option(None, "--paused-by", help="Operator or agent pausing the policy"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Pause a reminder without permanently disabling it."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    policy = _find_policy(store, policy_id)
+    now = _now()
+    until = _pause_until(resume_at, minutes)
+    policy["paused"] = True
+    policy["paused_reason"] = reason
+    policy["paused_by"] = paused_by or "operator"
+    policy["paused_at"] = _iso(now)
+    policy["resume_at"] = until
+    policy["snooze_until"] = until
+    policy["updated_at"] = _iso(now)
+    _save_store(path, store)
+    if as_json:
+        print_json({"policy": policy, "file": str(path), "state": "paused"})
+        return
+    console.print(f"Paused reminder policy {policy['id']}")
+
+
+@app.command("snooze")
+def snooze(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    minutes: int = typer.Option(30, "--minutes", "-m", help="Minutes to pause before auto-resume"),
+    reason: str = typer.Option("Snoozed by operator.", "--reason", "-r", help="Why this reminder is being snoozed"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Temporarily pause a reminder until a future time."""
+    pause(
+        policy_id,
+        reason=reason,
+        resume_at=None,
+        minutes=minutes,
+        paused_by="operator",
+        policy_file=policy_file,
+        as_json=as_json,
+    )
+
+
+@app.command("resume")
+def resume(
+    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
+    fire_in: int = typer.Option(0, "--fire-in-minutes", help="Set next fire to N minutes from now on resume"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Resume a paused reminder policy."""
+    if fire_in < 0:
+        raise typer.BadParameter("--fire-in-minutes cannot be negative")
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    policy = _find_policy(store, policy_id)
+    if int(policy.get("fired_count", 0)) >= int(policy.get("max_fires", 1)):
+        typer.echo(f"Error: policy {policy['id']} has reached max_fires; create a new policy", err=True)
+        raise typer.Exit(1)
+    disabled_reason = str(policy.get("disabled_reason") or "")
+    if disabled_reason.startswith("source task"):
+        typer.echo(f"Error: source task is terminal; refusing to resume {policy['id']}", err=True)
+        raise typer.Exit(1)
+    now = _now()
+    _resume_policy(policy, now=now)
+    policy["enabled"] = True
+    policy["next_fire_at"] = _iso(now + _dt.timedelta(minutes=fire_in))
+    _save_store(path, store)
+    if as_json:
+        print_json({"policy": policy, "file": str(path), "state": _policy_state(policy, now=now)})
+        return
+    console.print(f"Resumed reminder policy {policy['id']}")
+
+
+def _groom_report(store: dict[str, Any], *, now: _dt.datetime, check_tasks: bool) -> dict[str, Any]:
+    client = get_client() if check_tasks else None
+    items = []
+    for policy in [p for p in store.get("policies", []) if isinstance(p, dict)]:
+        reasons: list[str] = []
+        state = _policy_state(policy, now=now)
+        if state in {"disabled", "completed"}:
+            reasons.append(f"state:{state}")
+        next_fire = _parse_optional_iso(policy.get("next_fire_at"))
+        if policy.get("next_fire_at") and not next_fire:
+            reasons.append("invalid_next_fire_at")
+        elif (
+            next_fire
+            and next_fire < now - _dt.timedelta(days=STALE_AFTER_DAYS)
+            and state not in {"disabled", "completed"}
+        ):
+            reasons.append("stale_next_fire_at")
+        if policy.get("paused") and not policy.get("paused_reason"):
+            reasons.append("paused_without_reason")
+        source_task = str(policy.get("source_task_id") or "")
+        if check_tasks and source_task and client is not None:
+            lifecycle = _task_lifecycle(client, source_task)
+            if lifecycle and lifecycle.get("is_terminal"):
+                reasons.append(f"source_task_terminal:{lifecycle.get('status')}")
+            elif lifecycle is None:
+                reasons.append("source_task_unresolved")
+        elif not source_task:
+            reasons.append("no_source_task")
+        recommendation = "keep"
+        if any(r.startswith("source_task_terminal") for r in reasons) or state == "completed":
+            recommendation = "disable_or_remove_completed"
+        elif state == "paused":
+            recommendation = "resume_when_actionable_or_disable_if_junk"
+        elif "stale_next_fire_at" in reasons or "source_task_unresolved" in reasons:
+            recommendation = "review_stale_or_orphaned"
+        elif state == "disabled":
+            recommendation = "remove_if_no_longer_needed"
+        if reasons:
+            items.append(
+                {
+                    "policy_id": policy.get("id"),
+                    "state": state,
+                    "source_task_id": source_task,
+                    "reasons": reasons,
+                    "recommendation": recommendation,
+                }
+            )
+    return {
+        "summary": {
+            "checked": len([p for p in store.get("policies", []) if isinstance(p, dict)]),
+            "needs_attention": len(items),
+        },
+        "items": items,
+        "hygiene": [
+            "Close or disable reminders for completed work.",
+            "Pause blocked/noisy reminders with a reason and resume_at when possible.",
+            "Resume reminders when work is actionable again; keep next_fire_at near the next useful check-in.",
+            "Use list groups to groom due, paused, disabled, completed, and stale reminders regularly.",
+        ],
+    }
+
+
+@app.command("groom")
+def groom(
+    check_tasks: bool = typer.Option(
+        True, "--check-tasks/--no-check-tasks", help="Fetch source tasks to identify terminal/orphaned reminders"
+    ),
+    apply: bool = typer.Option(False, "--apply", help="Disable completed/source-terminal reminder policies"),
+    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
+    as_json: bool = JSON_OPTION,
+) -> None:
+    """Report noisy, stale, completed, or orphaned reminder policies."""
+    path = _policy_file(policy_file)
+    store = _load_store(path)
+    now = _now()
+    report = _groom_report(store, now=now, check_tasks=check_tasks)
+    changed: list[str] = []
+    if apply:
+        attention = {item["policy_id"]: item for item in report["items"]}
+        for policy in [p for p in store.get("policies", []) if isinstance(p, dict)]:
+            item = attention.get(policy.get("id"))
+            if not item:
+                continue
+            if item["recommendation"] == "disable_or_remove_completed":
+                policy["enabled"] = False
+                policy["paused"] = False
+                policy["disabled_reason"] = ",".join(item["reasons"])
+                policy["updated_at"] = _iso(now)
+                changed.append(str(policy.get("id")))
+        if changed:
+            _save_store(path, store)
+    report["file"] = str(path)
+    report["changed"] = changed
+    if as_json:
+        print_json(report)
+        return
+    console.print(
+        f"Reminder grooming: {report['summary']['needs_attention']} need attention / {report['summary']['checked']} checked"
+    )
+    if report["items"]:
+        print_table(
+            ["Policy", "State", "Task", "Reasons", "Recommendation"],
+            report["items"],
+            keys=["policy_id", "state", "source_task_id", "reasons", "recommendation"],
+        )
+    console.print("Hygiene:")
+    for item in report["hygiene"]:
+        console.print(f"  - {item}")
+
+
 def _build_fire_payload(client: Any, policy: dict[str, Any], *, now: _dt.datetime) -> dict[str, Any] | None:
     """Build target/reason/content/metadata for a due policy.
 
-    Returns None if the policy must be skipped (e.g. source task is terminal —
+    Returns None if the policy must be skipped (e.g. source task is terminal -
     side-effect: marks the policy disabled). Otherwise returns a dict with
     keys: target, target_resolved_from, content, metadata, channel.
     """
@@ -513,6 +807,8 @@ def _due_policies(store: dict[str, Any], *, now: _dt.datetime, include_manual: b
             continue
         if not include_manual and str(policy.get("mode", "auto")) == "manual":
             continue
+        if _is_paused(policy, now=now):
+            continue
         if int(policy.get("fired_count", 0)) >= int(policy.get("max_fires", 1)):
             policy["enabled"] = False
             policy["updated_at"] = _iso(now)
@@ -530,7 +826,7 @@ def _due_policies(store: dict[str, Any], *, now: _dt.datetime, include_manual: b
                 continue
             policy["_current_fire_key"] = fire_key
             due.append(policy)
-    due.sort(key=_policy_sort_key)
+    due.sort(key=lambda policy: _policy_sort_key(policy, now=now))
     return due
 
 
@@ -765,58 +1061,7 @@ def status(
         console.print("Next: (no enabled policies)")
 
 
-# ---- Operator commands: pause / resume / cancel / update -------------------
-
-
-@app.command("pause")
-def pause(
-    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
-    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
-    as_json: bool = JSON_OPTION,
-) -> None:
-    """Pause a reminder policy. Use ``resume`` to re-enable."""
-    path = _policy_file(policy_file)
-    store = _load_store(path)
-    policy = _find_policy(store, policy_id)
-    policy["enabled"] = False
-    policy["disabled_reason"] = "paused"
-    policy["updated_at"] = _iso(_now())
-    _save_store(path, store)
-    if as_json:
-        print_json({"policy": policy, "file": str(path)})
-        return
-    console.print(f"Paused reminder policy {policy['id']}")
-
-
-@app.command("resume")
-def resume(
-    policy_id: str = typer.Argument(..., help="Policy ID or unique prefix"),
-    policy_file: Optional[str] = typer.Option(None, "--file", help="Reminder policy JSON file"),
-    as_json: bool = JSON_OPTION,
-) -> None:
-    """Resume a paused reminder policy.
-
-    Refuses to resume policies that finished (max_fires reached) or were
-    auto-disabled because the source task is terminal.
-    """
-    path = _policy_file(policy_file)
-    store = _load_store(path)
-    policy = _find_policy(store, policy_id)
-    if int(policy.get("fired_count", 0)) >= int(policy.get("max_fires", 1)):
-        typer.echo(f"Error: policy {policy['id']} has reached max_fires; create a new policy", err=True)
-        raise typer.Exit(1)
-    disabled_reason = str(policy.get("disabled_reason") or "")
-    if disabled_reason.startswith("source task"):
-        typer.echo(f"Error: source task is terminal; refusing to resume {policy['id']}", err=True)
-        raise typer.Exit(1)
-    policy["enabled"] = True
-    policy.pop("disabled_reason", None)
-    policy["updated_at"] = _iso(_now())
-    _save_store(path, store)
-    if as_json:
-        print_json({"policy": policy, "file": str(path)})
-        return
-    console.print(f"Resumed reminder policy {policy['id']}")
+# ---- Operator commands: cancel / update ------------------------------------
 
 
 @app.command("cancel")

--- a/docs/reminder-lifecycle.md
+++ b/docs/reminder-lifecycle.md
@@ -83,3 +83,31 @@ See `tests/test_reminders_commands.py`:
 ## Change log
 
 - 2026-04-16 — Initial contract (@orion). Ships with tests + `_task_lifecycle` helper in `alerts.py`. Picks up source task status on every `_fire_policy` call; one extra GET per due policy (cost acceptable for local dogfood loop).
+
+
+## Pause/resume and grooming workflow (2026-04-27)
+
+Reminder policies now have a reversible pause state separate from permanent disable:
+
+- `axctl reminders pause <policy-id> --reason "blocked/noisy" [--resume-at ISO | --minutes N]`
+- `axctl reminders snooze <policy-id> --minutes N --reason "waiting for owner"`
+- `axctl reminders resume <policy-id> [--fire-in-minutes N]`
+- `axctl reminders groom [--apply]` reports stale/noisy/completed/orphaned policies and can disable completed/source-terminal reminders.
+
+Pause metadata is stored on the local policy as `paused`, `paused_reason`, `paused_by`, `paused_at`, `resume_at`, and `snooze_until`. The runner skips paused policies. If `resume_at`/`snooze_until` has passed, the runner auto-resumes the policy before checking whether it is due.
+
+`axctl reminders list --json` remains parse-safe and now includes:
+
+- top-level `policies`: the sorted policy list for backwards-compatible automation
+- `groups`: policies grouped into `due`, `active`, `paused`, `disabled`, `completed`, and `stale`
+- `summary`: counts by group
+
+### Agile reminder hygiene
+
+1. **Continue useful work:** keep active reminders only for tasks that still need a response or check-in.
+2. **Close/disable completed work:** terminal source tasks are skipped by the runner and should be disabled/removed during grooming.
+3. **Pause blocked/noisy work:** use pause/snooze with a clear reason instead of permanently disabling when work may become actionable again.
+4. **Resume when actionable:** set `resume_at`/`snooze_until` when possible; otherwise run `axctl reminders resume` when the blocker clears.
+5. **Groom regularly:** review `due`, `paused`, `disabled`, `completed`, and `stale` groups so junk reminders do not crowd out current work.
+
+`groom --apply` is intentionally conservative: it only disables reminders that are already completed by max-fires or whose source task resolves as terminal. Stale/orphaned/no-source reminders are reported for human review rather than silently deleted.

--- a/tests/test_reminders_commands.py
+++ b/tests/test_reminders_commands.py
@@ -525,3 +525,223 @@ def test_run_once_pending_review_falls_back_to_creator_when_no_owner(monkeypatch
     assert sent["content"].startswith("@chatgpt Reminder:"), "falls back to creator"
     metadata = sent["metadata"]
     assert metadata["reminder_policy"]["target_resolved_from"] == "creator_fallback"
+
+
+def test_pause_skips_due_policy_and_resume_reactivates(monkeypatch, tmp_path):
+    fake = _FakeClient()
+    _install_fake_runtime(monkeypatch, fake)
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "policies": [
+                    {
+                        "id": "rem-pause",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-1",
+                        "reason": "review task state",
+                        "target": "demo-agent",
+                        "severity": "info",
+                        "cadence_seconds": 300,
+                        "next_fire_at": "2026-04-16T00:00:00Z",
+                        "max_fires": 2,
+                        "fired_count": 0,
+                        "fired_keys": [],
+                    }
+                ],
+            }
+        )
+    )
+
+    pause_result = runner.invoke(
+        app,
+        [
+            "reminders",
+            "pause",
+            "rem-pause",
+            "--reason",
+            "blocked until review",
+            "--paused-by",
+            "cli_sentinel",
+            "--file",
+            str(policy_file),
+            "--json",
+        ],
+    )
+    assert pause_result.exit_code == 0, pause_result.output
+    stored = _load(policy_file)["policies"][0]
+    assert stored["paused"] is True
+    assert stored["paused_reason"] == "blocked until review"
+    assert stored["paused_by"] == "cli_sentinel"
+
+    run_result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    assert run_result.exit_code == 0, run_result.output
+    assert fake.sent == []
+    assert _load(policy_file)["policies"][0]["fired_count"] == 0
+
+    resume_result = runner.invoke(
+        app,
+        ["reminders", "resume", "rem-pause", "--fire-in-minutes", "0", "--file", str(policy_file), "--json"],
+    )
+    assert resume_result.exit_code == 0, resume_result.output
+    resumed = _load(policy_file)["policies"][0]
+    assert resumed["paused"] is False
+    assert resumed["enabled"] is True
+    assert resumed["resume_at"] is None
+
+    fired_result = runner.invoke(app, ["reminders", "run", "--once", "--file", str(policy_file), "--json"])
+    assert fired_result.exit_code == 0, fired_result.output
+    assert len(fake.sent) == 1
+
+
+def test_resume_refuses_completed_or_terminal_disabled_policy(tmp_path):
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "policies": [
+                    {
+                        "id": "rem-complete",
+                        "enabled": False,
+                        "source_task_id": "task-1",
+                        "next_fire_at": "2026-04-16T00:00:00Z",
+                        "max_fires": 1,
+                        "fired_count": 1,
+                    },
+                    {
+                        "id": "rem-terminal",
+                        "enabled": False,
+                        "source_task_id": "task-done",
+                        "next_fire_at": "2026-04-16T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                        "disabled_reason": "source task task-done is completed",
+                    },
+                ],
+            }
+        )
+    )
+
+    complete = runner.invoke(app, ["reminders", "resume", "rem-complete", "--file", str(policy_file), "--json"])
+    assert complete.exit_code == 1
+    assert "has reached max_fires" in complete.output
+
+    terminal = runner.invoke(app, ["reminders", "resume", "rem-terminal", "--file", str(policy_file), "--json"])
+    assert terminal.exit_code == 1
+    assert "source task is terminal" in terminal.output
+
+
+def test_list_json_groups_policies_by_operational_state(tmp_path):
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "policies": [
+                    {
+                        "id": "rem-due",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-1",
+                        "next_fire_at": "2026-04-27T06:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                    },
+                    {
+                        "id": "rem-paused",
+                        "enabled": True,
+                        "paused": True,
+                        "paused_reason": "too noisy",
+                        "resume_at": "2999-01-01T00:00:00Z",
+                        "source_task_id": "task-2",
+                        "next_fire_at": "2026-04-27T06:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                    },
+                    {
+                        "id": "rem-disabled",
+                        "enabled": False,
+                        "source_task_id": "task-3",
+                        "next_fire_at": "2999-01-01T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                    },
+                    {
+                        "id": "rem-complete",
+                        "enabled": False,
+                        "source_task_id": "task-4",
+                        "next_fire_at": "2999-01-01T00:00:00Z",
+                        "max_fires": 1,
+                        "fired_count": 1,
+                    },
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(app, ["reminders", "list", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [p["id"] for p in payload["groups"]["paused"]] == ["rem-paused"]
+    assert [p["id"] for p in payload["groups"]["disabled"]] == ["rem-disabled"]
+    assert [p["id"] for p in payload["groups"]["completed"]] == ["rem-complete"]
+    assert "summary" in payload
+    assert payload["policies"][0]["id"] in {"rem-due", "rem-paused", "rem-disabled", "rem-complete"}
+
+
+def test_groom_reports_terminal_source_task_and_apply_disables(monkeypatch, tmp_path):
+    _install_task_aware_client(
+        monkeypatch,
+        {
+            "/tasks/task-done": {
+                "task": {
+                    "id": "task-done",
+                    "title": "Already shipped",
+                    "status": "completed",
+                    "assignee_id": "agent-demo-agent",
+                }
+            },
+            "/agents/agent-demo-agent": {"agent": {"id": "agent-demo-agent", "name": "demo-agent"}},
+        },
+    )
+    policy_file = tmp_path / "reminders.json"
+    policy_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "policies": [
+                    {
+                        "id": "rem-groom",
+                        "enabled": True,
+                        "space_id": "space-abc",
+                        "source_task_id": "task-done",
+                        "reason": "finished work",
+                        "target": "demo-agent",
+                        "cadence_seconds": 300,
+                        "next_fire_at": "2999-01-01T00:00:00Z",
+                        "max_fires": 5,
+                        "fired_count": 0,
+                        "fired_keys": [],
+                    }
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(app, ["reminders", "groom", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["summary"]["needs_attention"] == 1
+    assert report["items"][0]["reasons"] == ["source_task_terminal:completed"]
+    assert report["items"][0]["recommendation"] == "disable_or_remove_completed"
+    assert any("Pause blocked/noisy" in item for item in report["hygiene"])
+
+    apply_result = runner.invoke(app, ["reminders", "groom", "--apply", "--file", str(policy_file), "--json"])
+    assert apply_result.exit_code == 0, apply_result.output
+    assert json.loads(apply_result.output)["changed"] == ["rem-groom"]
+    stored = _load(policy_file)["policies"][0]
+    assert stored["enabled"] is False
+    assert stored["disabled_reason"] == "source_task_terminal:completed"

--- a/tests/test_task_loop_modes.py
+++ b/tests/test_task_loop_modes.py
@@ -387,15 +387,16 @@ def test_pause_resume_cycle(monkeypatch, tmp_path):
     result = runner.invoke(app, ["reminders", "pause", "rem-pause", "--file", str(policy_file), "--json"])
     assert result.exit_code == 0, result.output
     policy = _load(policy_file)["policies"][0]
-    assert policy["enabled"] is False
-    assert policy["disabled_reason"] == "paused"
+    assert policy["enabled"] is True
+    assert policy["paused"] is True
+    assert policy["paused_reason"] == "Paused by operator."
 
     # Resume
     result = runner.invoke(app, ["reminders", "resume", "rem-pause", "--file", str(policy_file), "--json"])
     assert result.exit_code == 0, result.output
     policy = _load(policy_file)["policies"][0]
     assert policy["enabled"] is True
-    assert "disabled_reason" not in policy
+    assert policy["paused"] is False
 
 
 def test_update_priority_reorders_queue(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Adds reversible reminder pause/snooze/resume commands with pause metadata, reason, paused_by, paused_at, resume_at/snooze_until.
- Groups reminder list JSON/human output by due, active, paused, disabled, completed, and stale while keeping top-level policies parse-safe.
- Updates runner behavior to skip paused policies and adds conservative grooming report/apply for stale, noisy, orphaned, and completed/source-terminal reminders.
- Documents agile reminder hygiene in docs/reminder-lifecycle.md.

## Validation
- pytest -q (227 passed)
- pre-commit hooks on commit: ruff check, ruff format, pytest hook passed
- smoke: PYTHONPATH=. python3 -c 'from ax_cli.main import main; main()' reminders --help
