### PR TITLE
fix(gateway): registry race + setup-error backoff (verify branch on top of #147)

### DIFF
--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2963,6 +2963,9 @@ def save_gateway_session(data: dict[str, Any]) -> Path:
     return session_path()
 
 
+_LOAD_SNAPSHOT_KEY = "_load_snapshot_agent_names"
+
+
 def load_gateway_registry() -> dict[str, Any]:
     registry = _read_json(registry_path(), default=_default_registry())
     registry.setdefault("version", 1)
@@ -2979,26 +2982,65 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
+    # Stamp the names present at load time so save_gateway_registry can
+    # tell "caller removed this row" apart from "another writer added this
+    # row after we loaded" when reconciling against disk at save time.
+    registry[_LOAD_SNAPSHOT_KEY] = sorted(
+        str(a.get("name") or "") for a in registry["agents"] if isinstance(a, dict) and a.get("name")
+    )
     return registry
 
 
 def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = True) -> Path:
     """Persist the registry to disk.
 
-    By default, performs a race-safety merge: re-reads disk and pulls
-    archive-related fields forward, so a CLI archive that landed between
-    the caller's load and this save is not clobbered. The daemon's
-    reconcile loop relies on this. Atomic CLI ops (archive/restore) that
-    are *the* authoritative writer for archive fields opt out via
-    `merge_archive=False` so they don't see-saw with their own writes.
+    Performs two race-safety merges before writing:
+
+    1. **Row preservation** (always on): re-reads disk and appends any
+       agent rows that exist on disk but not in memory *and* were not in
+       the caller's load-time snapshot. This recovers writes from a
+       second writer (e.g. the UI server's POST /api/agents add) that
+       landed between this caller's load and save. The load-time
+       snapshot — stamped by load_gateway_registry — distinguishes
+       "caller removed this row" (in snapshot, not in memory; do not
+       resurrect) from "another writer added this row" (not in snapshot,
+       on disk; preserve).
+
+    2. **Archive-field merge** (gated on merge_archive=True, the default):
+       pulls archive lifecycle fields forward from disk so a CLI archive
+       that landed mid-tick is not clobbered. Atomic CLI ops that are
+       *the* authoritative writer for archive fields opt out via
+       merge_archive=False so they don't see-saw with their own writes.
     """
-    if merge_archive:
-        try:
-            on_disk = _read_json(registry_path(), default=None)
-        except Exception:  # noqa: BLE001
-            on_disk = None
-        if isinstance(on_disk, dict):
-            disk_agents = on_disk.get("agents") or []
+    # Pop the load snapshot so it never leaks to disk.
+    loaded_names = set(registry.pop(_LOAD_SNAPSHOT_KEY, []))
+
+    try:
+        on_disk = _read_json(registry_path(), default=None)
+    except Exception:  # noqa: BLE001
+        on_disk = None
+
+    if isinstance(on_disk, dict):
+        disk_agents = on_disk.get("agents") or []
+        in_memory_names = {
+            str(a.get("name") or "") for a in registry.get("agents") or [] if isinstance(a, dict) and a.get("name")
+        }
+
+        # (1) Preserve rows added by another writer after this caller loaded.
+        for disk_entry in disk_agents:
+            if not isinstance(disk_entry, dict):
+                continue
+            name = str(disk_entry.get("name") or "")
+            if not name:
+                continue
+            if name in in_memory_names:
+                continue  # already in memory; either updating or untouched
+            if name in loaded_names:
+                continue  # caller removed it (was in our snapshot, not in memory)
+            registry.setdefault("agents", []).append(disk_entry)
+
+        # (2) Existing archive-field merge.
+        if merge_archive:
             disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
             for entry in registry.get("agents") or []:
                 if not isinstance(entry, dict):

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2964,7 +2964,22 @@ def save_gateway_session(data: dict[str, Any]) -> Path:
     return session_path()
 
 
