### PR TITLE
feat(gateway): hide stale agents and signal lifecycle transitions upstream

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -302,9 +302,7 @@ def doctor(
             elif probe_result.get("skipped"):
                 console.print(f"[cyan]probe:[/cyan] skipped — {probe_result.get('reason')}")
             elif probe_result.get("ok") is False:
-                console.print(
-                    f"[red]probe:[/red] /auth/exchange rejected ({probe_result.get('code')})"
-                )
+                console.print(f"[red]probe:[/red] /auth/exchange rejected ({probe_result.get('code')})")
                 console.print(_invalid_credential_recovery_copy(probe_result.get("host")))
 
     if not data["ok"]:

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -45,6 +45,7 @@ from ..gateway import (
     GatewayDaemon,
     _format_daemon_log_line,
     _is_passive_runtime,
+    _is_system_agent,
     active_gateway_pid,
     active_gateway_pids,
     active_gateway_ui_pid,
@@ -1237,10 +1238,56 @@ def _set_managed_agent_desired_state(name: str, desired_state: str) -> dict:
     return annotate_runtime_health(entry, registry=registry)
 
 
-def _remove_managed_agent(name: str) -> dict:
+def _build_session_client_silent() -> AxClient | None:
+    """Build a user-PAT session client without raising. Returns None when
+    the gateway is not logged in or the session token is missing/invalid.
+
+    Used for best-effort upstream calls during local cleanup paths where a
+    missing session must not abort the command.
+    """
+    session = load_gateway_session()
+    if not session:
+        return None
+    token = str(session.get("token") or "")
+    if not token:
+        return None
+    try:
+        return AxClient(
+            base_url=str(session.get("base_url") or auth_cmd.DEFAULT_LOGIN_BASE_URL),
+            token=token,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _remove_managed_agent(name: str, *, client_factory=None) -> dict:
     registry = load_gateway_registry()
+    peek = find_agent_entry(registry, name)
+    if not peek:
+        raise LookupError(f"Managed agent not found: {name}")
+    # Best-effort upstream delete BEFORE local removal so the platform-side
+    # record can be retired in lockstep. Missing session, 404, or network
+    # failure are recorded as audit events but never block the local
+    # removal — the local registry is authoritative for the gateway.
+    agent_id = str(peek.get("agent_id") or "").strip()
+    if agent_id:
+        user_client = (
+            client_factory()
+            if client_factory is not None
+            else _build_session_client_silent()
+        )
+        if user_client is not None:
+            try:
+                user_client.delete_agent(agent_id)
+            except Exception as exc:  # noqa: BLE001
+                record_gateway_activity(
+                    "managed_agent_remove_upstream_failed",
+                    entry=peek,
+                    error=str(exc)[:360],
+                )
     entry = remove_agent_entry(registry, name)
     if not entry:
+        # Should be unreachable since peek succeeded; defensive only.
         raise LookupError(f"Managed agent not found: {name}")
     save_gateway_registry(registry)
     archive_stale_gateway_approvals()
@@ -1492,15 +1539,28 @@ def _no_invoking_principal_error() -> ValueError:
     )
 
 
-def _status_payload(*, activity_limit: int = 10) -> dict:
+def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -> dict:
     daemon = daemon_status()
     ui = ui_status()
     session = load_gateway_session()
     registry = daemon["registry"]
-    agents = [
+    all_agents = [
         _with_registry_refs(registry, annotate_runtime_health(agent, registry=registry))
         for agent in registry.get("agents", [])
     ]
+    # Partition out hidden + system agents so default surfaces stay tidy.
+    # System agents (switchboards, service accounts) are infrastructure
+    # plumbing; hidden agents are stale ones the daemon swept away.
+    hidden_agents_list = [
+        a for a in all_agents
+        if str(a.get("lifecycle_phase") or "active") == "hidden"
+    ]
+    system_agents_list = [a for a in all_agents if _is_system_agent(a)]
+    visible_agents = [
+        a for a in all_agents
+        if a not in hidden_agents_list and a not in system_agents_list
+    ]
+    agents = all_agents if include_hidden else visible_agents
     approvals = list_gateway_approvals()
     pending_approvals = [item for item in approvals if str(item.get("status") or "") == "pending"]
     live_agents = [a for a in agents if str(a.get("mode") or "") == "LIVE"]
@@ -1567,6 +1627,8 @@ def _status_payload(*, activity_limit: int = 10) -> dict:
             "errored_agents": len(errored_agents),
             "low_confidence_agents": len(low_confidence_agents),
             "blocked_agents": len(blocked_agents),
+            "hidden_agents": len(hidden_agents_list),
+            "system_agents": len(system_agents_list),
             "pending_approvals": len(pending_approvals),
         },
     }
@@ -4423,7 +4485,12 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                 self.wfile.write(body)
                 return
             if parsed.path == "/api/status":
-                _write_json_response(self, _status_payload(activity_limit=activity_limit))
+                query = parse_qs(parsed.query)
+                include_hidden = str((query.get("all") or ["0"])[0] or "0").lower() in {"1", "true", "yes"}
+                _write_json_response(
+                    self,
+                    _status_payload(activity_limit=activity_limit, include_hidden=include_hidden),
+                )
                 return
             if parsed.path == "/local/inbox":
                 query = parse_qs(parsed.query)
@@ -5145,9 +5212,17 @@ def activity(
 
 
 @app.command("status")
-def status(as_json: bool = JSON_OPTION):
+def status(
+    as_json: bool = JSON_OPTION,
+    show_all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Include hidden (auto-swept stale) and system (switchboard / service-account) agents.",
+    ),
+):
     """Show Gateway status, daemon state, and managed runtimes."""
-    payload = _status_payload()
+    payload = _status_payload(include_hidden=show_all)
     if as_json:
         print_json(payload)
         return
@@ -5171,6 +5246,12 @@ def status(as_json: bool = JSON_OPTION):
     err_console.print(f"  live        = {payload['summary']['live_agents']}")
     err_console.print(f"  on_demand   = {payload['summary']['on_demand_agents']}")
     err_console.print(f"  inbox       = {payload['summary']['inbox_agents']}")
+    hidden_n = payload["summary"].get("hidden_agents", 0)
+    system_n = payload["summary"].get("system_agents", 0)
+    if hidden_n or system_n:
+        hint = "" if show_all else "  (run with --all to include)"
+        err_console.print(f"  hidden      = {hidden_n}{hint}")
+        err_console.print(f"  system      = {system_n}")
     err_console.print(f"  alerts      = {payload['summary'].get('alert_count', 0)}")
     err_console.print(f"  approvals   = {payload['summary'].get('pending_approvals', 0)} pending")
     if payload.get("alerts"):
@@ -5608,11 +5689,19 @@ def watch(
     interval: float = typer.Option(2.0, "--interval", "-n", help="Dashboard refresh interval in seconds"),
     activity_limit: int = typer.Option(8, "--activity-limit", help="Number of recent events to display"),
     once: bool = typer.Option(False, "--once", help="Render one dashboard frame and exit"),
+    show_all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Include hidden (auto-swept stale) and system (switchboard / service-account) agents.",
+    ),
 ):
     """Watch the Gateway in a live terminal dashboard."""
 
     def render_dashboard() -> Group:
