### PR TITLE
fix(gateway): preserve reply metadata through Gateway local-send path

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -96,6 +96,7 @@ from ..gateway_runtime_types import (
     runtime_type_definition,
     runtime_type_list,
 )
+from ..mentions import merge_explicit_mentions_metadata
 from ..output import JSON_OPTION, console, err_console, print_json, print_table
 
 app = typer.Typer(name="gateway", help="Run the local Gateway control plane", no_args_is_help=True)
@@ -480,6 +481,15 @@ def _send_local_session_message(*, session_token: str, body: dict) -> dict:
         "gateway_pass_through_fingerprint_signature": session.get("fingerprint_signature"),
     }
     parent_id = str(body.get("parent_id") or "").strip()
+    if parent_id:
+        metadata.setdefault("routing_intent", "reply_with_mentions")
+    # Defense for clients that skip mention extraction (third-party scripts,
+    # older CLI versions, etc.). The helper is idempotent — re-running on
+    # already-extracted metadata is a no-op.
+    sender_name = str(entry.get("name") or "").strip()
+    metadata = (
+        merge_explicit_mentions_metadata(metadata, content, exclude=[sender_name] if sender_name else ()) or metadata
+    )
     payload = client.send_message(
         space_id,
         content,

--- a/ax_cli/commands/messages.py
+++ b/ax_cli/commands/messages.py
@@ -12,6 +12,7 @@ import typer
 
 from ..config import get_client, resolve_agent_name, resolve_gateway_config, resolve_space_id
 from ..context_keys import build_upload_context_key
+from ..mentions import merge_explicit_mentions_metadata
 from ..output import JSON_OPTION, console, handle_error, print_json, print_kv, print_table
 from .gateway import _approval_required_guidance, _local_process_fingerprint
 from .watch import _iter_sse
@@ -82,7 +83,19 @@ def _gateway_local_send(
                 )
             )
         raise typer.BadParameter(f"Gateway local session is {status}; approve the agent before sending.")
-    body = {"content": content, "space_id": space_id, "parent_id": parent_id}
+    # Preserve client-side routing intent: extract @handles from content so the
+    # backend can fan out the reply to mentioned agents in addition to the
+    # parent thread. Excluding the sender prevents self-mention noise. Gateway
+    # also re-extracts as defense for clients that skip this step.
+    sender_name = str(gateway_cfg.get("agent_name") or "").strip()
+    metadata = merge_explicit_mentions_metadata(
+        {"routing_intent": "reply_with_mentions"} if parent_id else None,
+        content,
+        exclude=[sender_name] if sender_name else (),
+    )
+    body: dict = {"content": content, "space_id": space_id, "parent_id": parent_id}
+    if metadata:
+        body["metadata"] = metadata
     try:
         response = httpx.post(
             f"{gateway_url.rstrip('/')}/local/send",

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -1022,6 +1022,11 @@ def test_gateway_local_connect_requests_approval_then_issues_session(monkeypatch
                 "gateway_pass_through_agent": "codex-local",
                 "gateway_pass_through_agent_id": "agent-local-1",
                 "gateway_pass_through_fingerprint_signature": session["fingerprint_signature"],
+                # Reply metadata is preserved through Gateway:
+                # parent_id flips routing_intent on, and the @handle in content
+                # is extracted so the backend can fan the reply out to night_owl.
+                "routing_intent": "reply_with_mentions",
+                "mentions": ["night_owl"],
             },
             "message_type": "text",
         }
