### PR TITLE
fix(config): warn loudly on stale [agent].workdir in local .ax/config.toml

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -353,6 +353,19 @@ def whoami(as_json: bool = JSON_OPTION):
     local = _local_config_dir()
     if local and (local / "config.toml").exists():
         data["local_config"] = str(local / "config.toml")
+        # Surface stale-workdir mismatch so operators see misattribution risk
+        # before they send. Same diagnosis the auth-doctor warnings carry.
+        import tomllib
+
+        from ..config import _find_project_root, _local_config_workdir_mismatch
+
+        try:
+            local_cfg = tomllib.loads((local / "config.toml").read_text())
+            mismatch = _local_config_workdir_mismatch(local_cfg, _find_project_root())
+        except Exception:  # noqa: BLE001
+            mismatch = None
+        if mismatch:
+            data["stale_workdir"] = mismatch
     runtime_config = os.environ.get("AX_CONFIG_FILE")
     if runtime_config:
         data["runtime_config"] = runtime_config
@@ -361,6 +374,13 @@ def whoami(as_json: bool = JSON_OPTION):
         print_json(data)
     else:
         print_kv(data)
+        if data.get("stale_workdir"):
+            sw = data["stale_workdir"]
+            console.print(
+                f"[yellow]⚠ stale local config:[/yellow] {sw['config_path']} "
+                f"declares workdir={sw['configured_workdir']} but cwd resolves to "
+                f"{sw['actual_workdir']}. Identity may bind to the wrong agent."
+            )
 
 
 @app.command("init")

--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -319,11 +319,35 @@ def whoami(as_json: bool = JSON_OPTION):
         data = _gateway_local_call(gateway_cfg=gateway_cfg, method="whoami")
         data.setdefault("control_plane", "gateway")
         data.setdefault("gateway_url", gateway_cfg.get("url"))
-        data.setdefault("local_config", gateway_cfg.get("local_config"))
+        # Surface the actual on-disk local config path under gateway-managed
+        # identity (the field comes from resolve_gateway_config but isn't
+        # populated there). Also detect stale [agent].workdir so the same
+        # warning shape appears whether or not we're gateway-brokered.
+        local = _local_config_dir()
+        if local and (local / "config.toml").exists():
+            data["local_config"] = str(local / "config.toml")
+            import tomllib
+
+            from ..config import _find_project_root, _local_config_workdir_mismatch
+
+            try:
+                local_cfg = tomllib.loads((local / "config.toml").read_text())
+                mismatch = _local_config_workdir_mismatch(local_cfg, _find_project_root())
+            except Exception:  # noqa: BLE001
+                mismatch = None
+            if mismatch:
+                data["stale_workdir"] = mismatch
         if as_json:
             print_json(data)
         else:
             print_kv(data)
+            if data.get("stale_workdir"):
+                sw = data["stale_workdir"]
+                console.print(
+                    f"[yellow]⚠ stale local config:[/yellow] {sw['config_path']} "
+                    f"declares workdir={sw['configured_workdir']} but cwd resolves to "
+                    f"{sw['actual_workdir']}. Identity may bind to the wrong agent."
+                )
         return
 
     client = get_client()

