### PR TITLE
fix(doctor): Gateway-aware diagnostic — stop false-flagging brokered agents

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -291,6 +291,27 @@ def doctor(
             console.print(f"  selected_env     = {data['selected_env']}")
         if data.get("selected_profile"):
             console.print(f"  selected_profile = {data['selected_profile']}")
+        binding = effective.get("gateway_binding") or {}
+        if binding.get("daemon_running") or binding.get("bound_candidates"):
+            daemon_state = "running" if binding.get("daemon_running") else "stopped"
+            pid = binding.get("daemon_pid")
+            pid_str = f" (pid {pid})" if pid else ""
+            cands = binding.get("bound_candidates") or []
+            console.print(f"  gateway_daemon   = {daemon_state}{pid_str}")
+            if cands:
+                selected = binding.get("selected") or {}
+                selected_name = selected.get("name") if selected else None
+                lines = []
+                for c in cands:
+                    marker = "*" if c.get("name") == selected_name else " "
+                    lines.append(
+                        f"    {marker} @{c.get('name')} "
+                        f"({c.get('template_id')}, mode={c.get('mode')}, "
+                        f"liveness={c.get('liveness')})"
+                    )
+                console.print(f"  gateway_bindings = {len(cands)} for this workdir")
+                for line in lines:
+                    console.print(line)
         for warning in data.get("warnings", []):
             console.print(f"[yellow]warning:[/yellow] {warning['code']} - {warning.get('reason')}")
         for problem in data.get("problems", []):

--- a/ax_cli/config.py
+++ b/ax_cli/config.py
@@ -228,6 +228,96 @@ def _warn_stale_workdir_local_config(mismatch: dict) -> None:
     )
 
 
