### PR TITLE
feat(gateway): hermes global defaults — 60-iter ceiling, durable per-agent memory

### DIFF
--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3775,20 +3775,30 @@ def _build_hermes_sentinel_env(entry: dict[str, Any]) -> dict[str, str]:
     hermes_repo = str(entry.get("hermes_repo_path") or "").strip() or "/home/ax-agent/shared/repos/hermes-agent"
     repo_root = str(_gateway_repo_root())
 
+    # Per-agent HERMES_HOME so each hermes agent gets its own memories/ dir
+    # under ~/.ax/gateway/agents/<name>/hermes-home. Without this, every
+    # hermes agent on the host shares ~/.hermes/memories/MEMORY.md and
+    # clobbers each other.
+    agent_name = str(entry.get("name") or "")
+    hermes_home = agent_dir(agent_name) / "hermes-home" if agent_name else None
+
     env.update(
         {
             "AX_TOKEN": token,
             "AX_BASE_URL": str(entry.get("base_url") or ""),
-            "AX_AGENT_NAME": str(entry.get("name") or ""),
+            "AX_AGENT_NAME": agent_name,
             "AX_AGENT_ID": str(entry.get("agent_id") or ""),
             "AX_SPACE_ID": str(entry.get("space_id") or ""),
             "AX_CONFIG_DIR": str(workdir / ".ax"),
             "AX_PYTHON": _hermes_sentinel_python(entry),
             "HERMES_MAX_ITERATIONS": str(
-                entry.get("hermes_max_iterations") or os.environ.get("HERMES_MAX_ITERATIONS") or 30
+                entry.get("hermes_max_iterations") or os.environ.get("HERMES_MAX_ITERATIONS") or 60
             ),
         }
     )
+    if hermes_home is not None:
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        env["HERMES_HOME"] = str(hermes_home)
     env.setdefault("AGENT_RUNNER_API_KEY", "staging-dispatch-key")
     env.setdefault("INTERNAL_DISPATCH_API_KEY", env["AGENT_RUNNER_API_KEY"])
 

--- a/ax_cli/runtimes/hermes/runtimes/hermes_sdk.py
+++ b/ax_cli/runtimes/hermes/runtimes/hermes_sdk.py
@@ -379,7 +379,7 @@ class HermesSDKRuntime(BaseRuntime):
                 tool_delay=0.5,
                 quiet_mode=True,
                 skip_context_files=True,
-                skip_memory=True,
+                skip_memory=False,
                 disabled_toolsets=disabled,
                 enabled_toolsets=enabled,
                 tool_progress_callback=_on_tool_progress,


### PR DESCRIPTION
## Summary
- Bump `HERMES_MAX_ITERATIONS` gateway default from 30 → 60. Widget hit 30 mid-task on a long supervisor instruction; 60 gives more headroom without inviting runaway loops.
- Flip `skip_memory=False` in the `hermes_sdk` runtime so MemoryStore is on for every gateway-managed hermes agent.
- Set `HERMES_HOME` per-agent to `~/.ax/gateway/agents/<name>/hermes-home` in the sentinel env builder. Without this, the hermes default is a single shared `~/.hermes/memories/MEMORY.md` and every hermes agent on the host would stomp each other.

Applies globally — no per-agent toggles. Existing running sentinels need a gateway restart to pick up the new env.

## Why
Widget (`widget_hermes_local`) hit max iterations and reported memory disabled. Both are safe defaults to flip globally now that we have a per-agent storage path the gateway already manages (the same `agent_dir(name)` we use for the agent token).

## Test plan
- [x] `uv run pytest tests/test_gateway_commands.py -k hermes` — 5/5 pass
- [x] Smoke test of `_build_hermes_sentinel_env` confirms `HERMES_HOME=~/.ax/gateway/agents/<name>/hermes-home` and `HERMES_MAX_ITERATIONS=60`
- [ ] Restart gateway locally and verify sentinels respawn with new env
- [ ] Confirm widget can converge on a real supervisor task within 60 iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)