### PR TITLE
fix(hermes): add --verbose to claude -p stream-json invocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 dist/
 build/
 .coverage
+.venv/
 ax_cli/_version.py
 uv.lock
 operator-qa-artifacts/

--- a/ax_cli/runtimes/hermes/runtimes/claude_cli.py
+++ b/ax_cli/runtimes/hermes/runtimes/claude_cli.py
@@ -34,6 +34,7 @@ class ClaudeCLIRuntime(BaseRuntime):
         cmd = [
             "claude", "-p",
             "--output-format", "stream-json",
+            "--verbose",
             "--dangerously-skip-permissions",
         ]
         if extra.get("add_dir"):

--- a/ax_cli/runtimes/hermes/sentinel.py
+++ b/ax_cli/runtimes/hermes/sentinel.py
@@ -453,6 +453,7 @@ def _build_claude_cmd(message: str, workdir: str, args,
     cmd = [
         "claude", "-p",
         "--output-format", "stream-json",
+        "--verbose",
         "--dangerously-skip-permissions",
         "--add-dir", "/home/ax-agent/shared/repos",
     ]

--- a/tests/test_hermes_claude_verbose.py
+++ b/tests/test_hermes_claude_verbose.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import inspect
 from types import SimpleNamespace
 
-from ax_cli.runtimes.hermes.sentinel import _build_claude_cmd
 from ax_cli.runtimes.hermes.runtimes.claude_cli import ClaudeCLIRuntime
+from ax_cli.runtimes.hermes.sentinel import _build_claude_cmd
 
 
 def test_hermes_sentinel_build_claude_cmd_includes_verbose() -> None:

--- a/tests/test_hermes_claude_verbose.py
+++ b/tests/test_hermes_claude_verbose.py
@@ -1,0 +1,36 @@
+"""Regression: --verbose must accompany --print + --output-format stream-json
+in every Claude Code subprocess command we build.
+
+Without --verbose the Claude CLI rejects the combination on Mac/Linux:
+    "When using --print, --output-format=stream-json requires --verbose"
+
+The fix in ax_cli/gateway.py::_build_sentinel_claude_cmd was already landed
+(see the cmd list there). This module locks the same behavior on the two
+remaining call sites that vendor the Hermes runtime.
+"""
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+from ax_cli.runtimes.hermes.sentinel import _build_claude_cmd
+from ax_cli.runtimes.hermes.runtimes.claude_cli import ClaudeCLIRuntime
+
+
+def test_hermes_sentinel_build_claude_cmd_includes_verbose() -> None:
+    args = SimpleNamespace(model=None, allowed_tools=None, system_prompt=None)
+    cmd = _build_claude_cmd("hello", "/tmp/wd", args)
+    assert "-p" in cmd, f"expected --print (-p) in cmd: {cmd}"
+    assert "stream-json" in cmd, f"expected stream-json in cmd: {cmd}"
+    assert "--verbose" in cmd, (
+        f"--verbose missing from Claude sentinel cmd; Claude CLI requires "
+        f"it whenever --print + --output-format stream-json are set. cmd={cmd}"
+    )
+
+
+def test_claude_cli_runtime_execute_constructs_verbose_cmd() -> None:
+    src = inspect.getsource(ClaudeCLIRuntime.execute)
+    assert '"--verbose"' in src or "'--verbose'" in src, (
+        "ClaudeCLIRuntime.execute() builds a Claude cmd missing --verbose. "
+        "Claude CLI rejects --print + --output-format stream-json without it."
+    )


### PR DESCRIPTION
## Summary

Claude CLI rejects `--print` + `--output-format stream-json` on Mac/Linux unless `--verbose` is also passed. `ax_cli/gateway.py::_build_sentinel_claude_cmd` already carries the flag (landed in #116). Two vendored Hermes call sites that build the same Claude command shape were missing it:

- `ax_cli/runtimes/hermes/sentinel.py::_build_claude_cmd`
- `ax_cli/runtimes/hermes/runtimes/claude_cli.py::ClaudeCLIRuntime.execute`

This adds `--verbose` to both, plus a regression test that locks the contract: `tests/test_hermes_claude_verbose.py`.

Also includes a one-commit `.gitignore` cleanup (`.venv/`).

Reported by Damon Sipe.

## Validation

- [x] `pytest tests/test_hermes_claude_verbose.py -v` (both new tests green)
- [ ] `pytest tests/ -v --tb=short` (full suite — please run on review env)
- [ ] `ruff check ax_cli/`
- [ ] `ruff format --check ax_cli/`

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated
