### PR TITLE
fix(tasks): verify created task landed in requested space on auth-con…

### DIFF
--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -697,6 +697,7 @@ class AxClient:
                     "space_id_hint": space_id,
                     "fingerprint": self._base_headers.get("X-AX-FP"),
                 },
+                expected_space_id=space_id,
             )
 
         body = {"title": title, "space_id": space_id, "priority": priority}
@@ -754,8 +755,17 @@ class AxClient:
         priority: str = "medium",
         requirements: dict | None = None,
         deadline: str | None = None,
+        expected_space_id: str | None = None,
     ) -> dict:
-        """POST /api/tasks using AX-GATEWAY-001 auth-contract draft shape."""
+        """POST /api/tasks using AX-GATEWAY-001 auth-contract draft shape.
+
+        The auth-contract draft uses the credential's session default space and
+        only carries ``space_id_hint`` in ``requirements``. When the caller knows
+        the requested space (``expected_space_id``), verify the task actually
+        landed there before returning success — otherwise an operator running
+        ``ax tasks create --space-id <X>`` could see a green checkmark while
+        the task silently filed into the credential's default space.
+        """
         body: dict = {
             "title": title,
             "requirements": requirements or {},
@@ -770,6 +780,8 @@ class AxClient:
         task = self._task_from_create_response(data)
         if not task.get("id"):
             raise RuntimeError("Task create response did not include an id.")
+        if expected_space_id:
+            self._verify_created_task_space(data, expected_space_id)
         return data
 
     def _task_from_create_response(self, data: object) -> dict:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -521,7 +521,6 @@ class TestCredentialManagement:
         with pytest.raises(RuntimeError, match="not visible in requested space"):
             client.create_task("space-123", "Review the spec", priority="high")
 
-
     def test_gateway_auth_contract_task_create_exchanges_then_posts_api_tasks(self, monkeypatch):
         import httpx
 
@@ -554,6 +553,10 @@ class TestCredentialManagement:
                 "status": "not_started",
                 "priority": "high",
                 "posted_by": {"id": "agent-123", "type": "agent"},
+                # Backend echoes space_id so the client can verify the task
+                # actually landed in the requested space (acceptance criterion
+                # for ax-cli-dev tasks 97e2f06c / cbb8f887 / 7fbd5d0f).
+                "space_id": "space-hint",
             },
             request=httpx.Request("POST", "https://example.com/api/tasks"),
         )
@@ -595,6 +598,123 @@ class TestCredentialManagement:
         assert "space_id" not in body
         assert "assigned_agent_id" not in body
         assert "assignee_id" not in body
+
+    def test_gateway_auth_contract_task_create_refuses_when_response_space_mismatches(self, monkeypatch):
+        """Regression for ax-cli-dev 97e2f06c / 7fbd5d0f: the auth-contract path
+        used to silently land tasks in the credential's default space when it
+        differed from --space-id. Verify that a mismatched response space_id
+        now raises RuntimeError instead of returning a false success.
+        """
+        import httpx
+
+        def fake_exchange(url, *, json=None, headers=None, timeout=None):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "exchanged.jwt",
+                    "expires_in": 3600,
+                    "token_class": "agent_access",
+                    "agent_id": "agent-123",
+                    "agent_name": "cli-sentinel-local",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        monkeypatch.setattr(httpx, "post", fake_exchange)
+        client = AxClient("https://example.com", "axp_a_AgentKey.AgentSecret", agent_name="cli-sentinel-local")
+        task_response = httpx.Response(
+            201,
+            json={
+                "id": "task-123",
+                "title": "Land gateway stub",
+                # Backend filed it in madtank's default workspace despite
+                # space_id_hint=ax-cli-dev-space — this is the silent-misfile
+                # scenario the bug reports describe.
+                "space_id": "madtank-space",
+            },
+            request=httpx.Request("POST", "https://example.com/api/tasks"),
+        )
+        client._http.post = MagicMock(return_value=task_response)
+
+        with pytest.raises(RuntimeError, match="created in the wrong space"):
+            client.create_task("ax-cli-dev-space", "Land gateway stub", priority="high")
+
+    def test_gateway_auth_contract_task_create_verifies_via_list_when_response_omits_space_id(self, monkeypatch):
+        """Backend doesn't always echo space_id today; client falls back to a
+        list_tasks probe in the requested space to confirm the new task is
+        actually there before returning success.
+        """
+        import httpx
+
+        def fake_exchange(url, *, json=None, headers=None, timeout=None):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "exchanged.jwt",
+                    "expires_in": 3600,
+                    "token_class": "agent_access",
+                    "agent_id": "agent-123",
+                    "agent_name": "cli-sentinel-local",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        monkeypatch.setattr(httpx, "post", fake_exchange)
+        client = AxClient("https://example.com", "axp_a_AgentKey.AgentSecret", agent_name="cli-sentinel-local")
+        task_response = httpx.Response(
+            201,
+            json={"id": "task-123", "title": "Land gateway stub"},
+            request=httpx.Request("POST", "https://example.com/api/tasks"),
+        )
+        list_response = httpx.Response(
+            200,
+            json={"tasks": [{"id": "task-123", "space_id": "ax-cli-dev-space"}]},
+            request=httpx.Request("GET", "https://example.com/api/v1/tasks"),
+        )
+        client._http.post = MagicMock(return_value=task_response)
+        client._http.get = MagicMock(return_value=list_response)
+
+        data = client.create_task("ax-cli-dev-space", "Land gateway stub", priority="high")
+
+        assert data["id"] == "task-123"
+        # Verification round-trip used the requested space, not the default.
+        assert client._http.get.call_args.kwargs["params"]["space_id"] == "ax-cli-dev-space"
+
+    def test_gateway_auth_contract_task_create_refuses_when_list_misses(self, monkeypatch):
+        """If the response omits space_id and the new task isn't visible in
+        the requested space, surface a clear failure instead of pretending."""
+        import httpx
+
+        def fake_exchange(url, *, json=None, headers=None, timeout=None):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "exchanged.jwt",
+                    "expires_in": 3600,
+                    "token_class": "agent_access",
+                    "agent_id": "agent-123",
+                    "agent_name": "cli-sentinel-local",
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        monkeypatch.setattr(httpx, "post", fake_exchange)
+        client = AxClient("https://example.com", "axp_a_AgentKey.AgentSecret", agent_name="cli-sentinel-local")
+        task_response = httpx.Response(
+            201,
+            json={"id": "task-123", "title": "Land gateway stub"},
+            request=httpx.Request("POST", "https://example.com/api/tasks"),
+        )
+        list_response = httpx.Response(
+            200,
+            json={"tasks": [{"id": "some-other-task", "space_id": "ax-cli-dev-space"}]},
+            request=httpx.Request("GET", "https://example.com/api/v1/tasks"),
+        )
+        client._http.post = MagicMock(return_value=task_response)
+        client._http.get = MagicMock(return_value=list_response)
+
+        with pytest.raises(RuntimeError, match="not visible in requested space"):
+            client.create_task("ax-cli-dev-space", "Land gateway stub", priority="high")
 
     def test_issue_agent_pat_sends_requested_audience(self):
         client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")


