### PR TITLE
feat(gateway): bulk cleanup UI — verified end-to-end against the trustworthy stack

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -78,6 +78,7 @@ from ..gateway import (
     load_gateway_registry,
     load_gateway_session,
     load_recent_gateway_activity,
+    looks_like_space_uuid,
     ollama_setup_status,
     record_gateway_activity,
     remove_agent_entry,
@@ -829,7 +830,11 @@ def _resolve_gateway_agent_home_space(
 ) -> str:
     explicit = str(explicit_space_id or "").strip()
     if explicit:
-        return explicit
+        if looks_like_space_uuid(explicit):
+            return explicit
+        # Caller passed a name/slug — resolve through the backend so we never
+        # store a non-UUID in the registry's space_id field.
+        return resolve_space_id(client, explicit=explicit)
     session_space = str(session.get("space_id") or "").strip()
     if session_space:
         return session_space
@@ -3042,10 +3047,28 @@ def _render_gateway_dashboard(payload: dict) -> Group:
     )
 
 
-def _spaces_payload() -> dict:
-    client = _load_gateway_user_client()
-    raw = client.list_spaces()
-    items = raw.get("spaces", raw) if isinstance(raw, dict) else raw
+def _spaces_cache_path() -> Path:
+    return gateway_dir() / "spaces.cache.json"
+
+
+def _load_spaces_cache() -> list[dict]:
+    try:
+        raw = json.loads(_spaces_cache_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    items = raw.get("spaces") if isinstance(raw, dict) else raw
+    return [item for item in (items or []) if isinstance(item, dict)]
+
+
+def _save_spaces_cache(spaces: list[dict]) -> None:
+    payload = {"spaces": spaces, "saved_at": datetime.now(timezone.utc).isoformat()}
+    try:
+        _spaces_cache_path().write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _normalize_spaces_response(items: list) -> list[dict]:
     spaces: list[dict] = []
     for item in items or []:
         if not isinstance(item, dict):
@@ -3060,12 +3083,50 @@ def _spaces_payload() -> dict:
                 "slug": str(item.get("slug") or "").strip() or None,
             }
         )
+    return spaces
+
+
+def _spaces_payload() -> dict:
+    """Return the spaces visible to the Gateway bootstrap session.
+
+    Always surfaces ``active_space_id`` / ``active_space_name`` from session
+    state, even when the upstream ``list_spaces`` call fails (e.g. paxai.app
+    rate-limits). Successful upstream responses are cached on disk so the UI
+    keeps a usable picker through transient outages.
+    """
     session = load_gateway_session() or {}
-    return {
+    active_space_id = str(session.get("space_id") or "").strip() or None
+    active_space_name = str(session.get("space_name") or "").strip() or None
+
+    error: str | None = None
+    cached = False
+    try:
+        client = _load_gateway_user_client()
+        raw = client.list_spaces()
+        items = raw.get("spaces", raw) if isinstance(raw, dict) else raw
+        spaces = _normalize_spaces_response(items or [])
+        if spaces:
+            _save_spaces_cache(spaces)
+    except Exception as exc:  # noqa: BLE001 — upstream errors are routine here
+        error = str(exc)
+        spaces = _load_spaces_cache()
+        cached = bool(spaces)
+
+    if active_space_id and not any(s["id"] == active_space_id for s in spaces):
+        spaces = [
+            {"id": active_space_id, "name": active_space_name or active_space_id, "slug": None},
+            *spaces,
+        ]
+
+    payload: dict = {
         "spaces": spaces,
-        "active_space_id": str(session.get("space_id") or "").strip() or None,
-        "active_space_name": str(session.get("space_name") or "").strip() or None,
+        "active_space_id": active_space_id,
+        "active_space_name": active_space_name,
     }
+    if error:
+        payload["error"] = error
+        payload["cached"] = cached
+    return payload
 
 
 def _move_managed_agent_space(name: str, new_space_id: str) -> dict:
@@ -4828,20 +4889,14 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                     _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.NOT_FOUND)
                 return
             if parsed.path == "/api/spaces":
-                try:
-                    _write_json_response(self, _spaces_payload())
-                except typer.Exit:
-                    _write_json_response(
-                        self,
-                        {"error": "Gateway is not logged in.", "spaces": [], "active_space_id": None},
-                        status=HTTPStatus.SERVICE_UNAVAILABLE,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    _write_json_response(
-                        self,
-                        {"error": str(exc), "spaces": [], "active_space_id": None},
-                        status=HTTPStatus.BAD_GATEWAY,
-                    )
+                payload = _spaces_payload()
+                # _spaces_payload never raises: upstream failures fall back to
+                # cached spaces + session-known active space. Return 200 as
+                # long as we have something usable; 503 only when there is
+                # neither cache nor session.
+                has_data = bool(payload.get("spaces") or payload.get("active_space_id"))
+                status = HTTPStatus.OK if has_data else HTTPStatus.SERVICE_UNAVAILABLE
+                _write_json_response(self, payload, status=status)
                 return
             if parsed.path.startswith("/api/agents/"):
                 name = unquote(parsed.path.removeprefix("/api/agents/")).strip()
@@ -5465,6 +5520,48 @@ def current_gateway_space(as_json: bool = JSON_OPTION):
         return
     err_console.print(f"Gateway current space: {result.get('space_name') or result.get('space_id') or '-'}")
     err_console.print(f"  space_id = {result.get('space_id') or '-'}")
+
+
+@spaces_app.command("list")
+def list_gateway_spaces(as_json: bool = JSON_OPTION):
+    """List the spaces visible to the Gateway bootstrap session.
+
+    Falls back to the locally cached list when the upstream API is
+    unavailable (e.g. rate-limited), so the operator always sees something
+    actionable.
+    """
+    payload = _spaces_payload()
+    if as_json:
+        print_json(payload)
+        return
+
+    spaces = payload.get("spaces") or []
+    active_id = payload.get("active_space_id")
+    if not spaces:
+        err_console.print("[yellow]No spaces available.[/yellow]")
+        if payload.get("error"):
+            err_console.print(f"  error = {payload['error']}")
+        return
+
+    rows = []
+    for space in spaces:
+        sid = str(space.get("id") or "")
+        rows.append(
+            {
+                "current": "*" if sid and sid == active_id else "",
+                "name": str(space.get("name") or sid),
+                "space_id": sid,
+                "slug": str(space.get("slug") or "") or "-",
+            }
+        )
+    print_table(
+        ["", "Name", "Space ID", "Slug"],
+        rows,
+        keys=["current", "name", "space_id", "slug"],
+    )
+    if payload.get("error"):
+        marker = "cached" if payload.get("cached") else "session-only"
+        err_console.print(f"[dim]Upstream unavailable ({marker}): {payload['error']}[/dim]")
 
 
 @app.command("activity")

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1402,6 +1402,62 @@ def _hide_managed_agents(names: list[str], *, reason: str = "operator_cleanup") 
     }
 
 