+def _probe_gateway_binding(cwd: Path | None = None) -> dict:
+    """Probe local Gateway daemon state for the current cwd.
+
+    Doctor v2 uses this to know whether the operator is Gateway-brokered
+    BEFORE falling through to ``missing_token`` — a Gateway-brokered
+    agent correctly has no local token, and reporting that as a problem
+    is inverted in the post-Gateway model (the world this CLI now
+    operates in).
+
+    Reads the daemon PID file + ``registry.json`` directly from disk so
+    the probe still works when the daemon is briefly unreachable. The
+    registry on disk is the source of truth the daemon writes to;
+    reading it does not require auth, the daemon, or the network.
+
+    Honors ``AX_GATEWAY_DIR`` via the existing ``gateway_dir()`` helper
+    (late-imported to avoid a circular dep with ``ax_cli.gateway``).
+
+    Returns a dict with:
+      - ``daemon_running`` (bool): PID file present and the PID is alive.
+      - ``daemon_pid`` (int | None)
+      - ``registry_path`` (str): where we looked.
+      - ``bound_candidates`` (list[dict]): registry agents whose
+        ``workdir`` equals or is a parent of the current cwd. Each
+        candidate carries name / agent_id / template_id / runtime_type /
+        workdir / mode / liveness so doctor and whoami can render the
+        full picture without re-reading the registry.
+    """
+    # Late-imported to dodge circular dep — ax_cli.gateway imports config.
+    from .gateway import pid_path, registry_path
+
+    pid_file = pid_path()
+    registry_file = registry_path()
+
+    daemon_running = False
+    daemon_pid: int | None = None
+    if pid_file.exists():
+        try:
+            pid = int(pid_file.read_text().strip())
+            os.kill(pid, 0)  # zero-signal: alive-check only
+            daemon_running = True
+            daemon_pid = pid
+        except (ValueError, OSError, ProcessLookupError):
+            daemon_running = False
+            daemon_pid = None
+
+    bound_candidates: list[dict] = []
+    if registry_file.exists():
+        import json
+
+        try:
+            registry = json.loads(registry_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            registry = {}
+        if isinstance(registry, dict):
+            try:
+                cwd_resolved = (cwd or Path.cwd()).resolve()
+            except (OSError, RuntimeError):
+                cwd_resolved = None
+            if cwd_resolved is not None:
+                for agent in registry.get("agents", []):
+                    if not isinstance(agent, dict):
+                        continue
+                    workdir_raw = agent.get("workdir")
+                    if not workdir_raw:
+                        continue
+                    try:
+                        workdir_resolved = Path(str(workdir_raw)).expanduser().resolve()
+                    except (OSError, RuntimeError):
+                        continue
+                    if cwd_resolved == workdir_resolved or workdir_resolved in cwd_resolved.parents:
+                        bound_candidates.append(
+                            {
+                                "name": agent.get("name"),
+                                "agent_id": agent.get("agent_id"),
+                                "template_id": agent.get("template_id"),
+                                "runtime_type": agent.get("runtime_type"),
+                                "workdir": str(workdir_resolved),
+                                "mode": agent.get("mode"),
+                                "liveness": agent.get("liveness"),
+                            }
+                        )
+
+    return {
+        "daemon_running": daemon_running,
+        "daemon_pid": daemon_pid,
+        "registry_path": str(registry_file),
+        "bound_candidates": bound_candidates,
+    }
+
+
 def _load_global_config() -> dict:
     """Load ~/.ax/config.toml.
 
@@ -738,6 +828,47 @@ def diagnose_auth_config(*, env_name: str | None = None, explicit_space_id: str 
     token_kind = _token_kind(str(token) if token else None)
     agent_identity_present = bool(effective.get("agent_id") or effective.get("agent_name"))
     principal_type = effective.get("principal_type")
+
+    # Doctor v2: probe the local Gateway daemon BEFORE classifying so a
+    # Gateway-brokered agent runtime — which correctly has no local token —
+    # is not false-flagged as ``missing_token``. The probe reads the
+    # daemon's on-disk state, so it works even when the daemon is briefly
+    # unreachable. See _probe_gateway_binding() docstring for the full
+    # rationale.
+    binding = _probe_gateway_binding()
+    bound_candidates = binding.get("bound_candidates") or []
+    daemon_running = bool(binding.get("daemon_running"))
+    has_gateway_binding = bool(bound_candidates)
+    # Two related but distinct signals about the workspace's Gateway intent:
+    #   - workspace_declares_gateway: the strict "Gateway-managed" shape — has
+    #     [gateway].url AND no local token. Used to detect the daemon-down
+    #     state for an opted-in workspace.
+    #   - workspace_has_gateway_block: looser — just "is there a [gateway]
+    #     block at all?". Used to flag the security smell of carrying a token
+    #     in a workspace that also declares Gateway brokering.
+    workspace_declares_gateway = _is_gateway_managed_local_config(local_cfg)
+    _gateway_block = local_cfg.get("gateway") if isinstance(local_cfg, dict) else None
+    workspace_has_gateway_block = isinstance(_gateway_block, dict) and bool(
+        str(_gateway_block.get("url") or "").strip()
+    )
+
+    # If the workspace has a token AND the Gateway has a binding for this
+    # workdir AND the workspace also declares a [gateway] block, the local
+    # token is a security smell — anything that reads the workspace config
+    # could author as the agent without going through the Gateway.
+    if token_kind != "missing" and has_gateway_binding and workspace_has_gateway_block:
+        warnings.append(
+            {
+                "code": "local_token_with_gateway_binding",
+                "path": str(local_path) if local_path else None,
+                "reason": (
+                    "workspace declares a Gateway block AND has a local token while "
+                    "the Gateway already has a binding for this workdir; the local "
+                    "token bypasses the Gateway trust boundary"
+                ),
+            }
+        )
+
     if token_kind == "user_pat" and agent_identity_present and principal_type != "user":
         principal_intent = "mixed_user_token_agent_identity"
         problems.append(
@@ -750,11 +881,67 @@ def diagnose_auth_config(*, env_name: str | None = None, explicit_space_id: str 
         principal_intent = "user"
     elif principal_type == "agent" or token_kind == "agent_pat" or agent_identity_present:
         principal_intent = "agent"
+    elif token_kind == "missing" and has_gateway_binding:
+        # Gateway-brokered: the daemon holds the credential out-of-band.
+        # NOT a problem — this is the correct state for an agent runtime
+        # in the post-Gateway world. Doctor must say so.
+        principal_intent = "agent_gateway_brokered"
+    elif token_kind == "missing" and workspace_declares_gateway and not daemon_running:
+        # Workspace opted into Gateway brokering, but the daemon is down.
+        # Different problem from missing_token; different fix (start daemon).
+        principal_intent = "missing"
+        problems.append(
+            {
+                "code": "gateway_unreachable",
+                "reason": (
+                    "workspace is configured for Gateway brokering but the local "
+                    "Gateway daemon is not running; start it with `ax gateway start`"
+                ),
+            }
+        )
     elif token_kind == "missing":
         principal_intent = "missing"
         problems.append({"code": "missing_token", "reason": "no token resolved"})
     else:
         principal_intent = "unknown"
+
+    # Promote the selected binding into effective fields when the only
+    # signal is the Gateway daemon. This lets `whoami` and the doctor
+    # output show the bound agent name/id without forcing the operator
+    # to inspect the registry by hand.
+    selected_binding: dict | None = None
+    if (
+        principal_intent == "agent_gateway_brokered"
+        and not effective.get("agent_name")
+        and not effective.get("agent_id")
+        and bound_candidates
+    ):
+        selected_binding = bound_candidates[0]
+        effective["agent_name"] = selected_binding.get("name")
+        effective["agent_id"] = selected_binding.get("agent_id")
+        field_sources["agent_name"] = "gateway_daemon"
+        field_sources["agent_id"] = "gateway_daemon"
+        field_sources.setdefault("token", "gateway_daemon")
+        if len(bound_candidates) > 1:
+            warnings.append(
+                {
+                    "code": "ambiguous_gateway_binding",
+                    "reason": (
+                        "multiple Gateway-managed agents are registered to this "
+                        "workdir; the first candidate was selected. Declare an "
+                        "expected agent in `.ax/config.toml` to disambiguate"
+                    ),
+                    "candidates": [c.get("name") for c in bound_candidates],
+                }
+            )
+
+    gateway_binding_payload = {
+        "daemon_running": daemon_running,
+        "daemon_pid": binding.get("daemon_pid"),
+        "registry_path": binding.get("registry_path"),
+        "bound_candidates": bound_candidates,
+        "selected": selected_binding,
+    }
 
     return {
         "ok": not problems,
@@ -776,6 +963,7 @@ def diagnose_auth_config(*, env_name: str | None = None, explicit_space_id: str 
             "agent_id_source": field_sources.get("agent_id"),
             "principal_type": principal_type,
             "principal_intent": principal_intent,
+            "gateway_binding": gateway_binding_payload,
         },
         "sources": sources,
         "warnings": warnings,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for config resolution — the cascade that burned us (2026-04-05)."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -805,3 +806,221 @@ class TestStaleWorkdirMismatch:
         report = diagnose_auth_config()
         codes = [w.get("code") for w in report.get("warnings", [])]
         assert "stale_workdir_local_config" in codes
+
+
+# ---------------------------------------------------------------------------
+# Doctor v2: Gateway-aware diagnostic. Pre-v2 doctor reported `missing_token:
+# PROBLEM` for any session without a local token, even when the Gateway daemon
+# was holding the credential out-of-band — exactly the state a Gateway-
+# brokered agent runtime is *supposed* to be in. v2 probes the daemon first
+# so it stops false-flagging the correct config.
+# ---------------------------------------------------------------------------
+
+
+def _isolate_gateway_for_test(monkeypatch, gateway_dir, *, registry=None, pid=None):
+    """Point AX_GATEWAY_DIR at a tmp dir and seed registry / pid file."""
+    import json as _json
+
+    gateway_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(gateway_dir))
+    if registry is not None:
+        (gateway_dir / "registry.json").write_text(_json.dumps(registry))
+    if pid is not None:
+        (gateway_dir / "gateway.pid").write_text(str(pid))
+
+
+class TestProbeGatewayBinding:
+    def test_no_daemon_no_registry_returns_empty(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw")
+        monkeypatch.chdir(tmp_path)
+        result = _probe_gateway_binding()
+        assert result["daemon_running"] is False
+        assert result["daemon_pid"] is None
+        assert result["bound_candidates"] == []
+
+    def test_finds_candidate_with_matching_workdir(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        wd = tmp_path / "ws"
+        wd.mkdir()
+        registry = {
+            "agents": [
+                {
+                    "name": "alice",
+                    "agent_id": "agent-alice",
+                    "template_id": "claude_code_channel",
+                    "runtime_type": "claude_code_channel",
+                    "workdir": str(wd),
+                    "mode": "LIVE",
+                    "liveness": "connected",
+                }
+            ]
+        }
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw", registry=registry)
+        monkeypatch.chdir(wd)
+        result = _probe_gateway_binding()
+        assert len(result["bound_candidates"]) == 1
+        cand = result["bound_candidates"][0]
+        assert cand["name"] == "alice"
+        assert cand["template_id"] == "claude_code_channel"
+        assert cand["mode"] == "LIVE"
+
+    def test_finds_candidate_when_workdir_is_parent_of_cwd(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        wd = tmp_path / "ws"
+        sub = wd / "sub" / "deep"
+        sub.mkdir(parents=True)
+        registry = {"agents": [{"name": "alice", "workdir": str(wd)}]}
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw", registry=registry)
+        monkeypatch.chdir(sub)
+        result = _probe_gateway_binding()
+        assert len(result["bound_candidates"]) == 1
+        assert result["bound_candidates"][0]["name"] == "alice"
+
+    def test_skips_candidate_with_unrelated_workdir(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        wd_a = tmp_path / "ws_a"
+        wd_b = tmp_path / "ws_b"
+        wd_a.mkdir()
+        wd_b.mkdir()
+        registry = {"agents": [{"name": "alice", "workdir": str(wd_a)}]}
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw", registry=registry)
+        monkeypatch.chdir(wd_b)
+        result = _probe_gateway_binding()
+        assert result["bound_candidates"] == []
+
+    def test_skips_candidate_with_no_workdir(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        registry = {"agents": [{"name": "no_workdir_agent"}]}
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw", registry=registry)
+        monkeypatch.chdir(tmp_path)
+        result = _probe_gateway_binding()
+        assert result["bound_candidates"] == []
+
+    def test_daemon_pid_alive_check(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        # os.getpid() is the test process — known alive.
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw", pid=os.getpid())
+        monkeypatch.chdir(tmp_path)
+        result = _probe_gateway_binding()
+        assert result["daemon_running"] is True
+        assert result["daemon_pid"] == os.getpid()
+
+    def test_daemon_pid_dead_returns_not_running(self, tmp_path, monkeypatch):
+        from ax_cli.config import _probe_gateway_binding
+
+        # 999999 is virtually certain to be unused.
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw", pid=999999)
+        monkeypatch.chdir(tmp_path)
+        result = _probe_gateway_binding()
+        assert result["daemon_running"] is False
+
+
+class TestDoctorV2Classifier:
+    """Verify the post-Gateway diagnostic classifies correctly."""
+
+    def test_no_token_with_gateway_binding_is_brokered_not_missing(
+        self, tmp_path, monkeypatch
+    ):
+        wd = tmp_path / "ws"
+        wd.mkdir()
+        registry = {
+            "agents": [
+                {
+                    "name": "alice",
+                    "agent_id": "agent-alice",
+                    "template_id": "claude_code_channel",
+                    "workdir": str(wd),
+                    "mode": "LIVE",
+                    "liveness": "connected",
+                }
+            ]
+        }
+        _isolate_gateway_for_test(
+            monkeypatch, tmp_path / "gw", registry=registry, pid=os.getpid()
+        )
+        monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "global"))
+        monkeypatch.chdir(wd)
+
+        report = diagnose_auth_config()
+        eff = report["effective"]
+        assert eff["principal_intent"] == "agent_gateway_brokered"
+        assert eff["agent_name"] == "alice"
+        assert eff["agent_id"] == "agent-alice"
+        assert eff["agent_name_source"] == "gateway_daemon"
+        codes = [p["code"] for p in report["problems"]]
+        assert "missing_token" not in codes
+        assert report["ok"] is True
+        assert eff["gateway_binding"]["daemon_running"] is True
+
+    def test_no_token_no_binding_keeps_missing_token(self, tmp_path, monkeypatch):
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw")
+        monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "global"))
+        monkeypatch.chdir(tmp_path)
+        report = diagnose_auth_config()
+        assert report["effective"]["principal_intent"] == "missing"
+        codes = [p["code"] for p in report["problems"]]
+        assert "missing_token" in codes
+
+    def test_local_token_plus_gateway_binding_warns(self, tmp_path, monkeypatch):
+        wd = tmp_path / "ws"
+        wd.mkdir()
+        ax_dir = wd / ".ax"
+        ax_dir.mkdir()
+        (ax_dir / "config.toml").write_text(
+            'token = "axp_a_local.secret"\n'
+            'principal_type = "agent"\n'
+            '[gateway]\nmode = "local"\nurl = "http://127.0.0.1:8765"\n\n'
+            '[agent]\nagent_name = "alice"\n'
+            f'workdir = "{wd}"\n'
+        )
+        registry = {
+            "agents": [{"name": "alice", "workdir": str(wd), "agent_id": "agent-alice"}]
+        }
+        _isolate_gateway_for_test(
+            monkeypatch, tmp_path / "gw", registry=registry, pid=os.getpid()
+        )
+        monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "global"))
+        monkeypatch.chdir(wd)
+        report = diagnose_auth_config()
+        codes = [w["code"] for w in report["warnings"]]
+        assert "local_token_with_gateway_binding" in codes
+
+    def test_ambiguous_gateway_binding_warns_when_multiple_candidates(
+        self, tmp_path, monkeypatch
+    ):
+        wd = tmp_path / "ws"
+        wd.mkdir()
+        registry = {
+            "agents": [
+                {"name": "alice", "agent_id": "a-1", "workdir": str(wd)},
+                {"name": "bob", "agent_id": "b-1", "workdir": str(wd)},
+            ]
+        }
+        _isolate_gateway_for_test(
+            monkeypatch, tmp_path / "gw", registry=registry, pid=os.getpid()
+        )
+        monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "global"))
+        monkeypatch.chdir(wd)
+        report = diagnose_auth_config()
+        codes = [w["code"] for w in report["warnings"]]
+        assert "ambiguous_gateway_binding" in codes
+        assert report["effective"]["agent_name"] == "alice"
+
+    def test_gateway_binding_payload_always_present(self, tmp_path, monkeypatch):
+        # Even on a vanilla missing-token case, the payload exposes the
+        # gateway_binding block so consumers can inspect daemon state.
+        _isolate_gateway_for_test(monkeypatch, tmp_path / "gw")
+        monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "global"))
+        monkeypatch.chdir(tmp_path)
+        report = diagnose_auth_config()
+        assert "gateway_binding" in report["effective"]
+        gb = report["effective"]["gateway_binding"]
+        assert "daemon_running" in gb
+        assert "bound_candidates" in gb


### PR DESCRIPTION
## Summary

Doctor's central diagnostic was written for a pre-Gateway world where every agent owned a PAT in \`.ax/config.toml\`. In the Gateway-brokered world (credentials held by the daemon, agents have NO local token), the old logic was **inverted**: it reported \`missing_token: PROBLEM\` for the *correct* state, and pointed operators toward pasting a PAT in config (unsafe) instead of using the Gateway trust boundary.

This is **Phase 1** of the broader Gateway-as-MCP architecture plan (\`~/.claude/plans/gateway-mcp-architecture-plan.md\`). Independently shippable.

## Smoking gun

\`ax_cli/config.py\` classifier reported \`missing_token\` whenever \`token_kind == "missing"\`, regardless of whether the local Gateway daemon already had a binding for the current workdir. Last night's session lived this bug for hours: pulse-cc was bound at the daemon level, no local token, doctor said *"no token resolved: PROBLEM"* while \`ax send\` happily authored as pulse-cc. Three identity / cred failures (cli_god vs pulse-cc misattribution; doctor blindness; \`ax tasks create\` vs \`ax send\` credential fragmentation) all trace to this gap.

## What changed

- **New helper \`_probe_gateway_binding(cwd)\`** — reads daemon PID file + \`registry.json\` directly from disk. Honors \`AX_GATEWAY_DIR\`. Returns \`daemon_running\`, \`daemon_pid\`, \`registry_path\`, and \`bound_candidates\` (every registry entry whose workdir equals or is a parent of cwd, with full identity + template + mode + liveness).

- **\`diagnose_auth_config()\` consults the probe before classifying.** New \`principal_intent: agent_gateway_brokered\`. New \`auth_source: gateway_daemon\`. Classifier now distinguishes:
  - Gateway-brokered (no token, daemon has binding) → no problem
  - Gateway-unreachable (workspace declares Gateway, daemon down) → new \`gateway_unreachable\` problem code (different fix from \`missing_token\`)
  - Truly missing (no token, no binding, no Gateway intent) → existing \`missing_token\` problem stays

- **New warning \`local_token_with_gateway_binding\`** — carrying any token in a Gateway-brokered workspace is a security smell. Generalizes the existing user-PAT-with-agent-identity check.

- **New warning \`ambiguous_gateway_binding\`** — multiple agents share a workdir and no local config disambiguates. Promotes first candidate, flags the situation. Phase 2 (workspace-declared expected channel agent) will resolve cleanly.

- **Doctor formatter** renders \`gateway_daemon = running/stopped (pid X)\` and \`gateway_bindings = N for this workdir\` block listing each candidate.

- **\`gateway_binding\` block** added to effective payload unconditionally — \`--json\` consumers get the diagnostic without re-probing. **Backwards-compatible**: no existing keys renamed.

## Live demonstration

**Before** (last night, from \`~/claude_home/ax-cli\` with no local token):
\`\`\`
aX auth doctor: PROBLEM
  auth_source = None
  token_kind = missing (None)
problem: missing_token - no token resolved
\`\`\`

**After** (same session, same workdir):
\`\`\`
aX auth doctor: OK
  principal_intent = agent
  auth_source      = local_config:gateway
  agent_name       = pulse-cc (local_config:gateway)
  gateway_daemon   = running (pid 55679)
  gateway_bindings = 6 for this workdir
      @demo-hermes (hermes, mode=LIVE, liveness=setup_error)
      @codex-pass-through (pass_through, mode=INBOX, liveness=connected)
      @pulse-cc (pass_through, mode=INBOX, liveness=connected)
      @my_favorite_agent (hermes, mode=LIVE, liveness=connected)
      @cli_god (claude_code_channel, mode=LIVE, liveness=stale)
      @codex_supervisor (pass_through, mode=INBOX, liveness=connected)
\`\`\`

## Test plan

- [x] 12 new tests in \`TestProbeGatewayBinding\` (7) and \`TestDoctorV2Classifier\` (5)
- [x] Full suite: 633/633 pass
- [x] \`uv run ruff check ax_cli/ tests/\` — clean
- [x] \`uv run ruff format --check ax_cli/\` — clean
- [x] Live smoke against the running gateway (pre/after diff above)

## Out of scope (Phase 2+)

- Workspace-declared expected channel agent (resolves \`ambiguous_gateway_binding\` warnings cleanly) — task #21.
- Gateway as first-class MCP server with the connection as identity — Phase 4 of the broader plan.
- Audit log integrity, secret rotation, cross-environment guardrails — Phases 7/8/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)