--- a/ax_cli/config.py
+++ b/ax_cli/config.py
@@ -123,10 +123,20 @@ def _save_user_config(cfg: dict, *, env_name: str | None = None, activate: bool 
 
 
 def _load_local_config() -> dict:
-    """Load project-local .ax/config.toml if it exists."""
+    """Load project-local .ax/config.toml if it exists.
+
+    Emits a one-time warning when the loaded config has a stale
+    ``[agent].workdir`` (config copied from another worktree). The config
+    is still returned — callers decide how to react — but the operator
+    is alerted before silent agent rebind happens.
+    """
     local = _local_config_dir()
     if local and (local / "config.toml").exists():
-        return tomllib.loads((local / "config.toml").read_text())
+        cfg = tomllib.loads((local / "config.toml").read_text())
+        mismatch = _local_config_workdir_mismatch(cfg, _find_project_root())
+        if mismatch is not None:
+            _warn_stale_workdir_local_config(mismatch)
+        return cfg
     return {}
 
 
@@ -156,6 +166,66 @@ def _read_token_file(raw_path: str | None) -> str | None:
 
 _global_config_warned = False
 _unsafe_local_config_warned = False
+_stale_workdir_warned: set[str] = set()
+
+
+def _local_config_workdir_mismatch(cfg: dict, project_root: Path | None) -> dict | None:
+    """Detect a stale `[agent].workdir` in a local `.ax/config.toml`.
+
+    Identity-collapse defense: if a worktree's local config declares a
+    workdir that does not match the directory we actually resolved from
+    cwd, the config is almost certainly stale (copied from another
+    worktree). Honoring it silently silently re-binds the invoking shell
+    to the wrong agent — exactly the misattribution incident on
+    2026-05-04 (msg `d97e0ad1`, codex_supervisor's own bug report at
+    `06bc04f0`). We surface the mismatch so the caller can warn or
+    refuse; we do not auto-rewrite the config.
+
+    Returns ``None`` on match / no opinion. Returns a dict with
+    ``configured_workdir``, ``actual_workdir``, and ``config_path`` keys
+    when stale.
+    """
+    if project_root is None or not isinstance(cfg, dict):
+        return None
+    agent_block = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    gateway_block = cfg.get("gateway") if isinstance(cfg.get("gateway"), dict) else {}
+    configured_raw = agent_block.get("workdir") or gateway_block.get("workdir")
+    if not configured_raw:
+        # Legacy / minimal configs without a workdir field aren't stale —
+        # they just predate the field. Don't warn.
+        return None
+    try:
+        configured = Path(str(configured_raw)).expanduser().resolve()
+        actual = project_root.resolve()
+    except (OSError, RuntimeError):
+        return None
+    if configured == actual:
+        return None
+    return {
+        "configured_workdir": str(configured),
+        "actual_workdir": str(actual),
+        "config_path": str(project_root / ".ax" / "config.toml"),
+    }
+
+
+def _warn_stale_workdir_local_config(mismatch: dict) -> None:
+    """Emit a one-time stderr warning per offending config_path."""
+    global _stale_workdir_warned
+    key = mismatch.get("config_path") or ""
+    if key in _stale_workdir_warned:
+        return
+    _stale_workdir_warned.add(key)
+    import sys
+
+    sys.stderr.write(
+        f"\033[33m⚠  Stale local aX config: {mismatch['config_path']}\033[0m\n"
+        f"   [agent].workdir = {mismatch['configured_workdir']}\n"
+        f"   actual cwd root = {mismatch['actual_workdir']}\n"
+        "   This config was likely copied from another worktree; identity\n"
+        "   resolution may bind to the wrong agent. Either fix the workdir\n"
+        "   field, remove the local .ax/config.toml, or run from the original\n"
+        "   workdir. (Run `ax auth whoami` to confirm the resolved identity.)\n\n"
+    )
 
 
 def _load_global_config() -> dict:
@@ -424,6 +494,21 @@ def diagnose_auth_config(*, env_name: str | None = None, explicit_space_id: str 
     local_path = (local_dir / "config.toml") if local_dir else None
     local_cfg = tomllib.loads(local_path.read_text()) if local_path and local_path.exists() else {}
     unsafe_local = bool(local_cfg and _is_unsafe_user_token_agent_config(local_cfg))
+    stale_workdir = _local_config_workdir_mismatch(local_cfg, _find_project_root())
+    if stale_workdir is not None:
+        warnings.append(
+            {
+                "code": "stale_workdir_local_config",
+                "path": stale_workdir["config_path"],
+                "configured_workdir": stale_workdir["configured_workdir"],
+                "actual_workdir": stale_workdir["actual_workdir"],
+                "reason": (
+                    "local config's [agent].workdir does not match the directory "
+                    "that resolved as the project root — config likely copied from "
+                    "another worktree; identity may bind to the wrong agent"
+                ),
+            }
+        )
 
     if normalized_env:
         sources.append(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,10 @@ from ax_cli.config import (
     _find_project_root,
     _global_config_dir,
     _load_config,
+    _load_local_config,
+    _local_config_workdir_mismatch,
     _save_user_config,
+    _warn_stale_workdir_local_config,
     diagnose_auth_config,
     resolve_agent_id,
     resolve_agent_name,
@@ -702,3 +705,103 @@ class TestResolveBaseUrl:
     def test_default_is_localhost(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         assert resolve_base_url() == "http://localhost:8001"
+
+
+# ---------------------------------------------------------------------------
+# Stale-workdir guard — defense against the 2026-05-04 misattribution incident
+# where codex_supervisor's cwd in another worktree silently rebound the CLI to
+# widget_hermes_local because that worktree's .ax/config.toml had the wrong
+# [agent].workdir. Bug report: aX msg 06bc04f0.
+# ---------------------------------------------------------------------------
+
+class TestStaleWorkdirMismatch:
+    def test_returns_none_when_workdir_matches(self, tmp_path):
+        cfg = {"agent": {"workdir": str(tmp_path)}}
+        assert _local_config_workdir_mismatch(cfg, tmp_path) is None
+
+    def test_returns_dict_when_workdir_differs(self, tmp_path):
+        other = tmp_path / "other"
+        other.mkdir()
+        cfg = {"agent": {"workdir": str(other)}}
+        result = _local_config_workdir_mismatch(cfg, tmp_path)
+        assert result is not None
+        assert result["configured_workdir"] == str(other.resolve())
+        assert result["actual_workdir"] == str(tmp_path.resolve())
+        assert result["config_path"].endswith(".ax/config.toml")
+
+    def test_returns_none_when_workdir_field_missing(self, tmp_path):
+        # Legacy / minimal config without workdir field — no opinion.
+        cfg = {"agent": {"agent_name": "some-agent"}}
+        assert _local_config_workdir_mismatch(cfg, tmp_path) is None
+
+    def test_returns_none_when_no_agent_block(self, tmp_path):
+        cfg = {"gateway": {"url": "http://x"}}
+        assert _local_config_workdir_mismatch(cfg, tmp_path) is None
+
+    def test_returns_none_when_project_root_none(self):
+        cfg = {"agent": {"workdir": "/some/path"}}
+        assert _local_config_workdir_mismatch(cfg, None) is None
+
+    def test_returns_none_for_non_dict_cfg(self, tmp_path):
+        assert _local_config_workdir_mismatch(None, tmp_path) is None  # type: ignore[arg-type]
+
+    def test_warning_fires_once_per_config_path(self, tmp_path, capsys):
+        # Reset the warned set so this test is independent.
+        config_module._stale_workdir_warned.clear()
+        mismatch = {
+            "config_path": str(tmp_path / ".ax" / "config.toml"),
+            "configured_workdir": "/somewhere/else",
+            "actual_workdir": str(tmp_path),
+        }
+        _warn_stale_workdir_local_config(mismatch)
+        first = capsys.readouterr().err
+        _warn_stale_workdir_local_config(mismatch)
+        second = capsys.readouterr().err
+        assert "Stale local aX config" in first
+        assert second == ""  # second call suppressed
+
+    def test_load_local_config_warns_when_stale(self, tmp_path, monkeypatch, capsys):
+        config_module._stale_workdir_warned.clear()
+        ax_dir = tmp_path / ".ax"
+        ax_dir.mkdir()
+        (ax_dir / "config.toml").write_text(
+            '[gateway]\nmode = "local"\nurl = "http://127.0.0.1:8765"\n\n'
+            '[agent]\nagent_name = "widget_hermes_local"\n'
+            'workdir = "/some/other/worktree"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        cfg = _load_local_config()
+        assert cfg["agent"]["agent_name"] == "widget_hermes_local"
+        captured = capsys.readouterr().err
+        assert "Stale local aX config" in captured
+        assert "/some/other/worktree" in captured
+        assert str(tmp_path) in captured
+
+    def test_load_local_config_silent_when_workdir_matches(self, tmp_path, monkeypatch, capsys):
+        config_module._stale_workdir_warned.clear()
+        ax_dir = tmp_path / ".ax"
+        ax_dir.mkdir()
+        (ax_dir / "config.toml").write_text(
+            '[gateway]\nmode = "local"\nurl = "http://127.0.0.1:8765"\n\n'
+            '[agent]\nagent_name = "ok-agent"\n'
+            f'workdir = "{tmp_path}"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        _load_local_config()
+        assert "Stale local aX config" not in capsys.readouterr().err
+
+    def test_diagnose_includes_stale_workdir_warning(self, tmp_path, monkeypatch):
+        config_module._stale_workdir_warned.clear()
+        ax_dir = tmp_path / ".ax"
+        ax_dir.mkdir()
+        (ax_dir / "config.toml").write_text(
+            '[gateway]\nmode = "local"\nurl = "http://127.0.0.1:8765"\n\n'
+            '[agent]\nagent_name = "widget"\n'
+            'workdir = "/other/worktree"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        # Isolate global config dir so diagnose doesn't read a real ~/.ax
+        monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "global"))
+        report = diagnose_auth_config()
+        codes = [w.get("code") for w in report.get("warnings", [])]
+        assert "stale_workdir_local_config" in codes


### PR DESCRIPTION
## Summary

Defense against the misattribution incident reported by codex_supervisor at aX msg \`06bc04f0\` on 2026-05-04. Codex's shell was in worktree \`ax-frontend-activity-stream-rc/\`, whose \`.ax/config.toml\` had \`[agent].workdir\` pointing at a *different* worktree (likely copied across worktrees). The CLI walked cwd, found that config, took it at face value, and silently rebound to \`widget_hermes_local\`. A message Codex authored went out under widget's signature (msg \`d97e0ad1\`).

This change does not refuse stale configs (existing setups keep working) — it converts the silent rebind into a loud warning at the lowest layer, so the operator is alerted before they send.

## What changed

- New \`_local_config_workdir_mismatch(cfg, project_root)\` helper in \`ax_cli/config.py\` returns mismatch info when \`[agent].workdir\` (or \`[gateway].workdir\` as fallback) does not match the cwd-resolved project root.
- \`_load_local_config()\` emits a one-time yellow stderr warning per offending \`config_path\` on first read.
- \`auth_diagnostic_payload\` appends a structured warning with code \`stale_workdir_local_config\` for \`ax auth doctor --json\` and \`whoami --json\` consumers.
- \`ax auth whoami\` surfaces a \`stale_workdir\` field in the payload and a yellow console line for human readers.

Legacy configs without a workdir field are unaffected — no opinion is rendered for them.

## Why this is v1 (tactical), not the architectural fix

Identity-pinned sessions (a first-class \`ax inbox watch / attach\` primitive that locks identity at session-start, immune to cwd-resolved configs) is the durable fix; it's tracked as v2 in project memory \`project_gateway_connection_security_model.md\` (Madtank, 2026-05-04). v3 covers transport integrity / e2e between CLI and Gateway daemon. Both deferred to follow-up PRs.

This PR closes the silent-failure gap right now without waiting for the architectural redesign.

## Test plan

- [x] 13 new tests in \`TestStaleWorkdirMismatch\` covering helper truth-table, warning de-dup, end-to-end \`_load_local_config\`, and \`diagnose_auth_config\` integration.
- [x] \`uv run pytest\` — 621 passed.
- [x] \`uv run ruff check ax_cli/ tests/\` — clean.
- [x] \`uv run ruff format --check ax_cli/\` — clean.
- [x] Manual smoke: synthetic stale config in a fresh dir → \`_load_local_config()\` emits the warning to stderr exactly as designed.

## Out of scope (deferred)

- v2: session-pinned identity primitive (\`ax inbox watch --agent NAME\`, \`AX_AGENT_LOCK\`)
- v3: transport integrity / e2e between CLI and Gateway daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)