### PR TITLE
fix(windows): skip POSIX permission checks for config and token cache

### DIFF
--- a/ax_cli/config.py
+++ b/ax_cli/config.py
@@ -10,6 +10,7 @@ the agent operates — never shared via ~/.ax/ unless explicitly requested.
 
 import os
 import re
+import sys
 import tomllib  # stdlib 3.11+
 from pathlib import Path
 from urllib.parse import urlparse
@@ -1035,7 +1036,15 @@ def _save_config(cfg: dict, *, local: bool = True) -> None:
 
 
 def _check_config_permissions() -> None:
-    """AUTH-SPEC-001 §13: Refuse PAT files with permissions broader than 0600."""
+    """AUTH-SPEC-001 §13: Refuse PAT files with permissions broader than 0600.
+
+    Skipped on Windows: NTFS uses ACLs, not POSIX mode bits, and
+    ``stat().st_mode`` always reports 0o666/0o644 there. The check would
+    fire on every CLI invocation with no way for the user to satisfy it.
+    Windows users should restrict access via ``icacls`` if needed.
+    """
+    if sys.platform == "win32":
+        return
     for config_dir_fn in (_local_config_dir, _global_config_dir):
         try:
             d = config_dir_fn() if callable(config_dir_fn) else config_dir_fn
@@ -1045,8 +1054,6 @@ def _check_config_permissions() -> None:
             if cf.exists():
                 mode = cf.stat().st_mode & 0o777
                 if mode > 0o600:
-                    import sys
-
                     print(
                         f"WARNING: {cf} has permissions {oct(mode)} — should be 0600. Run: chmod 600 {cf}",
                         file=sys.stderr,

--- a/ax_cli/token_cache.py
+++ b/ax_cli/token_cache.py
@@ -10,6 +10,7 @@ Cache file: separate from PAT config, permissions 0600.
 import hashlib
 import json
 import logging
+import sys
 import time
 from pathlib import Path
 
@@ -98,12 +99,16 @@ class TokenExchanger:
         cache_file = self._cache_dir / "tokens.json"
         if cache_file.exists():
             try:
-                # Verify permissions
-                mode = cache_file.stat().st_mode & 0o777
-                if mode != 0o600:
-                    logger.warning("Token cache has wrong permissions %o, removing", mode)
-                    cache_file.unlink()
-                    return
+                # NTFS uses ACLs, not POSIX mode bits — `stat().st_mode` always
+                # reports 0o666/0o644 on Windows regardless of actual access,
+                # which would delete the cache on every call. ACL-based
+                # protection (icacls) is the user's responsibility on Windows.
+                if sys.platform != "win32":
+                    mode = cache_file.stat().st_mode & 0o777
+                    if mode != 0o600:
+                        logger.warning("Token cache has wrong permissions %o, removing", mode)
+                        cache_file.unlink()
+                        return
                 data = json.loads(cache_file.read_text())
                 # Only load entries for this PAT
                 if isinstance(data, dict):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for config resolution — the cascade that burned us (2026-04-05)."""
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ from click.exceptions import Exit
 
 from ax_cli import config as config_module
 from ax_cli.config import (
+    _check_config_permissions,
     _find_project_root,
     _global_config_dir,
     _load_config,
@@ -691,6 +693,35 @@ class TestResolveToken:
 
         assert resolve_user_token() == "axp_u_dev.secret"
         assert resolve_user_base_url() == "https://dev.paxai.app"
+
+
+class TestCheckConfigPermissions:
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission semantics")
+    def test_warns_on_world_readable_config(self, tmp_path, monkeypatch, capsys):
+        cf = tmp_path / "config.toml"
+        cf.write_text('token = "axp_u_x.y"\n')
+        cf.chmod(0o644)
+        monkeypatch.setattr(config_module, "_local_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(config_module, "_global_config_dir", lambda: tmp_path / "nope")
+
+        _check_config_permissions()
+
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "0o644" in err
+
+    def test_skipped_on_windows(self, tmp_path, monkeypatch, capsys):
+        cf = tmp_path / "config.toml"
+        cf.write_text('token = "axp_u_x.y"\n')
+        if sys.platform != "win32":
+            cf.chmod(0o644)
+        monkeypatch.setattr(config_module, "_local_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(config_module, "_global_config_dir", lambda: tmp_path / "nope")
+        monkeypatch.setattr(config_module.sys, "platform", "win32")
+
+        _check_config_permissions()
+
+        assert capsys.readouterr().err == ""
 
 
 class TestResolveBaseUrl:

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -1,5 +1,7 @@
 """Tests for token exchange and caching (AUTH-SPEC-001 §13)."""
 
+import sys
+
 import pytest
 
 from ax_cli.token_cache import (
@@ -218,6 +220,7 @@ class TestTokenExchanger:
         assert token == "fake.jwt.token"
         assert mock_post.call_count == 1  # only the first exchange, second loaded from disk
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="NTFS uses ACLs, not POSIX mode bits")
     def test_disk_cache_permissions(self, tmp_path, monkeypatch, sample_pat, mock_exchange):
         mock_exchange()
         monkeypatch.chdir(tmp_path)
@@ -231,3 +234,30 @@ class TestTokenExchanger:
         assert cache_file.exists()
         mode = cache_file.stat().st_mode & 0o777
         assert mode == 0o600
+
+    def test_disk_cache_loads_on_windows_despite_loose_mode(
+        self, tmp_path, monkeypatch, sample_pat, mock_exchange
+    ):
+        """Regression: on Windows the cache file reports 0o666 via stat() and was
+        being deleted on every CLI invocation. With sys.platform == 'win32' the
+        loader must skip the mode check entirely and reuse the cache."""
+        mock_post = mock_exchange()
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".ax").mkdir()
+        (tmp_path / ".ax" / "config.toml").write_text("")
+        monkeypatch.setattr("ax_cli.token_cache.sys.platform", "win32")
+
+        exchanger1 = TokenExchanger("https://example.com", sample_pat)
+        exchanger1.get_token("user_access")
+        cache_file = tmp_path / ".ax" / "cache" / "tokens.json"
+        assert cache_file.exists()
+
+        if sys.platform != "win32":
+            cache_file.chmod(0o666)
+
+        exchanger2 = TokenExchanger("https://example.com", sample_pat)
+        token = exchanger2.get_token("user_access")
+
+        assert token == "fake.jwt.token"
+        assert mock_post.call_count == 1, "cache must persist; no second exchange call"
+        assert cache_file.exists(), "cache must not be deleted on Windows"


### PR DESCRIPTION
NTFS uses ACLs, not POSIX mode bits, so `stat().st_mode` always reports
0o666/0o644 on Windows regardless of actual access. Two checks were firing
on every CLI invocation with no way for the user to satisfy them:

- `_check_config_permissions` printed `WARNING: ...config.toml has permissions 0o666 - should be 0600` on every call.
- `TokenExchanger._load_disk_cache` saw the cache as world-readable, logged a warning, and deleted the file — defeating disk caching entirely on Windows and forcing a fresh `/auth/exchange` round-trip per command.

Skip both checks when `sys.platform == "win32"`. Windows users who want
restricted access should use `icacls`. POSIX behavior is unchanged.

Closes #20
Closes #3

## Summary

Both `_check_config_permissions` (in `ax_cli/config.py`) and `TokenExchanger._load_disk_cache` (in `ax_cli/token_cache.py`) early-return when `sys.platform == "win32"`. The existing `chmod(0o600)` calls are kept — Python no-ops them on Windows and they remain correct on POSIX. Tests guarded with `@pytest.mark.skipif(sys.platform == "win32", ...)` for POSIX-only mode assertions, plus two new tests for the Windows path:
- `tests/test_token_cache.py::test_disk_cache_loads_on_windows_despite_loose_mode` — proves the cache survives across exchanger instances when `sys.platform` is forced to `"win32"`.
- `tests/test_config.py::TestCheckConfigPermissions::test_skipped_on_windows` — proves no warning is emitted on Windows even with a 0o644 file.

## Validation

- [x] `pytest tests/test_token_cache.py tests/test_config.py::TestCheckConfigPermissions -v` (23 passed, 2 skipped — POSIX-only mode assertions)
- [x] `pytest tests/` full suite: 598 passed / 41 failed / 2 skipped on Windows. The 41 failures are **pre-existing on `main`** (verified with `git stash`); main has 42 failures because `test_disk_cache_permissions` was failing there and now correctly skips on Windows.
- [x] `ruff check ax_cli/` — clean
- [x] `ruff format --check ax_cli/` — 36 files already formatted
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; this PR does not change auth behavior, only Windows-conditional warning/cache-load logic
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable
- [x] Manual smoke on Windows 11: `python -c "from ax_cli.main import app; app(['auth', 'whoami'])"` — neither `WARNING: ...permissions 0o666` nor `Token cache has wrong permissions 666, removing` is printed any longer.

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

Cache *content* and exchange behavior are untouched — only the platform-conditional gate around the mode check is new. On POSIX the validation runs exactly as before; on Windows the cache is now actually used (it was being deleted on every call, forcing a fresh `/auth/exchange` round-trip per command).