@@ -5269,3 +5274,36 @@ def test_legacy_entry_without_lifecycle_phase_loads_as_active(monkeypatch, tmp_p
     daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
     # Legacy entry got swept normally (treated as implicit active → hidden).
     assert entry["lifecycle_phase"] == "hidden"
+
+
+def test_send_local_session_message_extracts_mentions_when_client_omits_them():
+    """Defense-in-depth: a client that forgets to populate metadata.mentions
+    must still result in mentions reaching the backend, because Gateway sees
+    the same content and re-extracts."""
+    from ax_cli.mentions import merge_explicit_mentions_metadata
+
+    metadata_input = {"purpose": "test"}
+    body = {
+        "space_id": "space-1",
+        "content": "@night_owl heads up",
+        "parent_id": "parent-7",
+        "metadata": metadata_input,
+    }
+
+    metadata = {
+        **metadata_input,
+        "gateway_local_session_id": "sess-1",
+        "gateway_pass_through_agent": "codex-local",
+    }
+    if body["parent_id"]:
+        metadata.setdefault("routing_intent", "reply_with_mentions")
+    metadata = (
+        merge_explicit_mentions_metadata(
+            metadata, body["content"], exclude=["codex-local"]
+        )
+        or metadata
+    )
+
+    assert metadata["mentions"] == ["night_owl"]
+    assert metadata["routing_intent"] == "reply_with_mentions"
+    assert metadata["purpose"] == "test"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -749,3 +749,115 @@ def test_messages_edit_and_delete_resolve_short_id_prefix(monkeypatch):
     assert calls["delete_id"] == message_id
     assert calls["space_ids"] == ["space-1", "space-1"]
     assert json.loads(delete_result.output)["message_id"] == message_id
+
+
+def test_gateway_local_send_extracts_mentions_into_metadata(monkeypatch):
+    """The reply-routing fix: @mentions in content must reach Gateway's body.metadata."""
+    from ax_cli.commands.messages import _gateway_local_send
+
+    captured: dict = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"message": {"id": "msg-1"}}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        if url.endswith("/local/connect"):
+            return FakeResponse()  # type: ignore[return-value]
+        if url.endswith("/local/send"):
+            captured["body"] = json
+            return FakeResponse()  # type: ignore[return-value]
+        raise AssertionError(url)
+
+    monkeypatch.setattr(
+        "ax_cli.commands.messages._gateway_local_connect",
+        lambda **kwargs: {"status": "approved", "session_token": "gw-session"},
+    )
+    monkeypatch.setattr("ax_cli.commands.messages.httpx.post", fake_post)
+
+    _gateway_local_send(
+        gateway_cfg={"url": "http://127.0.0.1:8765", "agent_name": "wishy"},
+        content="@nemotron @other_agent thanks for the review!",
+        space_id="space-1",
+        parent_id="parent-msg-7",
+    )
+
+    body = captured["body"]
+    assert body["parent_id"] == "parent-msg-7"
+    metadata = body.get("metadata") or {}
+    assert metadata.get("mentions") == ["nemotron", "other_agent"]
+    assert metadata.get("routing_intent") == "reply_with_mentions"
+
+
+def test_gateway_local_send_omits_metadata_when_no_mentions_or_parent(monkeypatch):
+    """Plain notify-only sends with no @mentions stay metadata-free."""
+    from ax_cli.commands.messages import _gateway_local_send
+
+    captured: dict = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"message": {"id": "msg-1"}}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        if url.endswith("/local/send"):
+            captured["body"] = json
+        return FakeResponse()  # type: ignore[return-value]
+
+    monkeypatch.setattr(
+        "ax_cli.commands.messages._gateway_local_connect",
+        lambda **kwargs: {"status": "approved", "session_token": "gw-session"},
+    )
+    monkeypatch.setattr("ax_cli.commands.messages.httpx.post", fake_post)
+
+    _gateway_local_send(
+        gateway_cfg={"url": "http://127.0.0.1:8765", "agent_name": "wishy"},
+        content="checking in, status update only",
+        space_id="space-1",
+        parent_id=None,
+    )
+
+    body = captured["body"]
+    assert "metadata" not in body, f"unexpected metadata: {body.get('metadata')}"
+
+
+def test_gateway_local_send_excludes_sender_from_mentions(monkeypatch):
+    """If the sender's own handle appears in content, it must not be re-routed to itself."""
+    from ax_cli.commands.messages import _gateway_local_send
+
+    captured: dict = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"message": {"id": "msg-1"}}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        if url.endswith("/local/send"):
+            captured["body"] = json
+        return FakeResponse()  # type: ignore[return-value]
+
+    monkeypatch.setattr(
+        "ax_cli.commands.messages._gateway_local_connect",
+        lambda **kwargs: {"status": "approved", "session_token": "gw-session"},
+    )
+    monkeypatch.setattr("ax_cli.commands.messages.httpx.post", fake_post)
+
+    _gateway_local_send(
+        gateway_cfg={"url": "http://127.0.0.1:8765", "agent_name": "wishy"},
+        content="@wishy @nemotron — back atcha",
+        space_id="space-1",
+        parent_id="parent-1",
+    )
+
+    metadata = captured["body"].get("metadata") or {}
+    assert metadata.get("mentions") == ["nemotron"], metadata.get("mentions")
+


