### PR TITLE
fix(auth): make ax auth whoami space-independent so multi-space users…

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -8,6 +8,7 @@ import typer
 
 from ..config import (
     _global_config_dir,
+    _load_config,
     _load_local_config,
     _load_user_config,
     _local_config_dir,
@@ -330,6 +331,36 @@ def doctor(
         raise typer.Exit(EXIT_NOT_OK)
 
 
+_UNRESOLVED_SPACE_LABEL = "unresolved (set AX_SPACE_ID or use --space-id)"
+
+
+def _best_effort_single_space_id(client) -> str:
+    """Return the user's only space id when unambiguous, else a label string.
+
+    Mirrors the auto-detect tail of ``resolve_space_id`` but never raises and
+    never writes to stderr — whoami must report identity even when space
+    resolution is ambiguous.
+    """
+    try:
+        spaces = client.list_spaces()
+    except Exception:  # noqa: BLE001 — network/auth issues should not crash whoami
+        return _UNRESOLVED_SPACE_LABEL
+    space_list = (
+        spaces
+        if isinstance(spaces, list)
+        else (spaces.get("spaces") or spaces.get("items") or [])
+        if isinstance(spaces, dict)
+        else []
+    )
+    if not isinstance(space_list, list) or len(space_list) != 1:
+        return _UNRESOLVED_SPACE_LABEL
+    only = space_list[0]
+    if not isinstance(only, dict):
+        return _UNRESOLVED_SPACE_LABEL
+    sid = only.get("id") or only.get("space_id")
+    return str(sid) if sid else _UNRESOLVED_SPACE_LABEL
+
+
 @app.command()
 def whoami(as_json: bool = JSON_OPTION):
     """Show current identity — principal, bound agent, resolved spaces."""
@@ -378,16 +409,19 @@ def whoami(as_json: bool = JSON_OPTION):
         handle_error(e)
 
     bound = data.get("bound_agent")
-    if bound:
-        data["resolved_space_id"] = bound.get("default_space_id", "none")
+    if bound and bound.get("default_space_id"):
+        data["resolved_space_id"] = bound["default_space_id"]
     else:
-        from ..config import resolve_space_id
-
-        try:
-            space_id = resolve_space_id(client, explicit=None)
-            data["resolved_space_id"] = space_id
-        except SystemExit:
-            data["resolved_space_id"] = "unresolved (set AX_SPACE_ID or use --space-id)"
+        # Identity is token-bound and space-independent — never crash whoami
+        # over space resolution. ``resolve_space_id`` raises ``typer.Exit``
+        # (a ``RuntimeError`` subclass, not ``SystemExit``) on multi-space
+        # ambiguity, which used to abort whoami completely for any user with
+        # >1 space. Do an exception-free cascade instead.
+        explicit_space = os.environ.get("AX_SPACE") or os.environ.get("AX_SPACE_ID") or _load_config().get("space_id")
+        if explicit_space:
+            data["resolved_space_id"] = str(explicit_space)
+        else:
+            data["resolved_space_id"] = _best_effort_single_space_id(client)
 
     # Show resolved agent name
     resolved = resolve_agent_name(client=client)

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -208,7 +208,9 @@ def test_user_login_env_stores_named_login_and_marks_active(monkeypatch, write_c
     monkeypatch.setattr("ax_cli.token_cache.TokenExchanger", FakeTokenExchanger)
     monkeypatch.setattr("ax_cli.client.AxClient", FakeAxClient)
 
-    result = runner.invoke(app, ["login", "--token", "axp_u_dev.secret", "--url", "https://dev.paxai.app", "--env", "dev"])
+    result = runner.invoke(
+        app, ["login", "--token", "axp_u_dev.secret", "--url", "https://dev.paxai.app", "--env", "dev"]
+    )
 
     assert result.exit_code == 0
     global_dir = config_dir.parent / "_global_config"
@@ -294,6 +296,101 @@ def test_auth_whoami_reports_runtime_config(monkeypatch, tmp_path):
     payload = json.loads(result.output)
     assert payload["runtime_config"] == str(runtime_config)
     assert payload["resolved_agent"] == "codex"
+
+
+def test_auth_whoami_does_not_crash_on_multi_space_user(monkeypatch):
+    """Regression for ax-cli-dev task f664c903 / Heath onboarding bug.
+
+    A fresh-laptop user with >1 space (e.g. logged into next.paxai.app) used
+    to fail their first `ax auth whoami` because the unbound-agent fallback
+    called `resolve_space_id`, which raises `typer.Exit` (a `RuntimeError`
+    subclass, not `SystemExit`) when more than one space exists. The
+    surrounding `except SystemExit:` block was therefore dead code and the
+    command exited 1 with `Error: Multiple spaces found.`
+
+    Identity is token-bound and space-independent; whoami must report the
+    user's id/email/role even when space resolution is ambiguous.
+    """
+
+    class FakeClient:
+        def whoami(self):
+            return {"id": "user-1", "email": "user@example.com", "bound_agent": None}
+
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": "space-a", "name": "Space A"},
+                    {"id": "space-b", "name": "Space B"},
+                ]
+            }
+
+    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: None)
+    monkeypatch.setattr(auth, "resolve_gateway_config", lambda: {})
+    monkeypatch.setattr(auth, "_local_config_dir", lambda: None)
+    # Don't let env or config cascade short-circuit the multi-space fallback.
+    monkeypatch.delenv("AX_SPACE_ID", raising=False)
+    monkeypatch.delenv("AX_SPACE", raising=False)
+    monkeypatch.setattr(auth, "_load_config", lambda: {})
+
+    result = runner.invoke(app, ["auth", "whoami", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["id"] == "user-1"
+    assert payload["email"] == "user@example.com"
+    assert payload["resolved_space_id"] == "unresolved (set AX_SPACE_ID or use --space-id)"
+    # The bug printed `Error: Multiple spaces found.` on stderr before exiting.
+    assert "Multiple spaces found" not in result.output
+
+
+def test_auth_whoami_resolves_single_space_for_unbound_user(monkeypatch):
+    """Best-effort: when the user has exactly one space we still surface its id."""
+
+    class FakeClient:
+        def whoami(self):
+            return {"id": "user-1", "bound_agent": None}
+
+        def list_spaces(self):
+            return {"spaces": [{"id": "the-only-space", "name": "Solo"}]}
+
+    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: None)
+    monkeypatch.setattr(auth, "resolve_gateway_config", lambda: {})
+    monkeypatch.setattr(auth, "_local_config_dir", lambda: None)
+    monkeypatch.delenv("AX_SPACE_ID", raising=False)
+    monkeypatch.delenv("AX_SPACE", raising=False)
+    monkeypatch.setattr(auth, "_load_config", lambda: {})
+
+    result = runner.invoke(app, ["auth", "whoami", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["resolved_space_id"] == "the-only-space"
+
+
+def test_auth_whoami_uses_explicit_space_from_env(monkeypatch):
+    """Env-configured space must short-circuit the list_spaces probe entirely."""
+
+    class FakeClient:
+        def whoami(self):
+            return {"id": "user-1", "bound_agent": None}
+
+        def list_spaces(self):
+            raise AssertionError("list_spaces should not be called when AX_SPACE_ID is set")
+
+    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: None)
+    monkeypatch.setattr(auth, "resolve_gateway_config", lambda: {})
+    monkeypatch.setattr(auth, "_local_config_dir", lambda: None)
+    monkeypatch.setenv("AX_SPACE_ID", "env-pinned-space")
+    monkeypatch.setattr(auth, "_load_config", lambda: {})
+
+    result = runner.invoke(app, ["auth", "whoami", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["resolved_space_id"] == "env-pinned-space"
 
 
 def test_auth_exchange_without_token_points_agents_to_gateway(monkeypatch, config_dir):


### PR DESCRIPTION
## Reproduction (from the task report)

```
ax login            # against next.paxai.app, user belongs to >1 space
ax auth whoami
-> Error: Multiple spaces found. Use --space-id or set AX_SPACE_ID.
exit code 1
```

Every fresh-laptop user with more than one space fails their first `ax auth whoami`. The README, `docs/login-e2e-runbook.md`, and `docs/operator-qa-runbook.md` all use whoami as the very first verification step after login, so this is a high-blast-radius bug despite the simple root cause.

## Root cause

`ax_cli/commands/auth.py` wrapped the unbound-agent space-resolution fallback in `except SystemExit:`. `resolve_space_id` raises `typer.Exit`, which is a `RuntimeError` subclass — **not** `SystemExit` — so the except block was dead code. The exit propagated, the command failed with code 1, and the noisy `Error: Multiple spaces found.` printed straight to stderr.

## Fix

Decouple identity from space resolution. Identity is token-bound and space-independent; whoami must report user id / email / role regardless of how many spaces the user belongs to.

- Drop the call to `resolve_space_id` from the unbound-agent path entirely.
- Run an exception-free cascade instead: `AX_SPACE` / `AX_SPACE_ID` env → merged config `space_id` → new `_best_effort_single_space_id` helper that returns the only space id when unambiguous and the existing `"unresolved (set AX_SPACE_ID or use --space-id)"` label otherwise.
- The new helper never raises and never writes to stderr, so whoami no longer leaks `Error: Multiple spaces found.` onto a successful invocation.

Also tightened the bound-agent branch: only use `default_space_id` when the bound agent actually carries one, falling through to the same cascade otherwise.

## Summary

One small helper, one rewritten branch, three new tests + one existing test still passing. No schema changes, no client changes. The single-space convenience case still works (`resolved_space_id` shows the only space id), the explicit-env case still works (env short-circuits the probe), and the multi-space case stops crashing.

## Validation

- [x] `pytest tests/test_auth_commands.py -v` — 13 passed (3 new + 10 existing, including the prior `test_auth_whoami_reports_runtime_config`)
- [x] `ruff check ax_cli/commands/auth.py tests/test_auth_commands.py` — clean
- [x] `ruff format` on touched files — formatted
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — `auth doctor` is unchanged; only `auth whoami` is touched
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

`whoami` still calls `client.whoami()` and surfaces the same identity fields. The only behavior change is that `resolved_space_id` reports `"unresolved (set AX_SPACE_ID or use --space-id)"` for multi-space users instead of crashing the command. Bound-agent identity, env-pinned space, and single-space convenience cases all keep working.