-        return _render_gateway_dashboard(_status_payload(activity_limit=activity_limit))
+        return _render_gateway_dashboard(
+            _status_payload(activity_limit=activity_limit, include_hidden=show_all)
+        )
 
     if once:
         console.print(render_dashboard())
@@ -6514,17 +6603,37 @@ def update_agent(
 
 
 @agents_app.command("list")
-def list_agents(as_json: bool = JSON_OPTION):
+def list_agents(
+    as_json: bool = JSON_OPTION,
+    show_all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Include hidden (auto-swept stale) and system (switchboard / service-account) agents.",
+    ),
+):
     """List Gateway-managed agents."""
-    agents = _status_payload()["agents"]
+    payload = _status_payload(include_hidden=show_all)
+    agents = payload["agents"]
     if as_json:
-        print_json({"agents": agents, "count": len(agents)})
+        print_json({
+            "agents": agents,
+            "count": len(agents),
+            "hidden": payload["summary"].get("hidden_agents", 0),
+            "system": payload["summary"].get("system_agents", 0),
+        })
         return
     print_table(
         ["Ref", "Agent", "Type", "Mode", "Presence", "Output", "Confidence", "Space"],
         [{**agent, "type": _agent_type_label(agent), "output": _agent_output_label(agent)} for agent in agents],
         keys=["registry_ref", "name", "type", "mode", "presence", "output", "confidence", "space_id"],
     )
+    hidden_n = payload["summary"].get("hidden_agents", 0)
+    system_n = payload["summary"].get("system_agents", 0)
+    if not show_all and (hidden_n or system_n):
+        err_console.print(
+            f"[dim]({hidden_n} hidden, {system_n} system — pass --all to include)[/dim]"
+        )
 
 
 @agents_app.command("show")

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1271,11 +1271,7 @@ def _remove_managed_agent(name: str, *, client_factory=None) -> dict:
     # removal — the local registry is authoritative for the gateway.
     agent_id = str(peek.get("agent_id") or "").strip()
     if agent_id:
-        user_client = (
-            client_factory()
-            if client_factory is not None
-            else _build_session_client_silent()
-        )
+        user_client = client_factory() if client_factory is not None else _build_session_client_silent()
         if user_client is not None:
             try:
                 user_client.delete_agent(agent_id)
@@ -1551,15 +1547,9 @@ def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -
     # Partition out hidden + system agents so default surfaces stay tidy.
     # System agents (switchboards, service accounts) are infrastructure
     # plumbing; hidden agents are stale ones the daemon swept away.
-    hidden_agents_list = [
-        a for a in all_agents
-        if str(a.get("lifecycle_phase") or "active") == "hidden"
-    ]
+    hidden_agents_list = [a for a in all_agents if str(a.get("lifecycle_phase") or "active") == "hidden"]
     system_agents_list = [a for a in all_agents if _is_system_agent(a)]
-    visible_agents = [
-        a for a in all_agents
-        if a not in hidden_agents_list and a not in system_agents_list
-    ]
+    visible_agents = [a for a in all_agents if a not in hidden_agents_list and a not in system_agents_list]
     agents = all_agents if include_hidden else visible_agents
     approvals = list_gateway_approvals()
     pending_approvals = [item for item in approvals if str(item.get("status") or "") == "pending"]
@@ -5200,10 +5190,7 @@ def activity(
                 "agent_name": item.get("agent_name") or "-",
                 "message_id": item.get("message_id") or "-",
                 "tool_name": item.get("tool_name") or "-",
-                "detail": item.get("activity_message")
-                or item.get("reply_preview")
-                or item.get("error")
-                or "",
+                "detail": item.get("activity_message") or item.get("reply_preview") or item.get("error") or "",
             }
             for item in filtered
         ],