### PR DESCRIPTION
Replies sent through `ax send` from a Gateway-managed workdir lost both of their routing-intent signals before reaching the backend:

- `parent_id` was passed but no `routing_intent` flag accompanied it, so the backend couldn't tell a thread reply apart from a fresh post.
- `@mentions` written into the reply body never made it into the outbound metadata, so mentioned agents (e.g. `@nemotron`) didn't receive the reply even when they were explicitly addressed.

The runtime adapters (Hermes sentinel, Claude Code Channel) already use `merge_explicit_mentions_metadata` for their own reply paths. This wires the same helper into the two CLI sites that fed the bug:

- `_gateway_local_send` (client side, in `ax_cli/commands/messages.py`) extracts `@handles` from `content`, excludes the sender to avoid self-mentions, and stamps `routing_intent: "reply_with_mentions"` when `parent_id` is set.
- `_send_local_session_message` (Gateway side, in `ax_cli/commands/gateway.py`) re-runs the same extraction as defense-in-depth, so third-party scripts that POST `/local/send` directly without populating mentions still get the right metadata forwarded to the backend.

The helper is idempotent — already-extracted mentions don't duplicate. Plain notify-only sends with no `@handle` and no `parent_id` keep the existing slim body shape (no metadata key added).

This addresses the **Gateway local send fix** called out in the ax-cli-dev task `1b7677d1` ("Preserve reply metadata: parent_id + extracted mentions in agent replies"), which named the local-send path as the blocker for end-to-end testing of the Hermes → nemotron mention case.

## Summary

Two send sites + four tests. No schema changes, no new dependencies, no behavior change for messages that don't include `@handle` references and aren't thread replies. The body shape on send becomes:

```json
{
  "content": "@nemotron thanks for the review",
  "space_id": "space-1",
  "parent_id": "msg-7",
  "metadata": {
    "routing_intent": "reply_with_mentions",
    "mentions": ["nemotron"]
  }
}
```

The direct (non-Gateway) `ax send` path is intentionally out of scope for this PR; that's a follow-up that touches the existing `client.send_message` test fakes and is best done separately.

## Validation

- [x] `pytest tests/test_messages.py tests/test_gateway_commands.py -k "gateway_local_send or send_local_session_message" -v` — 7 passed
- [x] `pytest tests/` full suite: same set of pre-existing failures as `main` (verified by `git stash`); my new tests pass and one prior assertion was updated to reflect the new metadata fields.
- [x] `ruff check ax_cli/commands/messages.py ax_cli/commands/gateway.py tests/test_messages.py tests/test_gateway_commands.py` — clean
- [x] `ruff format` on touched files — formatted
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; this PR does not change auth behavior
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

The Gateway proxy still uses the same managed-agent credential it always did; only the metadata attached to the outgoing message is different. Backend remains the enforcement point for whether each `@handle` can actually receive the routed reply.

## Follow-up notes

- Direct `ax send` (no Gateway) should also extract mentions — small change, but its existing test fakes don't accept a `metadata` kwarg yet, so it deserves its own PR.
- The same metadata shape could be propagated by `ax messages send` (when added) and by any future `ax messages reply` helper.
