### PR TITLE
Fix task space targeting by slug

### DIFF
--- a/ax_cli/commands/tasks.py
+++ b/ax_cli/commands/tasks.py
@@ -11,6 +11,7 @@ from ..config import get_client, resolve_space_id
 from ..output import JSON_OPTION, console, handle_error, mention_prefix, print_json, print_kv, print_table
 
 app = typer.Typer(name="tasks", help="Task operations", no_args_is_help=True)
+SPACE_OPTION = typer.Option(None, "--space", "--space-id", "-s", help="Target space id, slug, or name")
 
 
 def _agent_items(result: object) -> list[dict]:
@@ -32,6 +33,48 @@ def _agent_names(agent: dict) -> set[str]:
         if isinstance(value, str) and value.strip():
             names.add(value.strip().lower().removeprefix("@"))
     return names
+
+
+def _space_items(result: object) -> list[dict]:
+    if isinstance(result, list):
+        return [item for item in result if isinstance(item, dict)]
+    if not isinstance(result, dict):
+        return []
+    for key in ("spaces", "items", "results"):
+        items = result.get(key)
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    return []
+
+
+def _space_summary(client, space_id: str) -> dict[str, str]:
+    try:
+        spaces = _space_items(client.list_spaces())
+    except Exception:
+        return {"id": space_id, "label": space_id}
+
+    for space in spaces:
+        sid = str(space.get("id") or space.get("space_id") or "")
+        if sid == space_id:
+            slug = space.get("slug")
+            name = space.get("name")
+            label = str(slug or name or sid)
+            result = {"id": sid, "label": label}
+            if slug:
+                result["slug"] = str(slug)
+            if name:
+                result["name"] = str(name)
+            return result
+    return {"id": space_id, "label": space_id}
+
+
+def _annotate_task_space(task: dict[str, Any], space: dict[str, str]) -> dict[str, Any]:
+    task.setdefault("space_id", space["id"])
+    if space.get("slug"):
+        task.setdefault("space_slug", space["slug"])
+    if space.get("name"):
+        task.setdefault("space_name", space["name"])
+    return task
 
 
 def _resolve_assignee_id(client, assignee: str | None, *, space_id: str) -> str | None:
@@ -173,12 +216,13 @@ def create(
         True, "--notify/--no-notify", help="Send a message notifying the team about the new task"
     ),
     mention: Optional[str] = typer.Option(None, "--mention", help="@mention a user or agent in the task notification"),
-    space_id: Optional[str] = typer.Option(None, "--space-id", help="Override default space"),
+    space: Optional[str] = SPACE_OPTION,
     as_json: bool = JSON_OPTION,
 ):
     """Create a task and optionally notify the team."""
     client = get_client()