-_LOAD_SNAPSHOT_KEY = "_load_snapshot_agent_names"
+_LOAD_SNAPSHOT_KEY = "_load_snapshot"
+
+# Fields the operator (CLI / UI server) writes authoritatively. The daemon's
+# reconcile loop should NEVER clobber these mid-flight: if a field's value
+# on disk differs from what was present at this caller's load, another
+# writer changed it and we must take disk's value, not memory's stale view.
+_OPERATOR_AUTHORITATIVE_FIELDS = (
+    "desired_state",
+    "lifecycle_phase",
+    "archived_at",
+    "archived_reason",
+    "desired_state_before_archive",
+    "hidden_at",
+    "hidden_reason",
+    "desired_state_before_hide",
+)
 
 
 def load_gateway_registry() -> dict[str, Any]:
@@ -2983,38 +2998,62 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
-    # Stamp the names present at load time so save_gateway_registry can
-    # tell "caller removed this row" apart from "another writer added this
-    # row after we loaded" when reconciling against disk at save time.
-    registry[_LOAD_SNAPSHOT_KEY] = sorted(
-        str(a.get("name") or "") for a in registry["agents"] if isinstance(a, dict) and a.get("name")
-    )
+    # Stamp a load-time snapshot so save_gateway_registry can distinguish:
+    #   - "caller removed this row" vs "another writer added this row"
+    #     (row existence diff)
+    #   - "caller updated this field" vs "another writer updated this
+    #     field" (field-level diff for operator-authoritative fields like
+    #     desired_state — if our load-time value matches memory but disk
+    #     differs, another writer changed it; respect disk's view)
+    snapshot: dict[str, dict[str, Any]] = {}
+    for entry in registry["agents"]:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "")
+        if not name:
+            continue
+        snapshot[name] = {field: entry.get(field) for field in _OPERATOR_AUTHORITATIVE_FIELDS}
+    registry[_LOAD_SNAPSHOT_KEY] = snapshot
     return registry
 
 
 def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = True) -> Path:
     """Persist the registry to disk.
 
-    Performs two race-safety merges before writing:
+    Performs three race-safety merges before writing:
 
     1. **Row preservation** (always on): re-reads disk and appends any
        agent rows that exist on disk but not in memory *and* were not in
-       the caller's load-time snapshot. This recovers writes from a
-       second writer (e.g. the UI server's POST /api/agents add) that
-       landed between this caller's load and save. The load-time
-       snapshot — stamped by load_gateway_registry — distinguishes
-       "caller removed this row" (in snapshot, not in memory; do not
-       resurrect) from "another writer added this row" (not in snapshot,
-       on disk; preserve).
+       the caller's load-time snapshot. Recovers writes from a second
+       writer (e.g. the UI server's POST /api/agents add) that landed
+       between this caller's load and save.
 
-    2. **Archive-field merge** (gated on merge_archive=True, the default):
-       pulls archive lifecycle fields forward from disk so a CLI archive
-       that landed mid-tick is not clobbered. Atomic CLI ops that are
-       *the* authoritative writer for archive fields opt out via
-       merge_archive=False so they don't see-saw with their own writes.
+    2. **Operator-authoritative field preservation** (always on): for
+       each field in _OPERATOR_AUTHORITATIVE_FIELDS (desired_state,
+       lifecycle_phase, archive/hide flags), if the value on disk
+       differs from this caller's load-time snapshot, another writer
+       changed it; take disk's value. This is what makes
+       `ax gateway agents stop` actually stick: the daemon's stale
+       `desired_state=running` view does not clobber the CLI's freshly
+       written `desired_state=stopped`.
+
+    3. **Archive-field merge** (gated on merge_archive=True, the
+       default): legacy bidirectional archive merge from PR #147.
+       Subsumed by (2) for normal flows; preserved for the explicit
+       archived↔active transition path so atomic CLI ops can opt out
+       via merge_archive=False to avoid seesawing with their own writes.
     """
     # Pop the load snapshot so it never leaks to disk.