### PR DESCRIPTION
The Gateway-first auth-contract path (`POST /api/tasks` via `create_task_auth_contract`) skipped the same `_verify_created_task_space` check that the legacy `/api/v1/tasks` path runs. The auth-contract draft uses the credential's session default space and only carries the requested space as `requirements.space_id_hint`, so an operator running `ax tasks create --space-id <X>` could see a green checkmark while the task silently filed into the credential's default workspace.

Surfaced during the Joseph handoff on 2026-04-27 — tasks meant for `ax-cli-dev` landed in `madtank's Workspace` and the CLI reported success.

## Fix

- Add an optional `expected_space_id` to `create_task_auth_contract`. When set, run the existing `_verify_created_task_space` helper after parsing the response: fast-path on a matching `space_id` in the response body, fall back to a `list_tasks(space_id=...)` probe when the response omits `space_id`, and raise `RuntimeError` on a mismatch or when the new task is not visible in the requested space.
- Have `create_task` pass `expected_space_id=space_id` when delegating to the auth-contract path, so every CLI-facing call gets verified.

The legacy `/api/v1/tasks` path was already verified end-to-end (`_verify_created_task_space` + `_verify_session_space_for_task_fallback`). This PR brings the Gateway-first auth-contract path to parity, so operators get the clear, fail-loudly behavior the acceptance criteria call for regardless of which create route the client picks.

Closes ax-cli-dev tasks `97e2f06c`, `cbb8f887`, `7fbd5d0f` from the client side. The matching backend changes (legacy `/api/tasks` accepting explicit `space_id`, `/api/v1/tasks` returning JSON instead of HTML) are out of scope for this repo and tracked separately on `ax-backend-extract`.

## Summary

`create_task_auth_contract` grows one optional kwarg, the existing helper does the verification, three new tests cover the new code paths, and one existing test gets `space_id` added to its mocked response (matching the acceptance criterion that backend should echo `space_id` so clients can verify).

## Validation

- [x] `pytest tests/test_client.py -k auth_contract -v` — 4 passed (1 existing, updated; 3 new)
- [x] `pytest tests/test_client.py` — 34 passed on a clean branch from `main`
- [x] `pytest tests/test_tasks_commands.py` — 12 passed (no command-level regressions)
- [x] `ruff check ax_cli/client.py tests/test_client.py` — clean
- [x] `ruff format --check` on touched files — already formatted
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; auth flow unchanged
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable

Reviewers note: `tests/test_client.py` is sensitive to a stale on-disk token cache at `<repo>/.ax/cache/tokens.json` — running the full suite against a polluted cache can show this test failing in isolation. A clean branch checkout (or `rm <repo>/.ax/cache/tokens.json`) reproduces the green run shown above.

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

The new verification fires after the task POST has already landed; it can fail the call but never alters the credential or the request body. The exchange path, header injection, and JWT cache are untouched.

## Follow-up notes

- Once the backend consistently echoes `space_id` on `POST /api/tasks` (acceptance for `97e2f06c`), the `list_tasks` fallback inside `_verify_created_task_space` becomes a defense-in-depth path rather than the primary check. No client change required at that point.
- The matching backend hardening (legacy `/api/tasks` accepting explicit `space_id`, returning 400/403 on permission mismatch, returning JSON instead of HTML on `/api/v1/tasks`) is tracked in the same task cluster but lives in `ax-backend-extract`.