-    sid = resolve_space_id(client, explicit=space_id)
+    sid = resolve_space_id(client, explicit=space)
+    space_info = _space_summary(client, sid)
     assignee_id = _resolve_assignee_id(client, assign_to, space_id=sid)
     try:
         data = client.create_task(
@@ -191,11 +235,16 @@ def create(
     except httpx.HTTPStatusError as e:
         handle_error(e)
     task = data.get("task", data)
+    if isinstance(task, dict):
+        task = _annotate_task_space(task, space_info)
     tid = str(task.get("id", ""))[:8]
     if as_json:
         print_json(task)
     else:
-        console.print(f'[green]Created:[/green] "{task.get("title")}" (id={tid}…, priority={task.get("priority")})')
+        console.print(
+            f'[green]Created:[/green] "{task.get("title")}" '
+            f"(id={tid}…, priority={task.get('priority')}) in {space_info['label']} ({sid})"
+        )
 
     if notify:
         try:
@@ -227,20 +276,26 @@ def create(
 @app.command("list")
 def list_tasks(
     limit: int = typer.Option(20, "--limit", help="Max tasks to return"),
-    space_id: Optional[str] = typer.Option(None, "--space-id", help="Override default space"),
+    space: Optional[str] = SPACE_OPTION,
     as_json: bool = JSON_OPTION,
 ):
     """List tasks."""
     client = get_client()
-    sid = resolve_space_id(client, explicit=space_id)
+    sid = resolve_space_id(client, explicit=space)
+    space_info = _space_summary(client, sid)
     try:
         data = client.list_tasks(limit=limit, space_id=sid)
     except httpx.HTTPStatusError as e:
         handle_error(e)
     tasks = data if isinstance(data, list) else data.get("tasks", [])
     if as_json:
+        if isinstance(tasks, list):
+            for task in tasks:
+                if isinstance(task, dict):
+                    _annotate_task_space(task, space_info)
         print_json(tasks)
     else:
+        console.print(f"[dim]Space: {space_info['label']} ({sid})[/dim]")
         print_table(
             ["ID", "Title", "Status", "Priority"],
             tasks,

--- a/ax_cli/config.py
+++ b/ax_cli/config.py
@@ -13,6 +13,7 @@ import re
 import tomllib  # stdlib 3.11+
 from pathlib import Path
 from urllib.parse import urlparse
+from uuid import UUID
 
 import typer
 
@@ -803,10 +804,77 @@ def resolve_agent_name(*, explicit: str | None = None, client: AxClient | None =
     return None
 
 
+def _space_items(result: object) -> list[dict]:
+    if isinstance(result, list):
+        return [item for item in result if isinstance(item, dict)]
+    if not isinstance(result, dict):
+        return []
+    for key in ("spaces", "items", "results"):
+        items = result.get(key)
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    return []
+
+
+def _space_lookup_key(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    normalized = re.sub(r"[\s_]+", "-", normalized)
+    return re.sub(r"-+", "-", normalized).strip("-")
+
+
+def _is_uuid_like(value: str) -> bool:
+    try:
+        UUID(value)
+    except ValueError:
+        return False
+    return True
+
+
 def resolve_space_id(client: AxClient, *, explicit: str | None = None) -> str:
     """Resolve space: explicit > env > config > bound agent default > auto-detect."""
     if explicit:
-        return explicit
+        ref = explicit.strip()
+        if not ref:
+            typer.echo("Error: Empty space value. Use a space id, slug, or name.", err=True)
+            raise typer.Exit(1)
+        if _is_uuid_like(ref):
+            return ref
+
+        spaces = _space_items(client.list_spaces())
+        needle = _space_lookup_key(ref)
+        matches = []
+        for space in spaces:
+            values = (
+                space.get("id"),
+                space.get("space_id"),
+                space.get("slug"),
+                space.get("name"),
+            )
+            if any(_space_lookup_key(value) == needle for value in values if value):
+                matches.append(space)
+
+        if not matches:
+            typer.echo(
+                f"Error: No visible space matched '{explicit}'. Use a space UUID or run `axctl spaces list`.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        if len(matches) > 1:
+            candidates = ", ".join(
+                str(space.get("slug") or space.get("name") or space.get("id") or space.get("space_id"))
+                for space in matches[:5]
+            )
+            typer.echo(
+                f"Error: Space '{explicit}' matched multiple spaces ({candidates}). Use the space UUID.",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+        space_id = matches[0].get("id") or matches[0].get("space_id")
+        if not space_id:
+            typer.echo(f"Error: Matched space '{explicit}' did not include an id.", err=True)
+            raise typer.Exit(1)
+        return str(space_id)
     env = os.environ.get("AX_SPACE_ID")
     if env:
         return env
@@ -825,14 +893,14 @@ def resolve_space_id(client: AxClient, *, explicit: str | None = None) -> str:
 
     # Fallback: auto-detect from user's spaces
     spaces = client.list_spaces()
-    space_list = spaces if isinstance(spaces, list) else spaces.get("spaces", [])
+    space_list = _space_items(spaces)
     if len(space_list) == 1:
         return str(space_list[0].get("id", space_list[0].get("space_id")))
     if len(space_list) == 0:
         typer.echo("Error: No spaces found for this user.", err=True)
         raise typer.Exit(1)
     typer.echo(
-        "Error: Multiple spaces found. Use --space-id or set AX_SPACE_ID.",
+        "Error: Multiple spaces found. Use --space/--space-id or set AX_SPACE_ID.",
         err=True,
     )
     raise typer.Exit(1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+import pytest
+from click.exceptions import Exit
+
 from ax_cli import config as config_module
 from ax_cli.config import (
     _find_project_root,
@@ -12,6 +15,7 @@ from ax_cli.config import (
     resolve_agent_id,
     resolve_agent_name,
     resolve_base_url,
+    resolve_space_id,
     resolve_token,
     resolve_user_base_url,
     resolve_user_token,
@@ -196,9 +200,7 @@ class TestLoadConfig:
         assert cfg["principal_type"] == "agent"
         assert cfg["agent_name"] == "orion"
 
-    def test_unsafe_local_user_pat_agent_config_does_not_override_active_profile(
-        self, tmp_path, monkeypatch, capsys
-    ):
+    def test_unsafe_local_user_pat_agent_config_does_not_override_active_profile(self, tmp_path, monkeypatch, capsys):
         global_dir = tmp_path / "global"
         global_dir.mkdir()
         monkeypatch.setenv("AX_CONFIG_DIR", str(global_dir))
@@ -487,6 +489,57 @@ class TestResolveAgentName:
     def test_returns_none_when_not_set(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         assert resolve_agent_name() is None
+
+
+class TestResolveSpaceId:
+    def test_explicit_uuid_returns_without_listing_spaces(self):
+        class FakeClient:
+            def list_spaces(self):
+                raise AssertionError("UUID space refs should not require list_spaces")
+
+        assert resolve_space_id(FakeClient(), explicit="ed81ae98-50cb-4268-b986-1b9fe76df742") == (
+            "ed81ae98-50cb-4268-b986-1b9fe76df742"
+        )
+
+    def test_explicit_slug_resolves_to_space_id(self, monkeypatch):
+        monkeypatch.delenv("AX_SPACE_ID", raising=False)
+
+        class FakeClient:
+            def list_spaces(self):
+                return {
+                    "spaces": [
+                        {"id": "private-space", "slug": "madtank-workspace", "name": "madtank's Workspace"},
+                        {"id": "team-space", "slug": "ax-cli-dev", "name": "ax-cli-dev"},
+                    ]
+                }
+
+        assert resolve_space_id(FakeClient(), explicit="ax-cli-dev") == "team-space"
+
+    def test_explicit_name_resolves_case_insensitively(self, monkeypatch):
+        monkeypatch.delenv("AX_SPACE_ID", raising=False)
+
+        class FakeClient:
+            def list_spaces(self):
+                return {"spaces": [{"id": "team-space", "slug": "ax-cli-dev", "name": "aX CLI Dev"}]}
+
+        assert resolve_space_id(FakeClient(), explicit="AX CLI DEV") == "team-space"
+
+    def test_explicit_space_ref_fails_when_ambiguous(self, monkeypatch, capsys):
+        monkeypatch.delenv("AX_SPACE_ID", raising=False)
+
+        class FakeClient:
+            def list_spaces(self):
+                return {
+                    "spaces": [
+                        {"id": "space-1", "slug": "team", "name": "Team"},
+                        {"id": "space-2", "slug": "other", "name": "Team"},
+                    ]
+                }
+
+        with pytest.raises(Exit):
+            resolve_space_id(FakeClient(), explicit="team")
+
+        assert "matched multiple spaces" in capsys.readouterr().err
 
 
 class TestResolveToken:

--- a/tests/test_tasks_commands.py
+++ b/tests/test_tasks_commands.py
@@ -1,3 +1,5 @@
+import json
+
 from typer.testing import CliRunner
 
 from ax_cli.main import app
@@ -39,6 +41,55 @@ def test_tasks_create_assign_accepts_agent_handle(monkeypatch):
     assert result.exit_code == 0, result.output
     assert calls["list_agents"] == {"space_id": "space-1", "limit": 500}
     assert calls["create_task"]["assignee_id"] == "agent-123"
+
+
+def test_tasks_create_accepts_space_slug(monkeypatch):
+    calls = {}
+
+    class FakeClient:
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": "private-space", "slug": "madtank-workspace", "name": "madtank's Workspace"},
+                    {"id": "team-space", "slug": "ax-cli-dev", "name": "ax-cli-dev"},
+                ]
+            }
+
+        def create_task(self, space_id, title, *, description=None, priority="medium", assignee_id=None):
+            calls["create_task"] = {"space_id": space_id, "title": title}
+            return {"task": {"id": "task-1", "title": title, "priority": priority}}
+
+    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+
+    result = runner.invoke(
+        app,
+        ["tasks", "create", "Fix routing", "--space", "ax-cli-dev", "--no-notify", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["create_task"]["space_id"] == "team-space"
+    payload = json.loads(result.output)
+    assert payload["space_id"] == "team-space"
+    assert payload["space_slug"] == "ax-cli-dev"
+
+
+def test_tasks_create_human_output_includes_resolved_space(monkeypatch):
+    class FakeClient:
+        def list_spaces(self):
+            return {"spaces": [{"id": "team-space", "slug": "ax-cli-dev", "name": "ax-cli-dev"}]}
+
+        def create_task(self, space_id, title, *, description=None, priority="medium", assignee_id=None):
+            return {"task": {"id": "task-1", "title": title, "priority": priority}}
+
+    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+
+    result = runner.invoke(
+        app,
+        ["tasks", "create", "Fix routing", "--space", "ax-cli-dev", "--no-notify"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "in ax-cli-dev (team-space)" in result.output
 
 
 def test_tasks_create_assign_to_accepts_uuid_without_agent_lookup(monkeypatch):


### PR DESCRIPTION
## Summary
- allow task commands to target spaces by visible slug/name via --space / --space-id / -s
- resolve explicit space refs before task create/list so --space ax-cli-dev maps to the correct UUID
- include the resolved target space in human and JSON task output to make accidental private-space writes obvious

## Validation
- uv run pytest tests/test_config.py tests/test_tasks_commands.py -q
- uv run ruff check ax_cli/config.py ax_cli/commands/tasks.py tests/test_config.py tests/test_tasks_commands.py
- uv run ruff format --check ax_cli/config.py ax_cli/commands/tasks.py tests/test_config.py tests/test_tasks_commands.py
- full test suite passed locally during pre-push; local package build step then failed because python3.12-venv/ensurepip is missing on this host