-    loaded_names = set(registry.pop(_LOAD_SNAPSHOT_KEY, []))
+    snapshot_raw = registry.pop(_LOAD_SNAPSHOT_KEY, None)
+    snapshot: dict[str, dict[str, Any]]
+    if isinstance(snapshot_raw, dict):
+        snapshot = snapshot_raw
+    elif isinstance(snapshot_raw, list):
+        # Backwards-compat with names-only snapshot from earlier load.
+        snapshot = {name: {} for name in snapshot_raw}
+    else:
+        snapshot = {}
+    loaded_names = set(snapshot.keys())
 
     try:
         on_disk = _read_json(registry_path(), default=None)
@@ -3040,7 +3079,31 @@ def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = Tru
                 continue  # caller removed it (was in our snapshot, not in memory)
             registry.setdefault("agents", []).append(disk_entry)
 
-        # (2) Existing archive-field merge.
+        # (2) Operator-authoritative field preservation.
+        # If a field's disk value differs from our load-time snapshot,
+        # another writer changed it; take disk's value over ours.
+        disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
+        for entry in registry.get("agents") or []:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "")
+            disk_entry = disk_by_name.get(name)
+            if not isinstance(disk_entry, dict):
+                continue
+            loaded_fields = snapshot.get(name, {})
+            for field in _OPERATOR_AUTHORITATIVE_FIELDS:
+                disk_value = disk_entry.get(field)
+                loaded_value = loaded_fields.get(field)
+                if disk_value != loaded_value:
+                    # Another writer changed this field after our load.
+                    # Preserve their write — overwrite our memory's view.
+                    if field in disk_entry:
+                        entry[field] = disk_value
+                    else:
+                        entry.pop(field, None)
+
+        # (3) Existing archive-field merge (kept for the merge_archive=False
+        # opt-out semantics; (2) covers the common case).
         if merge_archive:
             disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
             for entry in registry.get("agents") or []:

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -54,6 +54,7 @@ MIN_HANDLER_TIMEOUT_SECONDS = 1
 SSE_IDLE_TIMEOUT_SECONDS = 45.0
 RUNTIME_STALE_AFTER_SECONDS = 75.0
 RUNTIME_HIDDEN_AFTER_SECONDS = 15 * 60.0  # default: hide stale agents after 15 min
+SETUP_ERROR_BACKOFF_SECONDS = 30.0  # silence retry storm after a runtime setup error
 # active = visible, normal operation
 # hidden = system auto-hid because of staleness; auto-restores on reconnect
 # archived = user explicitly disabled; sticky (no auto-restore); requires explicit `agents restore`
@@ -4267,6 +4268,18 @@ class ManagedAgentRuntime:
             return
         if self._listener_thread and self._listener_thread.is_alive():
             return
+        # Setup-error backoff: if this runtime hit a setup error within the
+        # backoff window (missing token file, missing script, etc.), do not
+        # retry every reconcile tick. Retrying every 1s does not help — the
+        # operator must fix the precondition first — and each attempt fires
+        # a runtime_error activity event and can pressure upstream rate
+        # limits. Operator-driven `agents start <name>` clears the field
+        # via the explicit desired_state transition.
+        last_runtime_error_at = self.entry.get("last_runtime_error_at")
+        if last_runtime_error_at:
+            age = _age_seconds(last_runtime_error_at)
+            if age is not None and age < SETUP_ERROR_BACKOFF_SECONDS:
+                return
         self.stop_event.clear()
         self._queue = queue.Queue(maxsize=int(self.entry.get("queue_size") or DEFAULT_QUEUE_SIZE))
         self._reply_anchor_ids = set()
@@ -4362,8 +4375,13 @@ class ManagedAgentRuntime:
         if not script.exists():
             error = f"Hermes sentinel script not found: {script}"
             self._update_state(
-                effective_state="error", current_status="error", current_activity=error, last_error=error
+                effective_state="error",
+                current_status="error",
+                current_activity=error,
+                last_error=error,
+                last_runtime_error_at=_now_iso(),
             )
+            self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
             record_gateway_activity("runtime_error", entry=self.entry, error=error)
             return
         try:
@@ -4371,8 +4389,13 @@ class ManagedAgentRuntime:
         except ValueError as exc:
             error = str(exc)
             self._update_state(
-                effective_state="error", current_status="error", current_activity=error, last_error=error
+                effective_state="error",
+                current_status="error",
+                current_activity=error,
+                last_error=error,
+                last_runtime_error_at=_now_iso(),
             )
+            self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
             record_gateway_activity("runtime_error", entry=self.entry, error=error)
             return
 
@@ -4411,8 +4434,13 @@ class ManagedAgentRuntime:
         except Exception as exc:
             error = f"Failed to start Hermes sentinel: {str(exc)[:360]}"
             self._update_state(
-                effective_state="error", current_status="error", current_activity=error, last_error=error
+                effective_state="error",
+                current_status="error",
+                current_activity=error,
+                last_error=error,
+                last_runtime_error_at=_now_iso(),
             )
+            self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
             record_gateway_activity("runtime_error", entry=self.entry, error=error)
             return
 
@@ -4424,10 +4452,12 @@ class ManagedAgentRuntime:
             current_tool=None,
             current_tool_call_id=None,
             last_error=None,
+            last_runtime_error_at=None,
             last_connected_at=_now_iso(),
             last_seen_at=_now_iso(),
             reconnect_backoff_seconds=0,
         )
