### PR TITLE
Preserve explicit mentions in agent replies

### DIFF
--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -23,6 +23,7 @@ import typer
 
 from .. import gateway as gateway_core
 from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..mentions import merge_explicit_mentions_metadata
 from ..output import JSON_OPTION, console, print_json
 from .listen import _is_self_authored, _iter_sse, _remember_reply_anchor, _should_respond, _strip_mention
 
@@ -817,7 +818,12 @@ class ChannelBridge:
 
             def _send_as_agent():
                 """Send using the agent_access JWT produced by the agent-bound PAT."""
-                return self.client.send_message(self.space_id, text, parent_id=reply_to)
+                metadata = merge_explicit_mentions_metadata(
+                    {"top_level_ingress": False, "routing": {"mode": "reply_target", "source": "channel_reply"}},
+                    text,
+                    exclude=[self.agent_name],
+                )
+                return self.client.send_message(self.space_id, text, parent_id=reply_to, metadata=metadata)
 
             data = await asyncio.to_thread(_send_as_agent)
             message = data.get("message", data)

--- a/ax_cli/mentions.py
+++ b/ax_cli/mentions.py
@@ -1,0 +1,60 @@
+"""Helpers for explicit aX handle mentions in message content."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+MENTION_RE = re.compile(r"(?<![\w/])@([A-Za-z0-9][A-Za-z0-9_-]{0,63})(?![\w-])")
+
+
+def extract_explicit_mentions(content: str, *, exclude: Iterable[str] = ()) -> list[str]:
+    """Return unique explicit @handles from user-visible message content."""
+    excluded = {item.lower().lstrip("@").strip() for item in exclude if item}
+    seen: set[str] = set()
+    mentions: list[str] = []
+    for match in MENTION_RE.finditer(content or ""):
+        handle = match.group(1).strip()
+        key = handle.lower()
+        if not handle or key in excluded or key in seen:
+            continue
+        seen.add(key)
+        mentions.append(handle)
+    return mentions
+
+
+def merge_explicit_mentions_metadata(
+    metadata: dict[str, Any] | None,
+    content: str,
+    *,
+    exclude: Iterable[str] = (),
+) -> dict[str, Any] | None:
+    """Merge explicit @mentions from content into message metadata.
+
+    The backend remains the enforcement point for whether each handle can be
+    routed. This helper preserves the client-side intent for replies, where the
+    server may otherwise only route to the parent thread.
+    """
+    mentions = extract_explicit_mentions(content, exclude=exclude)
+    if not mentions:
+        return metadata
+
+    merged = dict(metadata or {})
+    existing_raw = merged.get("mentions") if isinstance(merged.get("mentions"), list) else []
+    existing: list[Any] = list(existing_raw)
+    existing_keys: set[str] = set()
+    for item in existing:
+        if isinstance(item, dict):
+            raw = item.get("agent_name") or item.get("handle") or item.get("name") or ""
+        else:
+            raw = item
+        key = str(raw).lower().lstrip("@").strip()
+        if key:
+            existing_keys.add(key)
+    for mention in mentions:
+        if mention.lower() not in existing_keys:
+            existing.append(mention)
+            existing_keys.add(mention.lower())
+    merged["mentions"] = existing
+    return merged

--- a/ax_cli/runtimes/hermes/sentinel.py
+++ b/ax_cli/runtimes/hermes/sentinel.py
@@ -34,6 +34,8 @@ except ImportError:
     print("Error: httpx required. pip install httpx")
     sys.exit(1)
 
+from ax_cli.mentions import merge_explicit_mentions_metadata
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -259,6 +261,7 @@ class AxAPI:
         }
         if parent_id:
             body["parent_id"] = parent_id
+        metadata = merge_explicit_mentions_metadata(metadata, content, exclude=[self.agent_name])
         if metadata is not None:
             body["metadata"] = metadata
         try:

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -125,7 +125,17 @@ def test_channel_sends_with_agent_bound_pat():
         )
     )
 
-    assert client.sent == [{"space_id": "space-123", "content": "hello", "parent_id": "incoming-123"}]
+    assert client.sent == [
+        {
+            "space_id": "space-123",
+            "content": "hello",
+            "parent_id": "incoming-123",
+            "metadata": {
+                "top_level_ingress": False,
+                "routing": {"mode": "reply_target", "source": "channel_reply"},
+            },
+        }
+    ]
     assert client.processing_statuses == [
         {
             "message_id": "incoming-123",
@@ -137,6 +147,21 @@ def test_channel_sends_with_agent_bound_pat():
     result = bridge.writes[0]["result"]
     assert result["content"][0]["text"] == "sent reply to incoming-123 (msg-123)"
     assert "msg-123" in bridge._reply_anchor_ids
+
+
+def test_channel_reply_preserves_explicit_mentions_for_routing():
+    client = FakeClient("axp_a_AgentKey.Secret")
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "@nemotron can you check this with @peer-agent?"}},
+        )
+    )
+
+    assert client.sent[0]["metadata"]["mentions"] == ["nemotron"]
 
 
 def test_channel_can_publish_working_status_on_delivery():

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,20 @@
+from ax_cli.mentions import extract_explicit_mentions, merge_explicit_mentions_metadata
+
+
+def test_extract_explicit_mentions_dedupes_and_excludes_self():
+    assert extract_explicit_mentions(
+        "@nemotron please ask @Hermes and @nemotron again, not email@example.com",
+        exclude=["hermes"],
+    ) == ["nemotron"]
+
+
+def test_merge_explicit_mentions_metadata_preserves_existing_values():
+    metadata = {"routing": {"mode": "reply_target"}, "mentions": ["existing"]}
+
+    merged = merge_explicit_mentions_metadata(metadata, "@nemotron ping @existing")
+
+    assert merged == {
+        "routing": {"mode": "reply_target"},
+        "mentions": ["existing", "nemotron"],
+    }
+    assert metadata["mentions"] == ["existing"]


### PR DESCRIPTION
## Summary
- preserve explicit `@agent` mentions when live agents reply in-thread
- apply the same mention metadata helper to Claude Code Channel and Hermes replies
- add tests for mention extraction and reply fan-out intent

## Why
Hermes replied with `@nemotron`, but the outbound message stayed in `reply_target` routing with no authoritative mention metadata, so nemotron never received it. A reply should keep its parent context while still carrying explicit mentions for backend routing/enforcement.

## Validation
- `uv run ruff check ax_cli/mentions.py ax_cli/commands/channel.py ax_cli/runtimes/hermes/sentinel.py tests/test_mentions.py tests/test_channel.py`
- `uv run pytest tests/test_mentions.py tests/test_channel.py tests/test_gateway_commands.py -q` (`142 passed`)
