### PR TITLE
feat(tasks): add --assign-to to ax tasks update

### DIFF
--- a/ax_cli/commands/tasks.py
+++ b/ax_cli/commands/tasks.py
@@ -447,19 +447,31 @@ def update(
     task_id: str = typer.Argument(..., help="Task ID"),
     priority: Optional[str] = typer.Option(None, "--priority", help="New priority"),
     status: Optional[str] = typer.Option(None, "--status", help="New status"),
+    assign_to: Optional[str] = typer.Option(
+        None, "--assign-to", "--assign", help="Reassign task to an agent (handle, @handle, or UUID)"
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Update a task."""
-    fields = {}
+    fields: dict[str, Any] = {}
     if priority is not None:
         fields["priority"] = priority
     if status is not None:
         fields["status"] = status
-    if not fields:
-        typer.echo("Error: Provide at least one field to update (--priority, --status).", err=True)
+    if not fields and assign_to is None:
+        typer.echo(
+            "Error: Provide at least one field to update (--priority, --status, --assign-to).",
+            err=True,
+        )
         raise typer.Exit(1)
     gateway_cfg = resolve_gateway_config()
     if gateway_cfg:
+        if assign_to is not None:
+            typer.echo(
+                "Error: --assign-to is not supported with Gateway-native task updates yet.",
+                err=True,
+            )
+            raise typer.Exit(1)
         data = _gateway_local_call(
             gateway_cfg=gateway_cfg,
             method="update_task",
@@ -467,6 +479,8 @@ def update(
         )
     else:
         client = get_client()
+        if assign_to is not None:
+            fields["assignee_id"] = _resolve_update_assignee_id(client, task_id, assign_to)
         try:
             data = client.update_task(task_id, **fields)
         except httpx.HTTPStatusError as e:
@@ -475,3 +489,32 @@ def update(
         print_json(data)
     else:
         print_kv(data)
+
+
+def _resolve_update_assignee_id(client, task_id: str, assignee: str) -> str:
+    """Resolve --assign-to for ``ax tasks update``.
+
+    UUIDs short-circuit. Handles need the task's own space to scope the agent
+    lookup, so we fetch the task first and reuse the same resolver
+    ``ax tasks create --assign-to`` uses.
+    """
+    candidate = assignee.strip()
+    try:
+        return str(UUID(candidate))
+    except ValueError:
+        pass
+    try:
+        current = client.get_task(task_id)
+    except httpx.HTTPStatusError as e:
+        handle_error(e)
+    if isinstance(current, dict) and isinstance(current.get("task"), dict):
+        current = current["task"]
+    task_space_id = str(current.get("space_id") or "") if isinstance(current, dict) else ""
+    if not task_space_id:
+        typer.echo(
+            f"Error: Could not determine space for task {task_id} to resolve assignee handle "
+            f"'{assignee}'. Pass an agent UUID instead.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return _resolve_assignee_id(client, candidate, space_id=task_space_id)

--- a/tests/test_tasks_commands.py
+++ b/tests/test_tasks_commands.py
@@ -268,3 +268,100 @@ def test_tasks_create_assign_handle_mentions_assignee_by_default(monkeypatch):
         "id": "agent-123",
         "name": "demo-agent",
     }
+
+
+def test_tasks_update_assign_to_accepts_uuid_without_lookup(monkeypatch):
+    calls = {}
+    agent_id = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+
+    class FakeClient:
+        def get_task(self, task_id):
+            calls["get_task"] = task_id
+            return {"id": task_id, "space_id": "space-1"}
+
+        def list_agents(self, *, space_id=None, limit=None):
+            calls["list_agents"] = True
+            return {"agents": []}
+
+        def update_task(self, task_id, **fields):
+            calls["update_task"] = {"task_id": task_id, "fields": fields}
+            return {"id": task_id, **fields}
+
+    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.resolve_gateway_config", lambda: {})
+
+    result = runner.invoke(
+        app,
+        ["tasks", "update", "task-42", "--assign-to", agent_id, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    # UUID short-circuits — no get_task / list_agents needed.
+    assert "get_task" not in calls
+    assert "list_agents" not in calls
+    assert calls["update_task"] == {"task_id": "task-42", "fields": {"assignee_id": agent_id}}
+
+
+def test_tasks_update_assign_to_resolves_handle_via_task_space(monkeypatch):
+    calls = {}
+
+    class FakeClient:
+        def get_task(self, task_id):
+            calls["get_task"] = task_id
+            return {"task": {"id": task_id, "space_id": "space-9"}}
+
+        def list_agents(self, *, space_id=None, limit=None):
+            calls["list_agents"] = {"space_id": space_id, "limit": limit}
+            return {"agents": [{"id": "agent-789", "name": "demo-agent"}]}
+
+        def update_task(self, task_id, **fields):
+            calls["update_task"] = {"task_id": task_id, "fields": fields}
+            return {"id": task_id, **fields}
+
+    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.resolve_gateway_config", lambda: {})
+
+    result = runner.invoke(
+        app,
+        ["tasks", "update", "task-42", "--assign", "@demo-agent", "--status", "in_progress", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["get_task"] == "task-42"
+    assert calls["list_agents"] == {"space_id": "space-9", "limit": 500}
+    assert calls["update_task"] == {
+        "task_id": "task-42",
+        "fields": {"status": "in_progress", "assignee_id": "agent-789"},
+    }
+
+
+def test_tasks_update_assign_to_rejected_on_gateway_path(monkeypatch):
+    monkeypatch.setattr(
+        "ax_cli.commands.tasks.resolve_gateway_config",
+        lambda: {"url": "http://127.0.0.1:8765", "agent_name": "wishy", "workdir": "/repo"},
+    )
+
+    def _should_not_call(**kwargs):
+        raise AssertionError(f"Gateway path should not run when --assign-to is rejected: {kwargs}")
+
+    monkeypatch.setattr("ax_cli.commands.tasks._gateway_local_call", _should_not_call)
+
+    result = runner.invoke(
+        app,
+        ["tasks", "update", "task-42", "--assign-to", "demo-agent"],
+    )
+
+    assert result.exit_code == 1
+    assert "--assign-to is not supported with Gateway-native task updates" in result.output
+
+
+def test_tasks_update_requires_at_least_one_field(monkeypatch):
+    monkeypatch.setattr("ax_cli.commands.tasks.resolve_gateway_config", lambda: {})
+    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: object())
+
+    result = runner.invoke(app, ["tasks", "update", "task-42"])
+
+    assert result.exit_code == 1
+    assert "--priority" in result.output
+    assert "--status" in result.output
+    assert "--assign-to" in result.output


### PR DESCRIPTION
`ax tasks create` already takes `--assign-to` (and `--assign`) for setting the task assignee at creation. `ax tasks update` had no equivalent, which broke the self-assign demo beat surfaced during the Heath onboarding walk (parent task 665d9c0c, follow-up c605fbb1) — operators had to drop into the widget or the API to reassign work after a task existed.

Add the same flag to `update`, mirroring `create`'s shape:

```
ax tasks update <task-id> --assign-to @demo-agent
ax tasks update <task-id> --assign-to <uuid>
```

**Resolution**

- UUID input short-circuits — no extra API calls.
- Handle input fetches the task to learn its space, then reuses `_resolve_assignee_id` to look up the agent in that space and fail cleanly if the handle is ambiguous or unknown.

The Gateway-native path is rejected with a clear message, matching `tasks create` ("not supported with Gateway-native task updates yet"). The empty-update guard now mentions `--assign-to` alongside the existing fields. No changes to `AxClient.update_task` — the field is passed through the existing `**fields` PATCH body.

## Summary

One new flag, one small helper (`_resolve_update_assignee_id`), four new tests. The flag accepts the same input shapes as `tasks create --assign-to` so muscle memory transfers between the two commands. UUIDs skip the resolver round-trip; handles cost one extra `get_task` call to scope the agent lookup.

## Validation

- [x] `pytest tests/test_tasks_commands.py -v` — 12 passed (4 new + 8 existing)
- [x] `ruff check ax_cli/commands/tasks.py tests/test_tasks_commands.py` — clean
- [x] `ruff format --check` on touched files — already formatted
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; this PR does not change auth behavior
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable

## Release Notes

- [x] This should appear in the changelog (`feat:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

The flag plumbs through the same authoring client used by `tasks update --priority/--status` today; assignment authority is decided server-side as before. Gateway-native updates intentionally don't accept it yet — that's deferred so the Gateway proxy allowlist (`_LOCAL_PROXY_METHODS["update_task"]`) doesn't need to change in this PR.

## Follow-up notes

- Gateway-native `--assign-to` would need `assignee_id` added to the `update_task` proxy allowlist in `ax_cli/commands/gateway.py` and a small handle-resolution path through Gateway. Worth doing once the broader Gateway parity work (P0 task d620342a) lands.
- An `--unassign` flag (passing `assignee_id: null` to clear assignment) is a natural sibling. Not in scope here; can be a one-line follow-up once the API behavior is confirmed.