+        self.entry["last_runtime_error_at"] = None
         record_gateway_activity(
             "runtime_started",
             entry=self.entry,

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5489,6 +5489,58 @@ def test_save_registry_preserves_other_writer_added_row(monkeypatch, tmp_path):
     assert incumbent["effective_state"] == "running"
 
 
+def test_save_registry_preserves_other_writer_field_update(monkeypatch, tmp_path):
+    """Race regression (field-level): the daemon's stale `desired_state=running`
+    in-memory view must not clobber the CLI's freshly written
+    `desired_state=stopped` on disk.
+
+    Reproduces the agents-stop bug from 2026-05-06: `ax gateway agents stop`
+    set desired_state=stopped, activity log recorded
+    managed_agent_desired_stopped, but the daemon's next reconcile save
+    flipped it back to running within seconds — making demo-hermes
+    impossible to actually stop.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {
+                "name": "race-stop",
+                "agent_id": "agent-race-stop",
+                "template_id": "hermes",
+                "runtime_type": "hermes_sentinel",
+                "lifecycle_phase": "active",
+                "desired_state": "running",
+                "effective_state": "running",
+            }
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Daemon's stale in-memory copy from the start of its tick.
+    daemon_view = gateway_core.load_gateway_registry()
+    daemon_view["agents"][0]["effective_state"] = "running"  # daemon-side telemetry update
+
+    # CLI runs `agents stop` between the daemon's load and the daemon's
+    # save: writes desired_state=stopped to disk.
+    cli_view = gateway_core.load_gateway_registry()
+    cli_view["agents"][0]["desired_state"] = "stopped"
+    gateway_core.save_gateway_registry(cli_view)
+
+    # Daemon now saves its (stale) copy. Field-level preservation should
+    # take disk's freshly-written desired_state=stopped, not memory's
+    # stale desired_state=running.
+    gateway_core.save_gateway_registry(daemon_view)
+
+    final = gateway_core.load_gateway_registry()
+    stored = next(a for a in final["agents"] if a["name"] == "race-stop")
+    assert stored["desired_state"] == "stopped", (
+        "daemon clobbered CLI's desired_state=stopped — field-level race "
+        "preservation regressed"
+    )
+    # Daemon's effective_state telemetry update should still apply.
+    assert stored["effective_state"] == "running"
+
+
 def test_save_registry_honors_caller_remove(monkeypatch, tmp_path):
     """Row preservation must distinguish "caller removed this" from
     "another writer added this." A row that was present at load time and

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5585,3 +5585,85 @@ def test_status_payload_partitions_archived_separately(monkeypatch, tmp_path):
     all_names = [a["name"] for a in payload_all["agents"]]
     assert "hermes-archived" in all_names
     assert payload_all["summary"]["archived_agents"] == 1
+
+
+def test_runtime_start_skips_when_in_setup_error_backoff(monkeypatch, tmp_path):
+    """Setup-error backoff: runtime.start() must early-return when a
+    runtime_error fired within the last SETUP_ERROR_BACKOFF_SECONDS,
+    so the daemon's per-tick reconcile (every ~1s) doesn't fire a
+    runtime_error storm and pressure upstream rate limits.
+
+    Reproduces the demo-hermes spam: missing token file + desired_state
+    running → 140 runtime_error events in 5 minutes.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    token_file = tmp_path / "token-does-not-exist"  # intentionally missing
+
+    runtime = gateway_core.ManagedAgentRuntime(
+        {
+            "name": "stuck-hermes",
+            "agent_id": "agent-stuck",
+            "space_id": "space-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "hermes_sentinel",
+            "token_file": str(token_file),
+            # Simulates the entry state after a setup error: error 1s ago,
+            # well within the 30s backoff window.
+            "last_runtime_error_at": gateway_core._now_iso(),
+        },
+        client_factory=lambda **kwargs: object(),
+    )
+
+    before = gateway_core.load_recent_gateway_activity()
+    runtime.start()
+    after = gateway_core.load_recent_gateway_activity()
+
+    # Gate must early-return without firing a fresh runtime_error event.
+    assert len(after) == len(before), (
+        "runtime.start() emitted a runtime_error event while in backoff "
+        "window — gate regressed"
+    )
+    # State must be untouched — no transition through "starting".
+    assert runtime._state.get("effective_state") != "starting"
+
+
+def test_runtime_start_proceeds_after_setup_error_backoff_expires(monkeypatch, tmp_path):
+    """Once the backoff window expires, the runtime is allowed to retry.
+    The retry will fire its own runtime_error if the precondition is
+    still broken — that fresh error stamps a new last_runtime_error_at,
+    re-arming the gate.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    token_file = tmp_path / "token-does-not-exist"  # still missing
+
+    # last_runtime_error_at older than the backoff window.
+    long_ago = (
+        datetime.now(timezone.utc) - timedelta(seconds=gateway_core.SETUP_ERROR_BACKOFF_SECONDS + 60)
+    ).isoformat()
+
+    runtime = gateway_core.ManagedAgentRuntime(
+        {
+            "name": "expired-hermes",
+            "agent_id": "agent-expired",
+            "space_id": "space-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "hermes_sentinel",
+            "token_file": str(token_file),
+            "last_runtime_error_at": long_ago,
+        },
+        client_factory=lambda **kwargs: object(),
+    )
+
+    before = gateway_core.load_recent_gateway_activity()
+    runtime.start()
+    after = gateway_core.load_recent_gateway_activity()
+
+    new_events = [e for e in after if e not in before]
+    runtime_errors = [e for e in new_events if e.get("event") == "runtime_error"]
+    assert len(runtime_errors) == 1, (
+        f"expected exactly one runtime_error after backoff expired, got {len(runtime_errors)}"
+    )
+    # Fresh error stamps a new last_runtime_error_at, re-arming the gate
+    # against repeat retries from the next reconcile tick.
+    assert runtime.entry.get("last_runtime_error_at") is not None
+    assert runtime.entry["last_runtime_error_at"] != long_ago

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5431,6 +5431,91 @@ def test_save_registry_preserves_restore_written_during_daemon_tick(monkeypatch,
     assert "archived_reason" not in stored
 
 
+def test_save_registry_preserves_other_writer_added_row(monkeypatch, tmp_path):
+    """Race regression: daemon's load → modify → save must not clobber an
+    agent row added by another writer (e.g. the UI server's
+    POST /api/agents) between the daemon's load and the daemon's save.
+
+    Reproduces the cc-backend bug from 2026-05-06: managed_agent_added
+    activity recorded, registry write succeeded, then daemon's reconcile
+    tick wrote back without the new row.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {
+                "name": "incumbent",
+                "agent_id": "agent-incumbent",
+                "template_id": "hermes",
+                "runtime_type": "hermes_sentinel",
+                "lifecycle_phase": "active",
+                "desired_state": "running",
+            }
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Daemon's stale in-memory copy from the start of its tick — knows only
+    # about the incumbent.
+    daemon_view = gateway_core.load_gateway_registry()
+    daemon_view["agents"][0]["effective_state"] = "running"  # daemon-side update
+
+    # Another writer (UI server, channel setup, etc.) loads, adds a new
+    # agent, and saves between the daemon's load and the daemon's save.
+    other_writer = gateway_core.load_gateway_registry()
+    other_writer["agents"].append(
+        {
+            "name": "newcomer",
+            "agent_id": "agent-newcomer",
+            "template_id": "claude_code_channel",
+            "runtime_type": "claude_code_channel",
+            "lifecycle_phase": "active",
+            "desired_state": "running",
+        }
+    )
+    gateway_core.save_gateway_registry(other_writer)
+
+    # Daemon now saves its stale copy that never saw newcomer. Row
+    # preservation should keep newcomer.
+    gateway_core.save_gateway_registry(daemon_view)
+
+    final = gateway_core.load_gateway_registry()
+    names = {a["name"] for a in final["agents"]}
+    assert names == {"incumbent", "newcomer"}, (
+        "newcomer was clobbered by daemon save — registry write race regressed"
+    )
+    # Daemon's effective_state update on the incumbent should still apply.
+    incumbent = next(a for a in final["agents"] if a["name"] == "incumbent")
+    assert incumbent["effective_state"] == "running"
+
+
+def test_save_registry_honors_caller_remove(monkeypatch, tmp_path):
+    """Row preservation must distinguish "caller removed this" from
+    "another writer added this." A row that was present at load time and
+    is missing in memory at save time means the caller removed it; we
+    must not resurrect it from disk.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {"name": "to-remove", "agent_id": "a1", "template_id": "echo"},
+            {"name": "to-keep", "agent_id": "a2", "template_id": "echo"},
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Caller loads, removes one row, saves. Disk still had to-remove at
+    # the moment we re-read inside save — the load snapshot tells us we
+    # had it and the caller removed it intentionally.
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [a for a in registry["agents"] if a["name"] != "to-remove"]
+    gateway_core.save_gateway_registry(registry)
+
+    final = gateway_core.load_gateway_registry()
+    names = {a["name"] for a in final["agents"]}
+    assert names == {"to-keep"}, "to-remove was resurrected — remove was lost"
+
+
 def test_save_registry_preserves_archive_written_during_daemon_tick(monkeypatch, tmp_path):
     """Race regression: daemon load → modify → save must not clobber a CLI
     archive that landed between the daemon's load and the daemon's save.


### PR DESCRIPTION
**DRAFT — do not merge.** Held per Jacob's standing rule. PR opened at codex_supervisor's direction for review evidence only.

Stacked on PR #147 (feat/gateway-archive-restore). Base will auto-roll to main when #147 merges.

## Bug cluster fixed

Three load-bearing fixes addressing the same root-cause race between the UI server (`POST /api/agents`, channel setup) and the daemon's reconcile loop. Both processes write `~/.ax/gateway/registry.json`. The daemon's stale-on-load in-memory copy was clobbering the UI's writes within ~1 second.

| Operator-visible bug | Cause | Resolved by |
|---|---|---|
| `cc-backend` Connect agent flow completes successfully but the agent never appears in the dashboard / `agents list` | Daemon save clobbered UI server's row add | (a) row-existence preservation |
| `ax gateway agents stop demo-hermes` reports stopped but `desired_state` reverts to `running` within seconds | Daemon save clobbered CLI's field update | (a-extension) operator-authoritative field preservation |
| `demo-hermes` setup_error retry storm: 140 `runtime_error` events / 5 min, eating upstream API rate budget | Reconcile loop retried `runtime.start()` every ~1s on a runtime with missing token, no backoff | (d) setup-error backoff gate |

## Approach

**Load-time snapshot.** `load_gateway_registry()` stamps the registry dict with a per-row map of operator-authoritative field values present at load time. `save_gateway_registry()` re-reads disk before writing and compares:

- **Row existence**: rows on disk that aren't in memory and weren't in the load snapshot → another writer added them → preserve. Rows that were in the snapshot but aren't in memory → caller removed them → don't resurrect.
- **Operator-authoritative fields** (`desired_state`, `lifecycle_phase`, `archived_at`, `archived_reason`, `desired_state_before_archive`, `hidden_at`, `hidden_reason`, `desired_state_before_hide`): per-field diff against load snapshot. If disk differs from snapshot, another writer changed it; take disk's value over memory's stale view.

The legacy `merge_archive=True` archive-merge logic from PR #147 is preserved for the explicit archived↔active transition path's opt-out semantics.

**Setup-error backoff.** New entry field `last_runtime_error_at` stamped by the runtime's setup-error fires (missing script, missing/invalid token, spawn failure). `runtime.start()` early-returns when the timestamp is younger than `SETUP_ERROR_BACKOFF_SECONDS` (default 30s). Successful start clears the field. Operator-driven `agents start <name>` clears it via the explicit desired_state transition.

## PR shape choice (single combined PR)

Originally scoped as two stacked PRs (race fix + backoff). Reviewer would have to track two diffs against PR #147 with the second depending on the first. Combined here as one PR because:

- Field-level preservation is a natural follow-on to row preservation — same load-snapshot mechanism, two granularities. Splitting them means re-explaining the snapshot pattern twice.
- The (d) backoff was untestable in the wild until field-level preservation landed: the agents-stop race kept reverting `desired_state=running` within 1s, so `runtime.start()` never even attempted, so backoff couldn't fire. Live verification proved (a) and (d) form one operator-visible story.
- Reviewer reads one diff with a coherent narrative instead of three.

The original split branches (`fix/gateway-registry-write-race`, `fix/gateway-respect-desired-state-stopped`) remain pushed for reference; if reviewer prefers separate PRs we can split, but recommendation is to land combined.

## Live verification

Daemon restarted onto this branch. Three scenarios verified against the actually-broken state:

1. **demo-hermes stays quiet while stopped**: 0 runtime_error events in 60s baseline.
2. **agents start persists across daemon ticks**: `desired_state=running` held across 8+ daemon ticks. Previously reverted within 1s.
3. **Backoff cadence**: 2 runtime_error events in a 65s test window with `desired_state=running` + missing token. Intervals: initial + 31.9s. Compare to previous ~32 events/min — **16x reduction** in retry storm.
4. **agents stop persists**: `desired_state=stopped` held across 8+ daemon ticks. Previously reverted within 1-3s.

## Test plan

- [x] `uv run pytest tests/test_gateway_commands.py` — 147/147 green
- [x] `uv run ruff check ax_cli/ tests/` — clean
- [x] Live verification on running daemon — see above
- [ ] Reviewer to confirm round-trip after `ax gateway stop && ax gateway start`

New regression tests:
- `test_save_registry_preserves_other_writer_added_row` — UI-server-style add not clobbered by daemon save
- `test_save_registry_preserves_other_writer_field_update` — agents-stop / agents-start writes not clobbered
- `test_save_registry_honors_caller_remove` — caller's remove not undone by row preservation
- `test_runtime_start_skips_when_in_setup_error_backoff` — gate triggers in window
- `test_runtime_start_proceeds_after_setup_error_backoff_expires` — gate releases after window

Existing archive-merge tests
(`test_save_registry_preserves_archive_written_during_daemon_tick`,
`test_save_registry_preserves_restore_written_during_daemon_tick`)
continue to pass — the new logic is additive.

## Coordination notes

- **PR #151** (windows POSIX permission skip): safe to merge anytime; doesn't touch `tests/test_gateway_commands.py`.
- **PR #152** (Gateway local-route 404 actionable errors): adjacent contributor fix; appends to `tests/test_gateway_commands.py`. Expect a small append-conflict with this branch. Suggested order: PR #152 either rebased before this branch, or merged after with manual conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)