@@ -5699,9 +5686,7 @@ def watch(
     """Watch the Gateway in a live terminal dashboard."""
 
     def render_dashboard() -> Group:
-        return _render_gateway_dashboard(
-            _status_payload(activity_limit=activity_limit, include_hidden=show_all)
-        )
+        return _render_gateway_dashboard(_status_payload(activity_limit=activity_limit, include_hidden=show_all))
 
     if once:
         console.print(render_dashboard())
@@ -6236,13 +6221,7 @@ def _check_local_pending_replies(
         mid = str(m.get("id") or "").strip()
         if mid:
             ids.append(mid)
-        sender = (
-            m.get("display_name")
-            or m.get("agent_name")
-            or m.get("sender")
-            or m.get("sender_name")
-            or ""
-        )
+        sender = m.get("display_name") or m.get("agent_name") or m.get("sender") or m.get("sender_name") or ""
         sender = str(sender).strip()
         if sender and sender not in seen:
             senders.append(sender)
@@ -6616,12 +6595,14 @@ def list_agents(
     payload = _status_payload(include_hidden=show_all)
     agents = payload["agents"]
     if as_json:
-        print_json({
-            "agents": agents,
-            "count": len(agents),
-            "hidden": payload["summary"].get("hidden_agents", 0),
-            "system": payload["summary"].get("system_agents", 0),
-        })
+        print_json(
+            {
+                "agents": agents,
+                "count": len(agents),
+                "hidden": payload["summary"].get("hidden_agents", 0),
+                "system": payload["summary"].get("system_agents", 0),
+            }
+        )
         return
     print_table(
         ["Ref", "Agent", "Type", "Mode", "Presence", "Output", "Confidence", "Space"],
@@ -6631,9 +6612,7 @@ def list_agents(
     hidden_n = payload["summary"].get("hidden_agents", 0)
     system_n = payload["summary"].get("system_agents", 0)
     if not show_all and (hidden_n or system_n):
-        err_console.print(
-            f"[dim]({hidden_n} hidden, {system_n} system — pass --all to include)[/dim]"
-        )
+        err_console.print(f"[dim]({hidden_n} hidden, {system_n} system — pass --all to include)[/dim]")
 
 
 @agents_app.command("show")

--- a/ax_cli/commands/messages.py
+++ b/ax_cli/commands/messages.py
@@ -484,12 +484,7 @@ def check_pending_replies(
         mid = str(m.get("id") or "").strip()
         if mid:
             ids.append(mid)
-        sender = (
-            m.get("display_name")
-            or m.get("sender_handle")
-            or m.get("sender_name")
-            or ""
-        )
+        sender = m.get("display_name") or m.get("sender_handle") or m.get("sender_name") or ""
         sender = str(sender).strip()
         if sender and sender not in seen_senders:
             senders.append(sender)

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -53,6 +53,8 @@ DEFAULT_HANDLER_TIMEOUT_SECONDS = 900
 MIN_HANDLER_TIMEOUT_SECONDS = 1
 SSE_IDLE_TIMEOUT_SECONDS = 45.0
 RUNTIME_STALE_AFTER_SECONDS = 75.0
+RUNTIME_HIDDEN_AFTER_SECONDS = 15 * 60.0  # default: hide stale agents after 15 min
+_LIFECYCLE_PHASES = {"active", "hidden"}
 LOCAL_SESSION_TTL_SECONDS = 24 * 60 * 60
 GATEWAY_EVENT_PREFIX = "AX_GATEWAY_EVENT "
 DEFAULT_OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434").rstrip("/")
@@ -438,6 +440,42 @@ def _template_operator_defaults(template_id: str | None, runtime_type: object) -
     return dict(
         defaults_by_template.get(template_key) or defaults_by_runtime.get(runtime_key) or defaults_by_runtime["exec"]
     )
+
+
+def _is_system_agent(entry: dict[str, Any]) -> bool:
+    """Identify infrastructure agents exempt from lifecycle cleanup.
+
+    Per-space switchboards and explicit service accounts are gateway
+    plumbing, not user-managed agents — they should be hidden from default
+    listings and never auto-archived.
+    """
+    template_id = str(entry.get("template_id") or "").strip().lower()
+    if template_id in {"service_account", "inbox"}:
+        return True
+    name = str(entry.get("name") or "")
+    if name.startswith("switchboard-"):
+        return True
+    return False
+
+
+def _hide_after_stale_seconds(registry: dict[str, Any] | None = None) -> float:
+    """Resolve the stale-to-hidden threshold (env > registry > default)."""
+    env_raw = os.environ.get("AX_GATEWAY_HIDE_AFTER_STALE_SECONDS", "").strip()
+    if env_raw:
+        try:
+            return max(0.0, float(env_raw))
+        except ValueError:
+            pass
+    if isinstance(registry, dict):
+        gw = registry.get("gateway") or {}
+        if isinstance(gw, dict):
+            raw = gw.get("hide_after_stale_seconds")
+            if raw is not None:
+                try:
+                    return max(0.0, float(raw))
+                except (TypeError, ValueError):
+                    pass
+    return RUNTIME_HIDDEN_AFTER_SECONDS
 
 
 def _template_asset_defaults(template_id: str | None, runtime_type: object) -> dict[str, Any]:
@@ -3349,6 +3387,35 @@ def _apply_placement_event(
     }
 
 
+def _post_lifecycle_signal(
+    client: Any,
+    entry: dict[str, Any],
+    *,
+    phase: str,
+    note: str | None = None,
+) -> bool:
+    """Best-effort POST /api/v1/agents/heartbeat with status=<phase>.
+
+    Used to inform the aX platform when a gateway-managed agent crosses a
+    lifecycle threshold (connected/stale/offline/setup_error). 404 means the
+    platform has no record of this agent_id — treat as success so we don't
+    retry forever. Returns True iff a signal was sent (or 404'd).
+    """
+    if client is None:
+        return False
+    agent_id = str(entry.get("agent_id") or "").strip()
+    if not agent_id:
+        return False
+    try:
+        client.send_heartbeat(agent_id=agent_id, status=phase, note=note)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        if status_code == 404:
+            return True
+        return False
+
+
 def _post_placement_ack(
     client: Any,
     entry: dict[str, Any],
@@ -5608,6 +5675,101 @@ class GatewayDaemon:
         )
         return registry
 
+    def _sweep_client(self, session: dict[str, Any] | None) -> Any | None:
+        """Build a session-bound client for upstream lifecycle signals.
+
+        Returns None if the session is missing or client construction fails;
+        local sweep work continues either way.
+        """
+        if not session:
+            return None
+        token = session.get("token")
+        if not token:
+            return None
+        try:
+            return self.client_factory(
+                base_url=session.get("base_url"),
+                token=token,
+            )
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _sweep_lifecycle(
+        self,
+        registry: dict[str, Any],
+        *,
+        session: dict[str, Any] | None,
+    ) -> None:
+        """Per-tick sweep: hide stale agents, signal liveness transitions upstream.
+
+        - Skips system agents (switchboards, service accounts).
+        - Promotes active+stale entries past the hide threshold to lifecycle_phase=hidden.
+        - Auto-restores hidden entries that have come back online.
+        - On any liveness delta vs last_lifecycle_signal.phase, calls
+          send_heartbeat upstream best-effort. 404 counts as success.
+        """
+        agents = registry.get("agents") or []
+        if not agents:
+            return
+        threshold = _hide_after_stale_seconds(registry)
+        client = self._sweep_client(session)
+        for entry in agents:
+            if not isinstance(entry, dict):
+                continue
+            if _is_system_agent(entry):
+                continue
+            liveness = str(entry.get("liveness") or "").strip().lower()
+            age_raw = entry.get("last_seen_age_seconds")
+            try:
+                age = float(age_raw) if age_raw is not None else None
+            except (TypeError, ValueError):
+                age = None
+            phase = str(entry.get("lifecycle_phase") or "active").strip().lower()
+            if phase not in _LIFECYCLE_PHASES:
+                phase = "active"
+
+            # Hide transition: active → hidden once stale past threshold.
+            if (
+                phase == "active"
+                and liveness in {"stale", "offline", "setup_error"}
+                and age is not None
+                and age >= threshold
+            ):
+                entry["lifecycle_phase"] = "hidden"
+                entry["hidden_at"] = _now_iso()
+                entry["hidden_reason"] = liveness
+                record_gateway_activity(
+                    "managed_agent_hidden", entry=entry, reason=liveness
+                )
+                phase = "hidden"
+
+            # Auto-restore: hidden → active when reconnected and fresh.
+            elif (
+                phase == "hidden"
+                and liveness == "connected"
+                and (age is None or age <= RUNTIME_STALE_AFTER_SECONDS)
+            ):
+                entry["lifecycle_phase"] = "active"
+                entry.pop("hidden_at", None)
+                entry.pop("hidden_reason", None)
+                record_gateway_activity("managed_agent_unhidden", entry=entry)
+                phase = "active"
+
+            # Upstream signal on liveness delta. Sticky liveness rate-limits.
+            if liveness in {"connected", "stale", "offline", "setup_error"}:
+                last_signal = entry.get("last_lifecycle_signal") or {}
+                if not isinstance(last_signal, dict):
+                    last_signal = {}
+                prev_phase = str(last_signal.get("phase") or "").strip().lower()
+                if liveness != prev_phase:
+                    sent = _post_lifecycle_signal(client, entry, phase=liveness)
+                    if sent:
+                        entry["last_lifecycle_signal"] = {
+                            "phase": liveness,
+                            "at": _now_iso(),
+                            "agent_id": str(entry.get("agent_id") or ""),
+                        }
+
     def run(self, *, once: bool = False) -> None:
         session = load_gateway_session()
         if not session:
@@ -5642,6 +5804,7 @@ class GatewayDaemon:
             while not self._stop.is_set():
                 registry = load_gateway_registry()
                 registry = self._reconcile_registry(registry, session)
+                self._sweep_lifecycle(registry, session=session)
                 save_gateway_registry(registry)
                 if once:
                     break

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -5738,17 +5738,11 @@ class GatewayDaemon:
                 entry["lifecycle_phase"] = "hidden"
                 entry["hidden_at"] = _now_iso()
                 entry["hidden_reason"] = liveness
-                record_gateway_activity(
-                    "managed_agent_hidden", entry=entry, reason=liveness
-                )
+                record_gateway_activity("managed_agent_hidden", entry=entry, reason=liveness)
                 phase = "hidden"
 
             # Auto-restore: hidden → active when reconnected and fresh.
-            elif (
-                phase == "hidden"
-                and liveness == "connected"
-                and (age is None or age <= RUNTIME_STALE_AFTER_SECONDS)
-            ):
+            elif phase == "hidden" and liveness == "connected" and (age is None or age <= RUNTIME_STALE_AFTER_SECONDS):
                 entry["lifecycle_phase"] = "active"
                 entry.pop("hidden_at", None)
                 entry.pop("hidden_reason", None)

--- a/ax_cli/output.py
+++ b/ax_cli/output.py
@@ -18,6 +18,7 @@ def _redact_secrets(text: str) -> str:
     """Redact axp_* PAT shapes from any user-facing string."""
     return _AXP_SECRET_RE.sub("axp_<redacted>", text)
 
+
 console = Console()
 # Dedicated stderr console for status/log lines that mustn't pollute stdout
 # (e.g. when the caller parses --json output or pipes the command).

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -4957,3 +4957,313 @@ def test_gateway_activity_command_does_not_emit_credentials(monkeypatch, tmp_pat
     )
     result = runner.invoke(app, ["gateway", "activity", "--message-id", "msg-1", "--json"])
     assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# Gateway lifecycle v1: hide-stale sweep + upstream transition signals.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHeartbeatClient:
+    """Records send_heartbeat / delete_agent calls for assertion."""
+
+    def __init__(self, *, fail_with: Exception | None = None,
+                 fail_status_code: int | None = None):
+        self.heartbeats: list[dict] = []
+        self.deletes: list[str] = []
+        self._fail_with = fail_with
+        self._fail_status_code = fail_status_code
+
+    def send_heartbeat(self, *, agent_id=None, status=None, note=None,
+                       cadence_seconds=None):
+        self.heartbeats.append({
+            "agent_id": agent_id,
+            "status": status,
+            "note": note,
+            "cadence_seconds": cadence_seconds,
+        })
+        if self._fail_with is not None:
+            exc = self._fail_with
+            if self._fail_status_code is not None:
+                resp = type("R", (), {"status_code": self._fail_status_code})()
+                setattr(exc, "response", resp)
+            raise exc
+        return {"ok": True}
+
+    def delete_agent(self, identifier):
+        self.deletes.append(identifier)
+        if self._fail_with is not None:
+            raise self._fail_with
+        return {"ok": True, "id": identifier}
+
+
+def _stale_hermes_entry(name: str, *, age_seconds: float, liveness: str = "stale",
+                        agent_id: str = "agent-stale-1") -> dict:
+    return {
+        "name": name,
+        "agent_id": agent_id,
+        "space_id": "space-test",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "effective_state": "running",
+        "liveness": liveness,
+        "last_seen_age_seconds": age_seconds,
+        "last_seen_at": gateway_core._now_iso(),
+    }
+
+
+def _build_daemon(client) -> gateway_core.GatewayDaemon:
+    return gateway_core.GatewayDaemon(
+        client_factory=lambda **_: client,
+        poll_interval=0.0,
+    )
+
+
+def _isolate_gateway_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path / "gw"))
+
+
+def test_sweep_hides_stale_agent_after_threshold(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    monkeypatch.delenv("AX_GATEWAY_HIDE_AFTER_STALE_SECONDS", raising=False)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("hermes-old", age_seconds=20 * 60)
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
+    assert entry["lifecycle_phase"] == "hidden"
+    assert "hidden_at" in entry
+    assert entry["hidden_reason"] == "stale"
+    recent = gateway_core.load_recent_gateway_activity()
+    assert any(r.get("event") == "managed_agent_hidden" for r in recent)
+
+
+def test_sweep_idempotent_for_already_hidden(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("hermes-old", age_seconds=20 * 60)
+    registry = {"agents": [entry]}
+    session = {"token": "axp_u_test", "base_url": "http://x"}
+    daemon._sweep_lifecycle(registry, session=session)
+    daemon._sweep_lifecycle(registry, session=session)
+    hidden_events = [
+        r for r in gateway_core.load_recent_gateway_activity()
+        if r.get("event") == "managed_agent_hidden"
+    ]
+    assert len(hidden_events) == 1
+    assert len(client.heartbeats) == 1
+
+
+def test_sweep_skips_switchboard(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = {
+        "name": "switchboard-deadbeef",
+        "agent_id": "agent-switchboard",
+        "template_id": "inbox",
+        "effective_state": "running",
+        "liveness": "stale",
+        "last_seen_age_seconds": 24 * 60 * 60,
+    }
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
+    assert entry.get("lifecycle_phase", "active") == "active"
+    assert client.heartbeats == []
+
+
+def test_sweep_skips_service_account(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = {
+        "name": "system-events",
+        "agent_id": "agent-service",
+        "template_id": "service_account",
+        "effective_state": "running",
+        "liveness": "offline",
+        "last_seen_age_seconds": 24 * 60 * 60,
+    }
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
+    assert entry.get("lifecycle_phase", "active") == "active"
+    assert client.heartbeats == []
+
+
+def test_sweep_unhides_on_reconnect(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("hermes-back", age_seconds=2.0, liveness="connected")
+    entry["lifecycle_phase"] = "hidden"
+    entry["hidden_at"] = gateway_core._now_iso()
+    entry["hidden_reason"] = "stale"
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
+    assert entry["lifecycle_phase"] == "active"
+    assert "hidden_at" not in entry
+    assert "hidden_reason" not in entry
+    recent = gateway_core.load_recent_gateway_activity()
+    assert any(r.get("event") == "managed_agent_unhidden" for r in recent)
+
+
+def test_status_payload_filters_hidden_by_default(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    hidden = _stale_hermes_entry("hermes-hidden", age_seconds=30 * 60, liveness="offline",
+                                 agent_id="agent-hidden")
+    hidden["lifecycle_phase"] = "hidden"
+    active = {
+        "name": "hermes-live",
+        "agent_id": "agent-live",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "effective_state": "running",
+        "liveness": "connected",
+        "last_seen_age_seconds": 5.0,
+        "last_seen_at": gateway_core._now_iso(),
+    }
+    gateway_core.save_gateway_registry({"agents": [hidden, active]})
+
+    payload = gateway_cmd._status_payload(activity_limit=0)
+    names = [a["name"] for a in payload["agents"]]
+    assert "hermes-hidden" not in names
+    assert "hermes-live" in names
+    assert payload["summary"]["hidden_agents"] == 1
+    assert payload["summary"]["managed_agents"] == 1
+
+
+def test_status_payload_include_hidden_returns_all(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    hidden = _stale_hermes_entry("hermes-hidden", age_seconds=30 * 60, liveness="offline",
+                                 agent_id="agent-hidden")
+    hidden["lifecycle_phase"] = "hidden"
+    active = {
+        "name": "hermes-live",
+        "agent_id": "agent-live",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "effective_state": "running",
+        "liveness": "connected",
+        "last_seen_age_seconds": 5.0,
+        "last_seen_at": gateway_core._now_iso(),
+    }
+    gateway_core.save_gateway_registry({"agents": [hidden, active]})
+
+    payload = gateway_cmd._status_payload(activity_limit=0, include_hidden=True)
+    names = [a["name"] for a in payload["agents"]]
+    assert "hermes-hidden" in names
+    assert "hermes-live" in names
+    assert payload["summary"]["hidden_agents"] == 1
+
+
+def test_lifecycle_signal_sent_on_connected_to_stale(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("hermes-flap", age_seconds=20 * 60)
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
+    assert len(client.heartbeats) == 1
+    assert client.heartbeats[0]["status"] == "stale"
+    assert client.heartbeats[0]["agent_id"] == entry["agent_id"]
+    assert entry["last_lifecycle_signal"]["phase"] == "stale"
+
+
+def test_lifecycle_signal_idempotent(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("hermes-flap", age_seconds=20 * 60)
+    registry = {"agents": [entry]}
+    session = {"token": "axp_u_test", "base_url": "http://x"}
+    daemon._sweep_lifecycle(registry, session=session)
+    daemon._sweep_lifecycle(registry, session=session)
+    assert len(client.heartbeats) == 1
+
+
+def test_lifecycle_signal_404_tolerant(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    boom = httpx.HTTPStatusError(
+        "platform has no record",
+        request=httpx.Request("POST", "http://x/api/v1/agents/heartbeat"),
+        response=httpx.Response(404),
+    )
+    client = _RecordingHeartbeatClient(fail_with=boom, fail_status_code=404)
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("hermes-ghost", age_seconds=20 * 60)
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
+    # Hide still applied locally even though upstream said 404.
+    assert entry["lifecycle_phase"] == "hidden"
+    # Sticky last_lifecycle_signal updated → no infinite retry next tick.
+    assert entry["last_lifecycle_signal"]["phase"] == "stale"
+
+
+def test_remove_managed_agent_calls_delete_agent_then_local_remove(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    token_path = tmp_path / "tok"
+    token_path.write_text("axp_a_test\n")
+    entry = {
+        "name": "doomed-agent",
+        "agent_id": "agent-doomed",
+        "space_id": "space-x",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "token_file": str(token_path),
+    }
+    gateway_core.save_gateway_registry({"agents": [entry]})
+    client = _RecordingHeartbeatClient()
+    removed = gateway_cmd._remove_managed_agent("doomed-agent", client_factory=lambda: client)
+    assert removed["name"] == "doomed-agent"
+    assert client.deletes == ["agent-doomed"]
+    registry_after = gateway_core.load_gateway_registry()
+    assert all(a.get("name") != "doomed-agent" for a in registry_after.get("agents", []))
+    assert not token_path.exists()
+
+
+def test_remove_managed_agent_proceeds_on_upstream_failure(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    token_path = tmp_path / "tok"
+    token_path.write_text("axp_a_test\n")
+    entry = {
+        "name": "doomed-agent",
+        "agent_id": "agent-doomed",
+        "space_id": "space-x",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "token_file": str(token_path),
+    }
+    gateway_core.save_gateway_registry({"agents": [entry]})
+    boom = RuntimeError("network unreachable")
+    client = _RecordingHeartbeatClient(fail_with=boom)
+    removed = gateway_cmd._remove_managed_agent("doomed-agent", client_factory=lambda: client)
+    assert removed["name"] == "doomed-agent"
+    registry_after = gateway_core.load_gateway_registry()
+    assert all(a.get("name") != "doomed-agent" for a in registry_after.get("agents", []))
+    recent = gateway_core.load_recent_gateway_activity()
+    assert any(
+        r.get("event") == "managed_agent_remove_upstream_failed"
+        for r in recent
+    )
+
+
+def test_legacy_entry_without_lifecycle_phase_loads_as_active(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    # No lifecycle_phase field at all — represents pre-v1 on-disk entry.
+    entry = {
+        "name": "hermes-legacy",
+        "agent_id": "agent-legacy",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "effective_state": "running",
+        "liveness": "stale",
+        "last_seen_age_seconds": 30 * 60,
+    }
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
+    # Legacy entry got swept normally (treated as implicit active → hidden).
+    assert entry["lifecycle_phase"] == "hidden"


### PR DESCRIPTION
## Summary

Local Gateway registry was filling with stale test agents (probes, demos, two persistent switchboards) and the aX platform was told *nothing* about per-agent lifecycle — no heartbeat, no offline signal, no removal notification. This is v1 of a focused fix.

- **Per-tick sweep** on the existing daemon loop hides stale agents (default threshold 15 min, env override `AX_GATEWAY_HIDE_AFTER_STALE_SECONDS`) and auto-restores them on reconnect.
- **Switchboards (`template_id=inbox` or `switchboard-*`) and service accounts** are infrastructure — exempt from the sweep and filtered out of default listings. Reveal with `--all`.
- **Upstream wiring on transitions** — `client.send_heartbeat(agent_id, status=phase)` on liveness deltas (connected/stale/offline/setup_error) and `client.delete_agent(agent_id)` on `_remove_managed_agent`. Both already existed in `ax_cli/client.py` and were unused. Best-effort, 404-tolerant; failure never blocks local state.
- **UI surfaces** all share `_status_payload`, so one filter covers `status`, `watch`, `agents list`, and the web `/api/status`. `--all/-a` flag on the CLI commands; `?all=1` on the web endpoint. `summary.hidden_agents` and `summary.system_agents` are always populated for `--json` consumers.

Backwards-compatible: legacy entries without `lifecycle_phase` load as implicit `active`; first sweep tick handles them. No registry version bump.

## Why

The user (madtank) flagged the registry as already messy after a few days. The Gateway is the trust boundary where agents land in the aX platform — the lifecycle gap (silent disconnects, no upstream propagation) is the core thing to get right at this stage.

## Live verification

Pre-change, against the running gateway:
\`\`\`
agents      = 20
live        = 9
inbox       = 11
\`\`\`

Post-change, same gateway, same registry:
\`\`\`
agents      = 17
live        = 9
inbox       = 8
hidden      = 0  (run with --all to include)
system      = 3
\`\`\`

The 3 switchboards (`switchboard-49afd277`, `switchboard-12d6eafd`, `switchboard-78950af5`) are now correctly filtered out of the default view. `hidden=0` until the gateway is restarted to pick up the new sweep code.

## Test plan
- [x] 13 new lifecycle tests in `tests/test_gateway_commands.py` covering sweep transitions, idempotency, system-agent exemption, status-payload filtering, upstream-signal happy + 404 paths, and `_remove_managed_agent` upstream call ordering + failure resilience
- [x] `uv run pytest` — 611 passed
- [x] `uv run ruff check ax_cli/gateway.py ax_cli/commands/gateway.py tests/test_gateway_commands.py` — clean
- [x] `ax gateway status --help` and `ax gateway agents list --help` show the new `--all/-a` flag
- [x] `ax gateway status` against the running gateway honors the new default filter
- [ ] Restart gateway locally, verify `managed_agent_hidden` activity events fire after the threshold elapses (rolls into the post-merge gateway bounce)

## Out of scope (deferred to phase 2+)

Auto-archive, auto-delete, prune/archive/restore CLI commands, ephemeral-marker-at-creation, continuous heartbeat, per-entry hide-threshold override, dedicated "Hidden agents" web UI section.

Plan file: `~/.claude/plans/i-want-to-start-gentle-grove.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)