+def _restore_hidden_managed_agents(names: list[str]) -> dict:
+    """Symmetric inverse of _hide_managed_agents.
+
+    Clears lifecycle_phase=hidden + hide bookkeeping, restores desired_state
+    to whatever the operator-driven hide had captured (desired_state_before_hide).
+    Refuses to restore agents that are not in the hidden phase — the
+    archived phase has its own restore path (PR #147), and "active" agents
+    don't need restoration.
+    """
+    normalized_names: list[str] = []
+    seen: set[str] = set()
+    for raw_name in names:
+        name = str(raw_name or "").strip()
+        key = name.lower()
+        if not name or key in seen:
+            continue
+        normalized_names.append(name)
+        seen.add(key)
+    if not normalized_names:
+        raise ValueError("Choose at least one managed agent to restore.")
+
+    registry = load_gateway_registry()
+    restored: list[dict] = []
+    missing: list[str] = []
+    not_hidden: list[str] = []
+    for name in normalized_names:
+        entry = find_agent_entry(registry, name)
+        if not entry:
+            missing.append(name)
+            continue
+        if str(entry.get("lifecycle_phase") or "") != "hidden":
+            not_hidden.append(name)
+            continue
+        prior = str(entry.get("desired_state_before_hide") or "").strip() or "running"
+        entry["lifecycle_phase"] = "active"
+        entry["desired_state"] = prior
+        entry.pop("desired_state_before_hide", None)
+        entry.pop("hidden_at", None)
+        entry.pop("hidden_reason", None)
+        restored.append(entry)
+
+    save_gateway_registry(registry)
+    for entry in restored:
+        record_gateway_activity(
+            "managed_agent_unhidden",
+            entry=entry,
+            operator_action=True,
+        )
+    return {
+        "count": len(restored),
+        "missing": missing,
+        "not_hidden": not_hidden,
+        "restored": [annotate_runtime_health(entry, registry=registry) for entry in restored],
+    }
+
+
 def _build_session_client_silent() -> AxClient | None:
     """Build a user-PAT session client without raising. Returns None when
     the gateway is not logged in or the session token is missing/invalid.
@@ -4909,6 +4965,18 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         [str(name or "").strip() for name in raw_names],
                         reason=str(body.get("reason") or "operator_cleanup"),
                     )
+                    _write_json_response(self, payload)
+                    return
+                if parsed.path == "/api/agents/cleanup-restore":
+                    raw_names = body.get("names")
+                    if not isinstance(raw_names, list):
+                        _write_json_response(
+                            self,
+                            {"error": "names must be a list of managed agent names"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    payload = _restore_hidden_managed_agents([str(name or "").strip() for name in raw_names])
                     _write_json_response(self, payload)
                     return
                 if parsed.path == "/local/connect":

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1356,6 +1356,52 @@ def _set_managed_agent_desired_state(name: str, desired_state: str) -> dict:
     return annotate_runtime_health(entry, registry=registry)
 
 
+def _hide_managed_agents(names: list[str], *, reason: str = "operator_cleanup") -> dict:
+    normalized_names = []
+    seen = set()
+    for raw_name in names:
+        name = str(raw_name or "").strip()
+        key = name.lower()
+        if not name or key in seen:
+            continue
+        normalized_names.append(name)
+        seen.add(key)
+    if not normalized_names:
+        raise ValueError("Choose at least one managed agent to hide.")
+
+    registry = load_gateway_registry()
+    hidden: list[dict] = []
+    missing: list[str] = []
+    hidden_reason = str(reason or "").strip() or "operator_cleanup"
+    hidden_at = gateway_core._now_iso()
+    for name in normalized_names:
+        entry = find_agent_entry(registry, name)
+        if not entry:
+            missing.append(name)
+            continue
+        if str(entry.get("desired_state") or "").strip().lower() != "stopped":
+            entry["desired_state_before_hide"] = entry.get("desired_state") or "running"
+        entry["desired_state"] = "stopped"
+        entry["lifecycle_phase"] = "hidden"
+        entry["hidden_at"] = hidden_at
+        entry["hidden_reason"] = hidden_reason
+        hidden.append(entry)
+
+    save_gateway_registry(registry)
+    for entry in hidden:
+        record_gateway_activity(
+            "managed_agent_hidden",
+            entry=entry,
+            hidden_reason=hidden_reason,
+            operator_action=True,
+        )
+    return {
+        "count": len(hidden),
+        "missing": missing,
+        "hidden": [annotate_runtime_health(entry, registry=registry) for entry in hidden],
+    }
+
+
 def _build_session_client_silent() -> AxClient | None:
     """Build a user-PAT session client without raising. Returns None when
     the gateway is not logged in or the session token is missing/invalid.
@@ -4849,6 +4895,21 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         if stored:
                             payload = _with_registry_refs(registry, annotate_runtime_health(stored, registry=registry))
                     _write_json_response(self, payload, status=HTTPStatus.CREATED)
