### PR TITLE
fix(cli): make Gateway local-route 404 errors actionable

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -7233,6 +7233,47 @@ def _resolve_local_gateway_identity(
     return requested_agent or None, requested_ref or None
 
 
+def _local_route_failure_guidance(
+    *,
+    detail: str,
+    status_code: int | None,
+    gateway_url: str,
+    agent_name: str | None,
+    workdir: str | None,
+    action: str,
+) -> str:
+    """Build an actionable error message for /local/connect or /local/proxy failures.
+
+    The bare ``Gateway local connect failed: not found`` text from a 404 leaves
+    the operator with no idea what to try next — it doesn't even hint that the
+    workspace might be bound to a Live Listener (claude_code_channel, hermes)
+    that uses direct identity instead of the local-connect protocol.
+
+    For 404s we surface that and suggest the obvious recovery commands. For
+    other statuses we keep the message terse but still point at the Gateway UI.
+    """
+    name = (agent_name or "").strip()
+    subject = f"@{name}" if name else "this workspace"
+    base_url = gateway_url.rstrip("/")
+    detail_text = (detail or "").strip() or "no detail returned"
+    parts = [f"Gateway {action} failed for {subject}: {detail_text}."]
+    if status_code == 404:
+        parts.append(
+            "Either no Gateway binding is registered for this workspace, "
+            "or the workspace is bound to a Live Listener "
+            "(claude_code_channel, hermes, etc.) which uses direct identity, "
+            "not local-connect/proxy."
+        )
+        suggestions = ["ax gateway agents list --json"]
+        if name and workdir:
+            suggestions.append(f"ax gateway local connect {name} --workdir {workdir}")
+        elif name:
+            suggestions.append(f"ax gateway local connect {name}")
+        parts.append("Try: " + "; ".join(suggestions) + ".")
+    parts.append(f"Or open {base_url} to inspect Gateway agents.")
+    return " ".join(parts)
+
+
 def _approval_required_guidance(
     *,
     connect_payload: dict,
@@ -7373,9 +7414,27 @@ def _request_local_connect(
             detail = exc.response.json().get("error", detail)
         except Exception:
             pass
-        raise ValueError(f"Gateway local connect failed: {detail}") from exc
+        raise ValueError(
+            _local_route_failure_guidance(
+                detail=detail,
+                status_code=exc.response.status_code,
+                gateway_url=gateway_url,
+                agent_name=display_name,
+                workdir=resolved_workdir,
+                action="local connect",
+            )
+        ) from exc
     except Exception as exc:
-        raise ValueError(f"Gateway local connect failed: {exc}") from exc
+        raise ValueError(
+            _local_route_failure_guidance(
+                detail=str(exc),
+                status_code=None,
+                gateway_url=gateway_url,
+                agent_name=display_name,
+                workdir=resolved_workdir,
+                action="local connect",
+            )
+        ) from exc
     return payload
 
 

--- a/ax_cli/commands/messages.py
+++ b/ax_cli/commands/messages.py
@@ -14,7 +14,7 @@ from ..config import get_client, resolve_agent_name, resolve_gateway_config, res
 from ..context_keys import build_upload_context_key
 from ..mentions import merge_explicit_mentions_metadata
 from ..output import JSON_OPTION, console, handle_error, print_json, print_kv, print_table
-from .gateway import _approval_required_guidance, _local_process_fingerprint
+from .gateway import _approval_required_guidance, _local_process_fingerprint, _local_route_failure_guidance
 from .watch import _iter_sse
 
 app = typer.Typer(name="messages", help="Message operations", no_args_is_help=True)
@@ -49,9 +49,27 @@ def _gateway_local_connect(
             detail = exc.response.json().get("error", detail)
         except Exception:
             pass
-        raise typer.BadParameter(f"Gateway local connect failed: {detail}") from exc
+        raise typer.BadParameter(
+            _local_route_failure_guidance(
+                detail=detail,
+                status_code=exc.response.status_code,
+                gateway_url=gateway_url,
+                agent_name=display_name,
+                workdir=workdir,
+                action="local connect",
+            )
+        ) from exc
     except Exception as exc:
-        raise typer.BadParameter(f"Gateway local connect failed: {exc}") from exc
+        raise typer.BadParameter(
+            _local_route_failure_guidance(
+                detail=str(exc),
+                status_code=None,
+                gateway_url=gateway_url,
+                agent_name=display_name,
+                workdir=workdir,
+                action="local connect",
+            )
+        ) from exc
 
 
 def _gateway_local_send(
@@ -179,9 +197,27 @@ def _gateway_local_call(
             detail = exc.response.json().get("error", detail)
         except Exception:
             pass
-        raise typer.BadParameter(f"Gateway proxy {method} failed: {detail}") from exc
+        raise typer.BadParameter(
+            _local_route_failure_guidance(
+                detail=detail,
+                status_code=exc.response.status_code,
+                gateway_url=gateway_url,
+                agent_name=gateway_cfg.get("agent_name"),
+                workdir=gateway_cfg.get("workdir"),
+                action=f"proxy {method}",
+            )
+        ) from exc
     except Exception as exc:
-        raise typer.BadParameter(f"Gateway proxy {method} failed: {exc}") from exc
+        raise typer.BadParameter(
+            _local_route_failure_guidance(
+                detail=str(exc),
+                status_code=None,
+                gateway_url=gateway_url,
+                agent_name=gateway_cfg.get("agent_name"),
+                workdir=gateway_cfg.get("workdir"),
+                action=f"proxy {method}",
+            )
+        ) from exc
     return payload.get("result", payload)
 
 

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -7938,3 +7938,74 @@ def test_proxy_upload_file_rejects_path_outside_workdir(monkeypatch, tmp_path):
     except (ValueError, PermissionError) as exc:
         # Expected after the fix: proxy should raise on path traversal
         assert "workdir" in str(exc).lower() or "path" in str(exc).lower() or "outside" in str(exc).lower()
+
+
+def test_local_route_failure_guidance_404_suggests_recovery():
+    msg = gateway_cmd._local_route_failure_guidance(
+        detail="not found",
+        status_code=404,
+        gateway_url="http://127.0.0.1:8765",
+        agent_name="wishy",
+        workdir="/repo",
+        action="local connect",
+    )
+    assert "Gateway local connect failed for @wishy: not found" in msg
+    # The whole point of this PR — the message must point at the Live Listener
+    # case so users running `ax auth whoami` in a claude_code_channel workspace
+    # don't get a bare "not found".
+    assert "Live Listener" in msg
+    assert "claude_code_channel" in msg
+    assert "ax gateway agents list --json" in msg
+    assert "ax gateway local connect wishy --workdir /repo" in msg
+    assert "http://127.0.0.1:8765" in msg
+
+
+def test_local_route_failure_guidance_non_404_stays_terse():
+    msg = gateway_cmd._local_route_failure_guidance(
+        detail="connection refused",
+        status_code=None,
+        gateway_url="http://127.0.0.1:8765/",
+        agent_name=None,
+        workdir=None,
+        action="proxy whoami",
+    )
+    assert "Gateway proxy whoami failed for this workspace: connection refused" in msg
+    assert "Live Listener" not in msg  # only suggested for 404s
+    assert "Or open http://127.0.0.1:8765 to inspect Gateway agents." in msg
+
+
+def test_gateway_local_connect_404_uses_actionable_guidance(monkeypatch):
+    """Regression for #150: a 404 from /local/connect must point at the Live Listener path."""
+    from ax_cli.commands import messages as messages_cmd
+
+    class _FakeResponse:
+        status_code = 404
+
+        @staticmethod
+        def json():
+            return {"error": "not found"}
+
+        text = '{"error": "not found"}'
+
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("404", request=None, response=self)
+
+    def _fake_post(*args, **kwargs):
+        return _FakeResponse()
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    import typer
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        messages_cmd._gateway_local_connect(
+            gateway_url="http://127.0.0.1:8765",
+            agent_name="wishy",
+            registry_ref=None,
+            workdir="/repo",
+            space_id=None,
+        )
+    msg = str(excinfo.value)
+    assert "@wishy" in msg
+    assert "Live Listener" in msg
+    assert "ax gateway local connect wishy --workdir /repo" in msg


### PR DESCRIPTION
`ax auth whoami` (and any command going through `_gateway_local_connect` or `_gateway_local_call`) printed an opaque `Gateway local connect failed: not found` from any 404 — most often when the workspace is bound to a Live Listener (`claude_code_channel`, `hermes`, etc.) that uses direct identity instead of the local-connect/proxy protocol. The operator was left guessing whether the agent was missing, the binding was wrong, or something else was broken.

Add `_local_route_failure_guidance()` next to `_approval_required_guidance` and use it from the four error sites in `_gateway_local_connect`, `_gateway_local_call`, and `_request_local_connect`. On a 404 the new message:

- names the agent (e.g. `@wishy`),
- explains that this can mean either no Gateway binding or a Live Listener template,
- lists the two recovery commands (`ax gateway agents list --json` and `ax gateway local connect <name> --workdir <pwd>`),
- points at the local Gateway URL.

Non-404 errors stay terse but still surface the Gateway URL.

Closes #150

## Summary

Single helper, four call sites, three new tests. Behavior is unchanged — the only difference is the text the operator sees when local-connect or local-proxy returns 404. No new code paths, no new dependencies, no schema changes.

**Before** (from issue #150):
```
Error: Invalid value: Gateway local connect failed: not found
```

**After** (404 case):
```
Error: Invalid value: Gateway local connect failed for @wishy: not found.
Either no Gateway binding is registered for this workspace, or the workspace
is bound to a Live Listener (claude_code_channel, hermes, etc.) which uses
direct identity, not local-connect/proxy. Try: ax gateway agents list --json;
ax gateway local connect wishy --workdir /repo. Or open http://127.0.0.1:8765
to inspect Gateway agents.
```

## Validation

- [x] `pytest tests/test_gateway_commands.py -k "local_route_failure or gateway_local_connect_404" -v` — 3 passed
- [x] `pytest tests/` full suite: no new regressions; pre-existing failures are the same set as on `main` and unrelated to this change
- [x] `ruff check ax_cli/commands/gateway.py ax_cli/commands/messages.py tests/test_gateway_commands.py` — clean
- [x] `ruff format --check` on touched files — already formatted
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; this PR does not change auth behavior, only error-message text on 4xx
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

The error path catches the same exceptions, raises the same exception classes (`typer.BadParameter` and `ValueError`), and otherwise returns identically. Only the user-visible text inside those exceptions changes. No upstream API calls are added.