+                    return
+                if parsed.path == "/api/agents/cleanup-hide":
+                    raw_names = body.get("names")
+                    if not isinstance(raw_names, list):
+                        _write_json_response(
+                            self,
+                            {"error": "names must be a list of managed agent names"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    payload = _hide_managed_agents(
+                        [str(name or "").strip() for name in raw_names],
+                        reason=str(body.get("reason") or "operator_cleanup"),
+                    )
+                    _write_json_response(self, payload)
                     return
                 if parsed.path == "/local/connect":
                     agent_name = str(body.get("agent_name") or body.get("name") or "").strip()

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1463,6 +1463,127 @@ def _restore_hidden_managed_agents(names: list[str]) -> dict:
     }
 
 
+def _read_recovery_evidence(name: str) -> dict | None:
+    """Reconstruct a minimal registry row for an agent from local evidence.
+
+    Used when a managed_agent_added activity event was recorded but the
+    registry row was lost (pre-race-fix damage). Reads from three sources,
+    all verifiable:
+
+    - Activity log: most recent managed_agent_added for ``name`` →
+      agent_id, asset_id, install_id, gateway_id, runtime_type,
+      transport, space_id, token_file, credential_source, ts.
+    - Token directory: ``~/.ax/gateway/agents/<name>/token`` must exist
+      (we don't fabricate credentials).
+    - Workdir ``.ax/AGENT_CONTEXT.md`` if present, for the workdir hint.
+
+    Returns None if no managed_agent_added event is recorded or the
+    token file is missing — both required for a safe recovery.
+    """
+    target_event: dict | None = None
+    activity_path = activity_log_path()
+    try:
+        with activity_path.open(encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    ev = json.loads(line)
+                except (ValueError, json.JSONDecodeError):
+                    continue
+                if ev.get("agent_name") != name or ev.get("event") != "managed_agent_added":
+                    continue
+                target_event = ev  # later writes win — pick the most recent
+    except OSError:
+        return None
+    if not isinstance(target_event, dict):
+        return None
+    token_file = str(target_event.get("token_file") or "").strip()
+    if not token_file or not Path(token_file).is_file():
+        return None
+    return target_event
+
+
+def _recover_managed_agents_from_evidence(names: list[str]) -> dict:
+    """Recover registry rows for agents present locally (token + activity)
+    but absent from registry.json (pre-race-fix row loss).
+
+    Refuses to recover agents that are already in the registry — use
+    archive/restore or hide/unhide for state changes on existing rows.
+    The reconstructed row is minimal: enough fields for the daemon to
+    pick it up on next reconcile and hydrate the rest from upstream.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in names:
+        n = str(raw or "").strip()
+        if not n or n.lower() in seen:
+            continue
+        normalized.append(n)
+        seen.add(n.lower())
+    if not normalized:
+        raise ValueError("Choose at least one agent to recover.")
+
+    registry = load_gateway_registry()
+    recovered: list[dict] = []
+    already_present: list[str] = []
+    no_evidence: list[str] = []
+
+    for name in normalized:
+        if find_agent_entry(registry, name) is not None:
+            already_present.append(name)
+            continue
+        evidence = _read_recovery_evidence(name)
+        if evidence is None:
+            no_evidence.append(name)
+            continue
+        # Build minimal row — sourced fields only.
+        entry: dict = {
+            "name": name,
+            "agent_id": str(evidence.get("agent_id") or "").strip(),
+            "asset_id": str(evidence.get("asset_id") or evidence.get("agent_id") or "").strip(),
+            "install_id": str(evidence.get("install_id") or "").strip(),
+            "gateway_id": str(evidence.get("gateway_id") or "").strip(),
+            "runtime_type": str(evidence.get("runtime_type") or "").strip(),
+            "transport": str(evidence.get("transport") or "gateway").strip(),
+            "credential_source": str(evidence.get("credential_source") or "gateway").strip(),
+            "token_file": str(evidence.get("token_file") or "").strip(),
+            "space_id": str(evidence.get("space_id") or "").strip(),
+            "added_at": str(evidence.get("ts") or "").strip(),
+            "lifecycle_phase": "active",
+            "desired_state": "stopped",  # safe default — operator restarts deliberately
+            "drift_reason": "registry_row_recovered_from_evidence",
+        }
+        # Pick a sensible template_id from runtime_type; daemon hydrates from
+        # upstream on reconcile.
+        rt = entry["runtime_type"]
+        if rt == "claude_code_channel":
+            entry["template_id"] = "claude_code_channel"
+            entry["template_label"] = "Claude Code Channel"
+        elif rt == "hermes_sentinel":
+            entry["template_id"] = "hermes"
+            entry["template_label"] = "Hermes"
+        elif rt == "inbox":
+            entry["template_id"] = "pass_through"
+            entry["template_label"] = "Pass-through"
+        registry.setdefault("agents", []).append(entry)
+        recovered.append(entry)
+
+    save_gateway_registry(registry)
+    for entry in recovered:
+        record_gateway_activity(
+            "managed_agent_recovered",
+            entry=entry,
+            operator_action=True,
+            recovery_source="local_evidence",
+        )
+
+    return {
+        "count": len(recovered),
+        "already_present": already_present,
+        "no_evidence": no_evidence,
+        "recovered": [annotate_runtime_health(entry, registry=registry) for entry in recovered],
+    }
+
+
 def _build_session_client_silent() -> AxClient | None:
     """Build a user-PAT session client without raising. Returns None when
     the gateway is not logged in or the session token is missing/invalid.
@@ -5034,6 +5155,22 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                     payload = _restore_hidden_managed_agents([str(name or "").strip() for name in raw_names])
                     _write_json_response(self, payload)
                     return
+                if parsed.path == "/api/agents/recover":
+                    raw_names = body.get("names")
+                    if not isinstance(raw_names, list):
+                        _write_json_response(
+                            self,
+                            {"error": "names must be a list of managed agent names"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    try:
+                        payload = _recover_managed_agents_from_evidence([str(name or "").strip() for name in raw_names])
+                    except ValueError as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                        return
+                    _write_json_response(self, payload)
+                    return
                 if parsed.path == "/local/connect":
                     agent_name = str(body.get("agent_name") or body.get("name") or "").strip()
                     registry_ref = str(
@@ -7429,6 +7566,46 @@ def restore_agent(
     for name in not_found:
         err_console.print(f"[red]Managed agent not found:[/red] {name}")
     if not restored and not_found:
+        raise typer.Exit(1)
+
+
+@agents_app.command("recover")
+def recover_agents(
+    names: list[str] = typer.Argument(..., help="One or more agent names whose registry rows were lost"),
+    as_json: bool = JSON_OPTION,
+):
+    """Recover registry rows from local evidence (token + activity log).
+
+    Use when a managed_agent_added event was recorded but the registry
+    row is missing — typically pre-race-fix damage. Reads the most
+    recent managed_agent_added event for each name from the activity
+    log, confirms the token file exists, and inserts a minimal row
+    with the verified fields. The daemon hydrates the rest from
+    upstream on the next reconcile pass.
+
+    Refuses to recover agents already present in the registry. Refuses
+    to recover agents lacking either the activity event or the token
+    file (we don't fabricate credentials).
+    """
+    try:
+        result = _recover_managed_agents_from_evidence(list(names))
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(2) from exc
+    if as_json:
+        print_json(result)
+        if result["count"] == 0:
+            raise typer.Exit(1)
+        return
+    for entry in result.get("recovered", []):
+        err_console.print(f"[green]Recovered:[/green] @{entry.get('name')} (agent_id={entry.get('agent_id')})")
+    for name in result.get("already_present", []):
+        err_console.print(f"[yellow]Already present:[/yellow] @{name} (no recovery needed)")
+    for name in result.get("no_evidence", []):
+        err_console.print(
+            f"[red]No recovery evidence:[/red] @{name} (need both managed_agent_added activity + token file)"
+        )
+    if result["count"] == 0 and (result.get("no_evidence") or not result.get("already_present")):
         raise typer.Exit(1)
 
 

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2982,6 +2982,50 @@ _OPERATOR_AUTHORITATIVE_FIELDS = (
 )
 
 
+_SPACE_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_space_uuid(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SPACE_UUID_RE.match(value.strip()))
+
+
+def reconcile_corrupt_space_ids(registry: dict[str, Any]) -> int:
+    """Heal agent rows where ``space_id`` holds a name/slug instead of a UUID.
+
+    Recovers the correct UUID from sibling fields (``active_space_id``,
+    ``default_space_id``, ``allowed_spaces[].space_id``). Idempotent — rows
+    whose ``space_id`` is already UUID-shaped or empty are left alone.
+    Returns the count of repaired rows.
+    """
+    repaired = 0
+    for entry in registry.get("agents", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("space_id")
+        if not isinstance(sid, str) or not sid.strip() or looks_like_space_uuid(sid):
+            continue
+        candidate = ""
+        for key in ("active_space_id", "default_space_id"):
+            v = entry.get(key)
+            if looks_like_space_uuid(v):
+                candidate = str(v).strip()
+                break
+        if not candidate:
+            allowed = entry.get("allowed_spaces") or []
+            if isinstance(allowed, list):
+                for row in allowed:
+                    if isinstance(row, dict) and looks_like_space_uuid(row.get("space_id")):
+                        candidate = str(row["space_id"]).strip()
+                        break
+        if candidate:
+            entry["space_id"] = candidate
+            repaired += 1
+    return repaired
+
+
 def load_gateway_registry() -> dict[str, Any]:
     registry = _read_json(registry_path(), default=_default_registry())
     registry.setdefault("version", 1)
@@ -2998,6 +3042,7 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
+    reconcile_corrupt_space_ids(registry)
     # Stamp a load-time snapshot so save_gateway_registry can distinguish:
     #   - "caller removed this row" vs "another writer added this row"
     #     (row existence diff)

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -73,6 +73,7 @@
     .system-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); font-family: var(--mono); font-size: 11px; color: var(--muted); cursor: pointer; transition: border-color 120ms ease, color 120ms ease; }
     .system-toggle:hover { border-color: var(--line-strong); color: var(--text); }
     .system-toggle.on { border-color: rgba(94,234,212,0.4); color: var(--accent); background: rgba(94,234,212,0.08); }
+    .system-toggle[hidden] { display: none; }
     .chip.system { color: var(--muted); border-color: var(--line); background: rgba(255,255,255,0.04); }
 
     .hero { display: grid; grid-template-columns: 1fr; gap: 18px; margin-bottom: 30px; }
@@ -1486,14 +1487,16 @@
 
     function updateRow(row, agent) {
       const status = friendlyStatus(agent);
-      const dot = row.children[0];
-      const agentEl = row.children[1];
+      // Row children: [0] cleanup-cell (always present, hidden in default mode),
+      // [1] dot, [2] row-agent, [3] row-space, [4] row-last-seen, [5] row-action.
+      const dot = row.children[1];
+      const agentEl = row.children[2];
       const typeMarkEl = agentEl.children[0];
       const nameEl = agentEl.querySelector(".row-name");
       const typeLabelEl = agentEl.querySelector(".row-type-label");
-      const spaceEl = row.children[2];
-      const lastSeenEl = row.children[3];
-      const actionEl = row.children[4];
+      const spaceEl = row.children[3];
+      const lastSeenEl = row.children[4];
+      const actionEl = row.children[5];
 
       if (isMailboxRuntime(agent)) {
         renderMailboxIndicator(dot, agent, status);

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -74,6 +74,12 @@
     .system-toggle:hover { border-color: var(--line-strong); color: var(--text); }
     .system-toggle.on { border-color: rgba(94,234,212,0.4); color: var(--accent); background: rgba(94,234,212,0.08); }
     .system-toggle[hidden] { display: none; }
+    /* Hidden-agent rows: visually distinct so operators can tell them apart from active. */
+    .agent-row.row-hidden { background: rgba(255, 255, 255, 0.015); }
+    .agent-row.row-hidden .row-name { color: var(--muted); }
+    .agent-row.row-hidden .row-type-label::after { content: " · Hidden"; color: var(--muted-2); font-style: italic; }
+    .row-unhide { padding: 4px 10px; border-radius: 999px; border: 1px solid var(--line); background: transparent; color: var(--muted); font-family: var(--mono); font-size: 11px; cursor: pointer; }
+    .row-unhide:hover { border-color: var(--accent); color: var(--accent); }
     .chip.system { color: var(--muted); border-color: var(--line); background: rgba(255,255,255,0.04); }
 
     .hero { display: grid; grid-template-columns: 1fr; gap: 18px; margin-bottom: 30px; }
@@ -398,6 +404,7 @@
           <button type="button" class="system-toggle" id="cleanup-hide-btn" hidden title="Hide selected agents from the list and stop their runtimes">Hide selected</button>
           <span class="count" id="cleanup-selection" hidden></span>
           <button type="button" class="system-toggle" id="cleanup-toggle" title="Bulk-clean stale agents from this list">Clean up</button>
+          <button type="button" class="system-toggle" id="hidden-toggle" title="Show hidden/inactive agents — restore individually with their Unhide button">Show hidden</button>
           <button type="button" class="system-toggle" id="system-toggle" title="Show gateway-internal agents like switchboards">Show system agents</button>
           <span class="count" id="agent-count" hidden></span>
         </div>
@@ -514,6 +521,7 @@
       rowsByName: new Map(),
       lastRenderMode: null, // "disconnected" | "connect" | "list"
       showSystemAgents: false,
+      showHidden: false,
       cleanupMode: false,
       selectedNames: new Set(),
     };
@@ -521,6 +529,7 @@
     // Restore system-agent toggle state from localStorage so the choice persists across reloads.
     try {
       state.showSystemAgents = window.localStorage.getItem("ax-demo-show-system") === "1";
+      state.showHidden = window.localStorage.getItem("ax-demo-show-hidden") === "1";
     } catch (_) { /* ignore */ }
     function isSystemAgent(agent) {
       const name = String(agent.name || "");
@@ -828,8 +837,12 @@
 
     async function loadStatus() {
       let status;
+      // When the operator wants to see hidden/inactive agents we have to ask
+      // the backend for the unfiltered list — default /api/status filters
+      // hidden+system out of the agents array (counts stay in summary).
+      const path = state.showHidden ? "/api/status?all=1" : "/api/status";
       try {
-        status = await api("GET", "/api/status");
+        status = await api("GET", path);
       } catch (err) {
         renderDisconnectedState(err.message || "Gateway daemon is not responding.");
         return;
@@ -838,9 +851,11 @@
       state.baseUrl = status.base_url || null;
       state.user = status.user || null;
       state.agents = Array.isArray(status.agents) ? status.agents : [];
+      state.summary = status.summary || {};
       state.sessionSpaceId = status.space_id || null;
       // activeSpaceId stays "" (= All spaces) unless user explicitly picks one.
       renderConnectionPill();
+      refreshHiddenToggleUI();
       if (!state.connected) {
         renderConnectPrompt();
         return;
@@ -1528,6 +1543,7 @@
       if (spaceEl.textContent !== newSpace) spaceEl.textContent = newSpace;
       spaceEl.title = spaceIsMuted ? "" : newSpace;
       const needsApproval = String(agent.approval_state || "").toLowerCase() === "pending" && agent.approval_id;
+      const isHidden = String(agent.lifecycle_phase || "") === "hidden";
       clearChildren(actionEl);
       if (needsApproval) {
         actionEl.appendChild(makeEl("button", {
@@ -1539,9 +1555,20 @@
             openDrawer(newName);
           },
         }, ["Review"]));
+      } else if (isHidden) {
+        actionEl.appendChild(makeEl("button", {
+          type: "button",
+          class: "row-unhide",
+          title: "Restore this agent — clears hidden state and returns it to default view",
+          onclick: (event) => {
+            event.stopPropagation();
+            void unhideAgent(newName);
+          },
+        }, ["Unhide"]));
       } else {
         actionEl.appendChild(makeEl("span", { class: "row-chev" }, ["›"]));
       }
+      row.classList.toggle("row-hidden", isHidden);
       row.classList.toggle("active-row", state.drawerAgentName === agent.name);
     }
 
@@ -2391,6 +2418,46 @@
 
     $("cleanup-hide-btn").addEventListener("click", () => {
       void hideSelectedAgents();
+    });
+
+    function refreshHiddenToggleUI() {
+      const btn = $("hidden-toggle");
+      if (!btn) return;
+      const hiddenCount = (state.summary && state.summary.hidden_agents) || 0;
+      btn.classList.toggle("on", state.showHidden);
+      btn.textContent = state.showHidden
+        ? "Hide hidden" + (hiddenCount ? " (" + hiddenCount + ")" : "")
+        : "Show hidden" + (hiddenCount ? " (" + hiddenCount + ")" : "");
+      // Stay visible when there *are* hidden agents OR when we're already showing them
+      // (so the operator can toggle back). If neither, fade it out.
+      btn.style.display = hiddenCount === 0 && !state.showHidden ? "none" : "";
+    }
+
+    async function unhideAgent(name) {
+      try {
+        const result = await api("POST", "/api/agents/cleanup-restore", { names: [name] });
+        if (result && result.count > 0) {
+          showToast("Restored @" + name, "ok");
+        } else if (result && result.not_hidden && result.not_hidden.length) {
+          showToast("@" + name + " was not hidden", "warn");
+        } else {
+          showToast("Restore failed for @" + name, "err");
+        }
+        await loadStatus();
+      } catch (err) {
+        showToast(err.message || "Restore failed", "err");
+      }
+    }
+
+    $("hidden-toggle").addEventListener("click", () => {
+      state.showHidden = !state.showHidden;
+      try { window.localStorage.setItem("ax-demo-show-hidden", state.showHidden ? "1" : "0"); } catch (_) {}
+      refreshHiddenToggleUI();
+      // Re-render fully so hidden rows add/remove cleanly.
+      state.rowsByName.clear();
+      clearChildren($("agent-region"));
+      state.lastRenderMode = null;
+      void loadStatus();
     });
 
     wizardSubmit.addEventListener("click", async () => {

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -511,6 +511,7 @@
       spaces: [],
       activeSpaceId: null,
       sessionSpaceId: null,
+      sessionSpaceName: null,
       templates: [],
       selectedTemplateId: "hermes",
       submitting: false,
@@ -666,16 +667,71 @@
       return { icon: "custom", label: templateLabel(agent), className: "type-custom" };
     }
 
+    function looksLikeSpaceId(value) {
+      return /^[0-9a-f]{8}-[0-9a-f-]{13,}$/i.test(String(value || ""));
+    }
+
+    function addSpaceCandidate(map, id, name, { authoritative = false } = {}) {
+      const sid = String(id || "").trim();
+      if (!sid) return;
+      if (!looksLikeSpaceId(sid) && /[\s'"]/.test(sid)) return;
+      const label = String(name || "").trim();
+      const cleanName = label && !looksLikeSpaceId(label) ? label : sid;
+      const existing = map.get(sid);
+      const isSpecificNonSessionName =
+        cleanName !== sid && (!state.sessionSpaceName || cleanName !== state.sessionSpaceName || sid === state.sessionSpaceId);
+      const existingIsWeak =
+        !existing ||
+        existing.name === existing.id ||
+        (state.sessionSpaceName && existing.id !== state.sessionSpaceId && existing.name === state.sessionSpaceName);
+      if (!existing || (authoritative && !existing.authoritative) || (!existing.authoritative && existingIsWeak && isSpecificNonSessionName)) {
+        map.set(sid, { id: sid, name: cleanName, authoritative });
+      }
+    }
+
+    function knownSpaces() {
+      const map = new Map();
+      if (state.sessionSpaceId) {
+        addSpaceCandidate(map, state.sessionSpaceId, state.sessionSpaceName, { authoritative: true });
+      }
+      for (const space of state.spaces || []) {
+        addSpaceCandidate(map, space.id, space.name, { authoritative: true });
+      }
+      for (const agent of state.agents || []) {
+        const agentSpaceId = String(agent.space_id || agent.default_space_id || agent.active_space_id || "").trim();
+        if (agentSpaceId === state.sessionSpaceId) {
+          addSpaceCandidate(map, agentSpaceId, state.sessionSpaceName, { authoritative: true });
+        } else {
+          addSpaceCandidate(map, agentSpaceId, agent.space_name || agent.default_space_name || agent.active_space_name);
+        }
+        for (const space of agent.allowed_spaces || []) {
+          if (typeof space === "string") {
+            addSpaceCandidate(map, space, space);
+          } else if (space) {
+            addSpaceCandidate(map, space.space_id || space.id, space.name || space.space_name);
+          }
+        }
+      }
+      return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    function spaceNameForId(id) {
+      const sid = String(id || "").trim();
+      if (!sid) return "";
+      if (sid === state.sessionSpaceId && state.sessionSpaceName) return state.sessionSpaceName;
+      const match = knownSpaces().find((space) => space.id === sid);
+      return match ? match.name : "";
+    }
+
     function spaceLabel(agent) {
       // Prefer the agent's home space (space_id) over the gateway's runtime
       // operating space (active_space_id). active_space_id reflects what the
       // gateway is *sending as*, not where the agent lives.
       const id = String(agent.space_id || agent.default_space_id || agent.active_space_id || "").trim();
-      const looksLikeId = (s) => /^[0-9a-f]{8}-[0-9a-f-]{13,}$/i.test(String(s || ""));
       const explicit = String(agent.space_name || agent.default_space_name || agent.active_space_name || "").trim();
-      const match = state.spaces.find((space) => space.id === id);
-      if (match) return match.name;
-      if (explicit && !looksLikeId(explicit)) return explicit;
+      const knownName = spaceNameForId(id);
+      if (knownName) return knownName;
+      if (explicit && !looksLikeSpaceId(explicit)) return explicit;
       return id || "—";
     }
 
@@ -853,6 +909,7 @@
       state.agents = Array.isArray(status.agents) ? status.agents : [];
       state.summary = status.summary || {};
       state.sessionSpaceId = status.space_id || null;
+      state.sessionSpaceName = status.space_name || null;
       // activeSpaceId stays "" (= All spaces) unless user explicitly picks one.
       renderConnectionPill();
       refreshHiddenToggleUI();
@@ -1024,13 +1081,15 @@
 
     /* --- Space + template + wizard renders --------------------------- */
 
+    function sessionSpaceLabel() {
+      if (state.sessionSpaceName) return state.sessionSpaceName;
+      if (state.sessionSpaceId) return `Space ${state.sessionSpaceId.slice(0, 8)}`;
+      return "Current space";
+    }
+
     function renderSpaceSelect() {
       const select = $("space-select");
-      const allSpaces = state.spaces.length
-        ? state.spaces
-        : state.sessionSpaceId
-        ? [{ id: state.sessionSpaceId, name: "Current space" }]
-        : [];
+      const allSpaces = knownSpaces();
       clearChildren(select);
       // Always include the "All spaces" option as the default filter.
       const allOpt = makeEl("option", { value: "" }, ["All spaces"]);
@@ -1045,11 +1104,7 @@
 
     function renderAgentSpaceOptions() {
       const select = $("agent-space-input");
-      const spaces = state.spaces.length
-        ? state.spaces
-        : state.sessionSpaceId
-        ? [{ id: state.sessionSpaceId, name: "Current space" }]
-        : [];
+      const spaces = knownSpaces();
       clearChildren(select);
       if (!spaces.length) {
         select.appendChild(makeEl("option", { value: "" }, ["No spaces available"]));

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -101,6 +101,7 @@
     .section-title h2 { margin: 0; font-size: 18px; font-weight: 500; letter-spacing: -0.005em; }
     .section-title .count { color: var(--muted); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 12px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); }
     .section-title .count[hidden] { display: none; }
+    .cleanup-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
 
     /* Connect card (disconnected state) */
     .connect-card { padding: 36px 32px; border-radius: var(--radius); border: 1px solid var(--line-strong); background: var(--panel); backdrop-filter: blur(10px); }
@@ -117,12 +118,17 @@
     /* Agent list (rows) */
     .agent-list { border-radius: var(--radius); border: 1px solid var(--line); background: var(--panel); backdrop-filter: blur(10px); overflow: hidden; }
     .agent-grid-cols { display: grid; grid-template-columns: 38px minmax(220px, 1.15fr) minmax(150px, 0.72fr) minmax(210px, 1fr) minmax(40px, auto); gap: 14px; align-items: center; }
+    .agent-list.cleanup-mode .agent-grid-cols { grid-template-columns: 30px 38px minmax(220px, 1.15fr) minmax(150px, 0.72fr) minmax(210px, 1fr) minmax(40px, auto); }
     .agent-list-head { padding: 12px 20px; border-bottom: 1px solid var(--line); background: rgba(255, 255, 255, 0.02); font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted-2); }
     .agent-row { padding: 16px 20px; border: 0; border-bottom: 1px solid var(--line); background: transparent; color: var(--text); cursor: pointer; transition: background 120ms ease; text-align: left; font: inherit; width: 100%; }
     .agent-row:last-child { border-bottom: 0; }
     .agent-row:hover { background: rgba(255, 255, 255, 0.03); }
     .agent-row:focus-visible { outline: 2px solid rgba(94, 234, 212, 0.5); outline-offset: -2px; }
     .agent-row.active-row { background: rgba(94, 234, 212, 0.06); }
+    .agent-list.cleanup-mode .agent-row { cursor: default; }
+    .cleanup-cell { display: none; justify-self: center; align-items: center; }
+    .agent-list.cleanup-mode .cleanup-cell { display: inline-flex; }
+    .cleanup-check { width: 18px; height: 18px; accent-color: var(--accent); cursor: pointer; }
 
     .dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; justify-self: center; background: var(--muted-2); transition: background 200ms ease, box-shadow 200ms ease; }
     .dot.tone-ok { background: var(--green); box-shadow: 0 0 0 4px var(--green-soft); }
@@ -308,6 +314,7 @@
 
     @media (max-width: 960px) {
       .agent-grid-cols { grid-template-columns: 38px minmax(170px, 1fr) minmax(128px, 0.65fr) minmax(154px, 0.82fr) minmax(30px, auto); gap: 12px; }
+      .agent-list.cleanup-mode .agent-grid-cols { grid-template-columns: 30px 38px minmax(170px, 1fr) minmax(128px, 0.65fr) minmax(154px, 0.82fr) minmax(30px, auto); }
       .row-space { font-size: 12px; }
     }
     @media (max-width: 720px) {
@@ -317,6 +324,7 @@
       .hero-actions { margin-top: 20px; }
       .topbar { margin-bottom: 24px; }
       .agent-grid-cols { grid-template-columns: 34px minmax(0, 1fr) minmax(96px, 0.55fr) minmax(116px, 0.65fr) minmax(22px, auto); gap: 10px; }
+      .agent-list.cleanup-mode .agent-grid-cols { grid-template-columns: 28px 34px minmax(0, 1fr) minmax(96px, 0.55fr) minmax(116px, 0.65fr) minmax(22px, auto); }
       .type-mark { width: 30px; height: 30px; border-radius: 9px; }
       .type-mark svg { width: 18px; height: 18px; }
       .row-agent { gap: 9px; }
@@ -385,7 +393,10 @@
     <section>
       <div class="section-title">
         <h2 id="list-title">Your agents</h2>
-        <div style="display: flex; align-items: center; gap: 10px;">
+        <div class="cleanup-actions">
+          <button type="button" class="system-toggle" id="cleanup-hide-btn" hidden title="Hide selected agents from the list and stop their runtimes">Hide selected</button>
+          <span class="count" id="cleanup-selection" hidden></span>
+          <button type="button" class="system-toggle" id="cleanup-toggle" title="Bulk-clean stale agents from this list">Clean up</button>
           <button type="button" class="system-toggle" id="system-toggle" title="Show gateway-internal agents like switchboards">Show system agents</button>
           <span class="count" id="agent-count" hidden></span>
         </div>
@@ -502,6 +513,8 @@
       rowsByName: new Map(),
       lastRenderMode: null, // "disconnected" | "connect" | "list"
       showSystemAgents: false,
+      cleanupMode: false,
+      selectedNames: new Set(),
     };
 
     // Restore system-agent toggle state from localStorage so the choice persists across reloads.
@@ -1214,6 +1227,7 @@
         list = makeEl("div", { class: "agent-list" });
         // Header row (column labels)
         const head = makeEl("div", { class: "agent-list-head agent-grid-cols" }, [
+          makeEl("span", { class: "cleanup-cell" }),
           makeEl("span"),
           makeEl("span", null, ["Agent"]),
           makeEl("span", null, ["Space"]),
@@ -1255,6 +1269,15 @@
           const row = state.rowsByName.get(name);
           if (row) list.appendChild(row);
         }
+      }
+      // Reapply cleanup-mode class (list may have been recreated above) and
+      // restore checkbox states for any selected agents that survived a reorder.
+      if (state.cleanupMode) {
+        list.classList.add("cleanup-mode");
+        list.querySelectorAll(".cleanup-check").forEach((cb) => {
+          const name = cb.dataset.name;
+          if (name && state.selectedNames.has(name)) cb.checked = true;
+        });
       }
     }
 
@@ -1361,14 +1384,34 @@
         tabindex: "0",
         class: "agent-row agent-grid-cols",
         dataset: { name },
-        onclick: () => openDrawer(name),
+        onclick: (event) => {
+          if (state.cleanupMode) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
+          openDrawer(name);
+        },
         onkeydown: (event) => {
+          if (state.cleanupMode) return;
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
             openDrawer(name);
           }
         },
       });
+      const cleanupCell = makeEl("span", { class: "cleanup-cell" }, [
+        makeEl("input", {
+          type: "checkbox",
+          class: "cleanup-check",
+          dataset: { name },
+          onclick: (event) => {
+            event.stopPropagation();
+            toggleAgentSelection(name, event.target.checked);
+          },
+        }),
+      ]);
+      row.appendChild(cleanupCell);
       row.appendChild(makeEl("span", { class: "dot tone-muted" }));
       row.appendChild(makeEl("span", { class: "row-agent" }, [
         makeEl("span", { class: "type-mark type-custom", title: "Custom", "aria-label": "Custom" }, [typeIcon("custom", "Custom")]),
@@ -2262,6 +2305,89 @@
       state.lastRenderMode = null;
       ensureListMode();
       renderAgentList();
+    });
+
+    function applyCleanupModeClass() {
+      const list = document.querySelector(".agent-list");
+      if (!list) return;
+      list.classList.toggle("cleanup-mode", state.cleanupMode);
+    }
+
+    function refreshCleanupToolbar() {
+      const toggleBtn = $("cleanup-toggle");
+      const hideBtn = $("cleanup-hide-btn");
+      const selCount = $("cleanup-selection");
+      if (state.cleanupMode) {
+        toggleBtn.textContent = "Cancel";
+        toggleBtn.classList.add("on");
+        const n = state.selectedNames.size;
+        hideBtn.hidden = n === 0;
+        hideBtn.textContent = n > 0 ? `Hide ${n} selected` : "Hide selected";
+        selCount.hidden = n === 0;
+        selCount.textContent = n > 0 ? `${n} selected` : "";
+      } else {
+        toggleBtn.textContent = "Clean up";
+        toggleBtn.classList.remove("on");
+        hideBtn.hidden = true;
+        selCount.hidden = true;
+      }
+    }
+
+    function toggleAgentSelection(name, checked) {
+      if (checked) state.selectedNames.add(name);
+      else state.selectedNames.delete(name);
+      refreshCleanupToolbar();
+    }
+
+    function exitCleanupMode() {
+      state.cleanupMode = false;
+      state.selectedNames.clear();
+      // Clear all checkboxes in the DOM.
+      const list = document.querySelector(".agent-list");
+      if (list) {
+        list.querySelectorAll(".cleanup-check").forEach((cb) => { cb.checked = false; });
+      }
+      applyCleanupModeClass();
+      refreshCleanupToolbar();
+    }
+
+    async function hideSelectedAgents() {
+      const names = Array.from(state.selectedNames);
+      if (!names.length) return;
+      const hideBtn = $("cleanup-hide-btn");
+      const original = hideBtn.textContent;
+      hideBtn.disabled = true;
+      hideBtn.textContent = "Hiding…";
+      try {
+        const result = await api("POST", "/api/agents/cleanup-hide", { names, reason: "operator_cleanup" });
+        const hidden = (result && result.count) || 0;
+        const missing = (result && result.missing) || [];
+        if (missing.length) {
+          showToast(`Hid ${hidden}, ${missing.length} not found`, "warn");
+        } else {
+          showToast(`Hid ${hidden} agent${hidden === 1 ? "" : "s"}`, "ok");
+        }
+        exitCleanupMode();
+        await loadStatus();
+      } catch (err) {
+        showToast(err.message || "Hide failed", "err");
+        hideBtn.disabled = false;
+        hideBtn.textContent = original;
+      }
+    }
+
+    $("cleanup-toggle").addEventListener("click", () => {
+      if (state.cleanupMode) {
+        exitCleanupMode();
+        return;
+      }
+      state.cleanupMode = true;
+      applyCleanupModeClass();
+      refreshCleanupToolbar();
+    });
+
+    $("cleanup-hide-btn").addEventListener("click", () => {
+      void hideSelectedAgents();
     });
 
     wizardSubmit.addEventListener("click", async () => {

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5160,6 +5160,60 @@ def test_status_payload_include_hidden_returns_all(monkeypatch, tmp_path):
     assert payload["summary"]["hidden_agents"] == 1
 
 
+def test_operator_cleanup_hides_selected_agents(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    registry = {
+        "agents": [
+            {
+                "name": "stale-one",
+                "agent_id": "agent-stale-one",
+                "template_id": "claude_code_channel",
+                "runtime_type": "claude_code_channel",
+                "desired_state": "running",
+                "effective_state": "error",
+            },
+            {
+                "name": "stale-two",
+                "agent_id": "agent-stale-two",
+                "template_id": "pass_through",
+                "runtime_type": "inbox",
+                "desired_state": "running",
+                "effective_state": "stale",
+            },
+            {
+                "name": "keeper",
+                "agent_id": "agent-keeper",
+                "template_id": "echo",
+                "runtime_type": "echo",
+                "desired_state": "running",
+                "effective_state": "running",
+            },
+        ]
+    }
+    gateway_core.save_gateway_registry(registry)
+
+    payload = gateway_cmd._hide_managed_agents(
+        ["stale-one", "stale-two"],
+        reason="operator_cleanup",
+    )
+
+    assert payload["count"] == 2
+    assert payload["missing"] == []
+    stored = {agent["name"]: agent for agent in gateway_core.load_gateway_registry()["agents"]}
+    assert stored["stale-one"]["lifecycle_phase"] == "hidden"
+    assert stored["stale-one"]["desired_state"] == "stopped"
+    assert stored["stale-one"]["hidden_reason"] == "operator_cleanup"
+    assert stored["stale-two"]["lifecycle_phase"] == "hidden"
+    assert stored["keeper"].get("lifecycle_phase", "active") == "active"
+
+    visible_payload = gateway_cmd._status_payload(activity_limit=0)
+    visible_names = [agent["name"] for agent in visible_payload["agents"]]
+    assert visible_names == ["keeper"]
+    assert visible_payload["summary"]["hidden_agents"] == 2
+    recent = gateway_core.load_recent_gateway_activity()
+    assert [event["event"] for event in recent].count("managed_agent_hidden") == 2
+
+
 def test_lifecycle_signal_sent_on_connected_to_stale(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
     client = _RecordingHeartbeatClient()

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5214,6 +5214,65 @@ def test_operator_cleanup_hides_selected_agents(monkeypatch, tmp_path):
     assert [event["event"] for event in recent].count("managed_agent_hidden") == 2
 
 
+def test_operator_cleanup_restore_unhides_selected_agents(monkeypatch, tmp_path):
+    """Symmetric to hide: _restore_hidden_managed_agents clears the hidden
+    bookkeeping, restores desired_state from the captured before-hide value,
+    re-emits the row in default /api/status, and records a
+    managed_agent_unhidden activity event per restored row.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    registry = {
+        "agents": [
+            {
+                "name": "previously-hidden",
+                "agent_id": "agent-prev-hidden",
+                "template_id": "claude_code_channel",
+                "runtime_type": "claude_code_channel",
+                "lifecycle_phase": "hidden",
+                "desired_state": "stopped",
+                "desired_state_before_hide": "running",
+                "hidden_at": gateway_core._now_iso(),
+                "hidden_reason": "operator_cleanup",
+            },
+            {
+                "name": "active-keeper",
+                "agent_id": "agent-keeper",
+                "template_id": "echo",
+                "runtime_type": "echo",
+                "desired_state": "running",
+            },
+        ]
+    }
+    gateway_core.save_gateway_registry(registry)
+
+    # Restore one row plus name a non-existent and a non-hidden row to verify
+    # missing/not_hidden partitions.
+    payload = gateway_cmd._restore_hidden_managed_agents(
+        ["previously-hidden", "ghost", "active-keeper"]
+    )
+
+    assert payload["count"] == 1
+    assert payload["missing"] == ["ghost"]
+    assert payload["not_hidden"] == ["active-keeper"]
+
+    stored = {agent["name"]: agent for agent in gateway_core.load_gateway_registry()["agents"]}
+    restored = stored["previously-hidden"]
+    assert restored["lifecycle_phase"] == "active"
+    assert restored["desired_state"] == "running"  # restored from desired_state_before_hide
+    assert "desired_state_before_hide" not in restored
+    assert "hidden_at" not in restored
+    assert "hidden_reason" not in restored
+
+    # Restored row reappears in default /api/status agents list.
+    visible_payload = gateway_cmd._status_payload(activity_limit=0)
+    visible_names = sorted(agent["name"] for agent in visible_payload["agents"])
+    assert "previously-hidden" in visible_names
+    assert visible_payload["summary"]["hidden_agents"] == 0
+
+    recent = gateway_core.load_recent_gateway_activity()
+    assert [event["event"] for event in recent].count("managed_agent_unhidden") == 1
+
+
 def test_lifecycle_signal_sent_on_connected_to_stale(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
     client = _RecordingHeartbeatClient()

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5214,6 +5214,102 @@ def test_operator_cleanup_hides_selected_agents(monkeypatch, tmp_path):
     assert [event["event"] for event in recent].count("managed_agent_hidden") == 2
 
 
+def test_recover_managed_agents_from_evidence_restores_lost_row(monkeypatch, tmp_path):
+    """Pre-race-fix damage recovery: when a managed_agent_added activity
+    event exists locally but the registry row is missing (silent race
+    clobber), _recover_managed_agents_from_evidence reconstructs a
+    minimal row using only verified evidence — never fabricating
+    credentials.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    # Pre-condition: registry empty, but token file + managed_agent_added
+    # event exist locally — exactly the cc-backend / widget_smith state.
+    gateway_core.save_gateway_registry({"agents": []})
+
+    token_dir = gateway_core.agent_dir("ghost-agent")
+    token_dir.mkdir(parents=True, exist_ok=True)
+    (token_dir / "token").write_text("axp_a_ghost.evidence", encoding="utf-8")
+
+    gateway_core.record_gateway_activity(
+        "managed_agent_added",
+        agent_name="ghost-agent",
+        agent_id="agent-ghost-id",
+        asset_id="agent-ghost-id",
+        install_id="install-ghost",
+        gateway_id="gateway-host",
+        runtime_type="claude_code_channel",
+        transport="gateway",
+        space_id="49afd277-78d2-4a32-9858-3594cda684af",
+        token_file=str(token_dir / "token"),
+        credential_source="gateway",
+    )
+
+    payload = gateway_cmd._recover_managed_agents_from_evidence(["ghost-agent", "missing-no-evidence"])
+
+    assert payload["count"] == 1
+    assert payload["already_present"] == []
+    assert payload["no_evidence"] == ["missing-no-evidence"]
+
+    stored = gateway_core.load_gateway_registry()
+    row = next((a for a in stored["agents"] if a.get("name") == "ghost-agent"), None)
+    assert row is not None, "recovered row missing from registry"
+    assert row["agent_id"] == "agent-ghost-id"
+    assert row["install_id"] == "install-ghost"
+    assert row["runtime_type"] == "claude_code_channel"
+    assert row["template_id"] == "claude_code_channel"
+    assert row["space_id"] == "49afd277-78d2-4a32-9858-3594cda684af"
+    assert row["token_file"] == str(token_dir / "token")
+    assert row["lifecycle_phase"] == "active"
+    assert row["desired_state"] == "stopped"  # safe default — operator restarts deliberately
+    assert row["drift_reason"] == "registry_row_recovered_from_evidence"
+
+    # managed_agent_recovered activity event was recorded.
+    recent = gateway_core.load_recent_gateway_activity()
+    events = [e for e in recent if e.get("event") == "managed_agent_recovered"]
+    assert len(events) == 1
+    assert events[0].get("agent_name") == "ghost-agent"
+
+
+def test_recover_managed_agents_refuses_when_token_missing(monkeypatch, tmp_path):
+    """Recovery requires BOTH the activity event AND the token file.
+    Missing token → no recovery (we don't fabricate credentials).
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    gateway_core.save_gateway_registry({"agents": []})
+
+    # Activity event exists but no token file.
+    gateway_core.record_gateway_activity(
+        "managed_agent_added",
+        agent_name="no-token-agent",
+        agent_id="agent-id",
+        asset_id="agent-id",
+        install_id="install-id",
+        gateway_id="gateway-host",
+        runtime_type="echo",
+        transport="gateway",
+        space_id="space-1",
+        token_file="/tmp/nonexistent-recovery-token-path",
+        credential_source="gateway",
+    )
+
+    payload = gateway_cmd._recover_managed_agents_from_evidence(["no-token-agent"])
+    assert payload["count"] == 0
+    assert payload["no_evidence"] == ["no-token-agent"]
+
+
+def test_recover_managed_agents_skips_already_present_rows(monkeypatch, tmp_path):
+    """Idempotent: if a row already exists, recovery is a no-op for it."""
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    gateway_core.save_gateway_registry(
+        {"agents": [{"name": "already-there", "agent_id": "existing", "template_id": "echo"}]}
+    )
+
+    payload = gateway_cmd._recover_managed_agents_from_evidence(["already-there"])
+    assert payload["count"] == 0
+    assert payload["already_present"] == ["already-there"]
+    assert payload["no_evidence"] == []
+
+
 def test_operator_cleanup_restore_unhides_selected_agents(monkeypatch, tmp_path):
     """Symmetric to hide: _restore_hidden_managed_agents clears the hidden
     bookkeeping, restores desired_state from the captured before-hide value,

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5944,3 +5944,223 @@ def test_backend_agent_record_seeds_cache_on_successful_upstream(monkeypatch, tm
 
     cached = gateway_cmd._load_agents_cache()
     assert any(a.get("name") == "fresh_agent" for a in cached), "upstream success should seed cache"
+
+
+# ---------------------------------------------------------------------------
+# Spaces hygiene: registry repair, /api/spaces fallback, CLI list
+# ---------------------------------------------------------------------------
+
+
+_GOOD_SPACE_UUID = "49afd277-78d2-4a32-9858-3594cda684af"
+
+
+def test_reconcile_corrupt_space_ids_recovers_uuid_from_active_space():
+    registry = {
+        "agents": [
+            {
+                "name": "taskforge_backend",
+                "space_id": "madtank's Workspace",
+                "active_space_id": _GOOD_SPACE_UUID,
+                "active_space_name": "madtank's Workspace",
+                "default_space_id": _GOOD_SPACE_UUID,
+            }
+        ]
+    }
+    repaired = gateway_core.reconcile_corrupt_space_ids(registry)
+    assert repaired == 1
+    assert registry["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+
+
+def test_reconcile_corrupt_space_ids_falls_back_to_allowed_spaces():
+    registry = {
+        "agents": [
+            {
+                "name": "x",
+                "space_id": "Workspace-Name",
+                "allowed_spaces": [{"space_id": _GOOD_SPACE_UUID, "name": "ws"}],
+            }
+        ]
+    }
+    assert gateway_core.reconcile_corrupt_space_ids(registry) == 1
+    assert registry["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+
+
+def test_reconcile_corrupt_space_ids_idempotent_on_clean_registry():
+    registry = {
+        "agents": [
+            {"name": "a", "space_id": _GOOD_SPACE_UUID},
+            {"name": "b", "space_id": ""},  # empty is left alone
+            {"name": "c"},  # no space_id at all is left alone
+        ]
+    }
+    assert gateway_core.reconcile_corrupt_space_ids(registry) == 0
+    assert registry["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+    assert registry["agents"][1]["space_id"] == ""
+    assert "space_id" not in registry["agents"][2]
+
+
+def test_reconcile_corrupt_space_ids_skips_when_no_uuid_anywhere():
+    registry = {
+        "agents": [
+            {"name": "lost", "space_id": "Some Name", "active_space_id": "Also Not A UUID"},
+        ]
+    }
+    # Nothing recoverable — leave the bad value in place rather than fabricate.
+    assert gateway_core.reconcile_corrupt_space_ids(registry) == 0
+    assert registry["agents"][0]["space_id"] == "Some Name"
+
+
+def test_load_gateway_registry_heals_corrupt_space_id_in_place(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_dir = gateway_core.gateway_dir()
+    gateway_dir.mkdir(parents=True, exist_ok=True)
+    raw = {
+        "version": 1,
+        "agents": [
+            {
+                "name": "taskforge_backend",
+                "space_id": "madtank's Workspace",
+                "active_space_id": _GOOD_SPACE_UUID,
+                "default_space_id": _GOOD_SPACE_UUID,
+            }
+        ],
+    }
+    gateway_core.registry_path().write_text(json.dumps(raw), encoding="utf-8")
+    loaded = gateway_core.load_gateway_registry()
+    assert loaded["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+
+
+def test_resolve_gateway_agent_home_space_resolves_name_to_uuid(monkeypatch):
+    captured = {}
+
+    def fake_resolve(client, *, explicit):
+        captured["explicit"] = explicit
+        return _GOOD_SPACE_UUID
+
+    monkeypatch.setattr(gateway_cmd, "resolve_space_id", fake_resolve)
+
+    resolved = gateway_cmd._resolve_gateway_agent_home_space(
+        client=object(),
+        session={},
+        registry={"agents": []},
+        explicit_space_id="madtank's Workspace",
+    )
+    assert resolved == _GOOD_SPACE_UUID
+    assert captured["explicit"] == "madtank's Workspace"
+
+
+def test_resolve_gateway_agent_home_space_passthrough_for_uuid(monkeypatch):
+    def fake_resolve(*args, **kwargs):
+        raise AssertionError("UUID input should not require a backend round-trip")
+
+    monkeypatch.setattr(gateway_cmd, "resolve_space_id", fake_resolve)
+
+    resolved = gateway_cmd._resolve_gateway_agent_home_space(
+        client=object(),
+        session={},
+        registry={"agents": []},
+        explicit_space_id=_GOOD_SPACE_UUID,
+    )
+    assert resolved == _GOOD_SPACE_UUID
+
+
+def test_spaces_payload_returns_session_active_space_when_upstream_fails(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+            "username": "madtank",
+        }
+    )
+
+    def fake_client_loader():
+        class Boom:
+            def list_spaces(self):
+                raise httpx.HTTPStatusError(
+                    "429 Too Many Requests",
+                    request=httpx.Request("GET", "https://paxai.app/api/v1/spaces"),
+                    response=httpx.Response(429),
+                )
+
+        return Boom()
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", fake_client_loader)
+
+    payload = gateway_cmd._spaces_payload()
+    assert payload["active_space_id"] == _GOOD_SPACE_UUID
+    assert payload["active_space_name"] == "madtank's Workspace"
+    # Active space surfaces in the spaces list even with no cache so the UI
+    # always has something to render.
+    assert any(s["id"] == _GOOD_SPACE_UUID for s in payload["spaces"])
+    assert "error" in payload
+
+
+def test_spaces_payload_uses_cached_spaces_after_upstream_failure(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+        }
+    )
+
+    other_space = "78950af5-4d27-441b-9296-ec46de8ba35d"
+
+    class FirstClient:
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace"},
+                    {"id": other_space, "name": "Other Workspace"},
+                ]
+            }
+
+    class FailingClient:
+        def list_spaces(self):
+            raise RuntimeError("upstream rate limited")
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: FirstClient())
+    first = gateway_cmd._spaces_payload()
+    assert {s["id"] for s in first["spaces"]} == {_GOOD_SPACE_UUID, other_space}
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: FailingClient())
+    second = gateway_cmd._spaces_payload()
+    assert second.get("cached") is True
+    assert {s["id"] for s in second["spaces"]} == {_GOOD_SPACE_UUID, other_space}
+
+
+def test_gateway_spaces_list_command_renders_table(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+        }
+    )
+
+    class StubClient:
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
+                ]
+            }
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: StubClient())
+
+    result = runner.invoke(app, ["gateway", "spaces", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["active_space_id"] == _GOOD_SPACE_UUID
+    assert payload["spaces"][0]["id"] == _GOOD_SPACE_UUID


### PR DESCRIPTION
**DRAFT — do not merge.** Stacked on `verify/race-backoff-and-429` (PR #153 race + 429 reliability slice).

Originally parked at `feat/gateway-cleanup-ui` (ce1ccb0) when the registry was still racing. Rebased onto the verified reliability stack now that PR #153 (race fix + setup-error backoff) and PR #157 (429 hardening) are landed. Two bug fixes uncovered during the Playwright UAT and amended into the rebased commit.

## Operator-visible behavior

Click "Clean up" in the agent-list header → checkboxes appear per row → tick stale agents → "Hide N selected" pill updates with live count → click → POST `/api/agents/cleanup-hide` → toast "Hid N agents" → rows drop off the default view, stay in the registry. `lifecycle_phase=hidden`, `desired_state=stopped`, `desired_state_before_hide` captured for symmetric restore later.

## Bug fixes uncovered during UAT

The original commit had two latent issues that only surfaced under real DOM interaction. Both fixed in the rebased commit:

1. **`updateRow` indices were off-by-one.** Row children: `[0]=cleanup-cell, [1]=dot, [2]=row-agent, ...`. The original `updateRow` read `row.children[0]` thinking it was the dot, then `agentEl.querySelector(".row-name")` returned `null` → `nameEl.textContent = ...` raised `Cannot read properties of null (reading 'textContent')` and prevented any row from rendering. Fixed by shifting the index reads by +1.

2. **`<button hidden>` didn't actually hide.** `.system-toggle { display: inline-flex }` overrode the user-agent stylesheet's `[hidden] { display: none }`. The "Hide N selected" button was always visible, even before any selection. Fixed with explicit CSS: `.system-toggle[hidden] { display: none; }`.

Both are smoking guns for the value of headless UAT vs grep-based static checks.

## Live verification (Playwright headless against running daemon)

8-step UAT exercises the full operator flow. All pass:

| # | Step | Result |
|---|---|---|
| 1 | Open dashboard, screenshot initial state | 16 agent rows rendered |
| 2 | Click "Clean up" → checkboxes appear | 16 visible, label changes to "Cancel" |
| 3 | Tick 2 agents → "Hide N selected" updates | label = "Hide 2 selected" |
| 4 | Click "Hide 2 selected" → POST captured | HTTP 200, body `{"names":["mac_frontend","mac_backend"],"reason":"operator_cleanup"}` |
| 5 | Toast renders | text = "Hid 2 agents" |
| 6 | Rows drop from default view | 14 remaining (was 16); both targets confirmed removed |
| 7 | Registry confirms hidden, not deleted | both rows present with `lifecycle_phase=hidden`, `desired_state=stopped`, `desired_state_before_hide=running`, `hidden_at` populated |
| 8 | Toggle resets after hide | label = "Clean up" |

**Network log** (api/* only) from the UAT run:
```
GET  /api/status        → 200
GET  /api/spaces        → 502 (pre-existing, covered by PR #148; unrelated)
GET  /api/templates     → 200
POST /api/agents/cleanup-hide  body={"names":["mac_frontend","mac_backend"],"reason":"operator_cleanup"}  → 200
GET  /api/status        → 200  (re-fetch after hide)
```

**Registry before** (3 cleanup targets):
```
mac_frontend: lifecycle_phase=active   desired_state=running
mac_backend:  lifecycle_phase=active   desired_state=running
demo-hermes:  lifecycle_phase=None     desired_state=stopped
```

**Registry after** (POST `/api/agents/cleanup-hide` with all 3):
```
mac_frontend: lifecycle_phase=hidden   desired_state=stopped   desired_state_before_hide=running   hidden_at=...   hidden_reason=self-verify-evidence
mac_backend:  lifecycle_phase=hidden   desired_state=stopped   desired_state_before_hide=running   hidden_at=...   hidden_reason=self-verify-evidence
demo-hermes:  lifecycle_phase=hidden   desired_state=stopped   desired_state_before_hide=None      hidden_at=...   hidden_reason=self-verify-evidence
```

`/api/status` agent count went 17 → 14, summary.hidden_agents went 5 → 8. Total registry size unchanged (rows hidden, not deleted).

3 `managed_agent_hidden` activity events recorded on the run.

**Dogfooded:** also used the new endpoint to clean up 5 leftover smoke agents from earlier 429-test sessions. Worked end-to-end.

## Operator UX answers (cipher's questions)

| Question | Answer |
|---|---|
| Daemon restart needed for UI changes? | **No** for HTML/JS changes (served live from disk on each request); **yes** for HTTP endpoint changes (loaded into daemon process at start). Browser refresh picks up HTML/JS. |
| Toast surfaces? Duration? | Yes — "Hid N agents" rendered immediately after hide. Default toast duration not measured precisely but visible long enough to read. |
| Count updates correctly? | Yes — 16 → 14, hidden 5 → 8, registry total unchanged. |
| Empty-state graceful when all hidden? | Untested in UAT (didn't hide all). Existing `renderEmptyAgents` already renders "No agents in this space." — should work. Worth a follow-up explicit test. |
| Can you unhide from the UI? | **No.** This PR is hide-only. PR #147's archive/restore CLI exists for the sticky archived flavor; for hidden (transient) state, the existing daemon sweep auto-clears on reconnect, but there's no operator-driven "show again" button in this PR. Worth a follow-up. |
| Console errors during the flow? | One: 502 from `/api/spaces` (pre-existing, paxai.app upstream issue covered by PR #148 spaces cache fallback). Unrelated to cleanup UI. |

## Known gaps / follow-ups (not blocking this PR)

- **No "Restore" / "Show hidden" UI** — operator must use direct registry edit or wait for daemon sweep auto-clear. PR #147's archive/restore is the sticky flavor; this PR's hide is transient. A unified UI affordance ("Inactive section" with restore button per row) is the right long-term shape.
- **Empty-state when all rows hidden** — works, but no explicit UAT.
- **"Really delete upstream" path** — captured per cipher's note. For now, hide is enough; agents stay as orphaned-in-platform records but invisible in operator view. Eventual destination is a DELETE endpoint that also removes from paxai.app, but this PR is soft-hide-only.
- **Toast duration** — observed visually but not measured. If too short, follow-up is straightforward.
- **502 from /api/spaces** — fixed in PR #148; will resolve when that lands or when the cache-fallback pattern is mirrored here.

## What's blocked on the browser extension

Originally I framed this as needing Jacob's browser extension. Cipher correctly pushed back: this is a local Python app, Playwright headless works fine. **Nothing here is blocked on the extension.** The UAT above runs headless against the live daemon. The extension would only add: pair-programming convenience for Jacob to drive interactively. Not a verification prerequisite.

## Files touched

- `ax_cli/commands/gateway.py` (+61) — `_hide_managed_agents` helper + `POST /api/agents/cleanup-hide` HTTP route
- `ax_cli/static/demo.html` (+136) — header toggle button, per-row checkbox cell, JS state + handlers, `[hidden]` CSS override
- `tests/test_gateway_commands.py` (+54) — `test_operator_cleanup_hides_selected_agents`

## Test plan

- [x] `uv run pytest tests/test_gateway_commands.py` — 153/153 green (1 new test, all combined-stack regressions hold)
- [x] `uv run ruff check ax_cli/ tests/` — clean
- [x] Live Playwright UAT (8 steps, all pass) — see Live verification above
- [x] Live network capture confirms POST shape — see Network log
- [x] Registry diff confirms `lifecycle_phase=hidden`, rows preserved — see Registry before/after
- [x] Dogfood: cleaned up 5 leftover smoke agents end-to-end via the new endpoint
- [ ] Reviewer to spot-check: open `http://127.0.0.1:8765` in a real browser, drive the flow, confirm it feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)