### PR TITLE
fix(hermes): skip POSIX permission check for token files on Windows

### DIFF
--- a/ax_cli/runtimes/hermes/runtimes/hermes_sdk.py
+++ b/ax_cli/runtimes/hermes/runtimes/hermes_sdk.py
@@ -46,11 +46,15 @@ CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 def _read_token_file(path: Path) -> str:
     """Read a token file securely. Returns empty string on failure."""
     try:
-        stat = path.stat()
-        # Warn if token file is world-readable
-        if stat.st_mode & 0o077:
-            log.warning("Token file %s has loose permissions (mode %o). "
-                        "Run: chmod 600 %s", path, stat.st_mode & 0o777, path)
+        # NTFS uses ACLs, not POSIX mode bits — stat().st_mode always
+        # reports 0o666/0o644 on Windows regardless of actual access, so
+        # the world-readable check would fire on every read with no way
+        # for the user to satisfy it. icacls is the Windows alternative.
+        if sys.platform != "win32":
+            stat = path.stat()
+            if stat.st_mode & 0o077:
+                log.warning("Token file %s has loose permissions (mode %o). "
+                            "Run: chmod 600 %s", path, stat.st_mode & 0o777, path)
         return path.read_text().strip()
     except OSError:
         return ""

--- a/tests/test_hermes_sdk_runtime.py
+++ b/tests/test_hermes_sdk_runtime.py
@@ -1,0 +1,53 @@
+"""Tests for the Hermes SDK runtime adapter.
+
+Currently focused on Windows-vs-POSIX permission warning parity — the
+adapter's `_read_token_file` used to log a "loose permissions" warning on
+every call against Windows because NTFS reports POSIX mode bits as
+0o666/0o644 regardless of the file's actual ACLs. This is the same class
+of bug fixed for `ax_cli/token_cache.py` and `ax_cli/config.py` upstream;
+the Hermes adapter was a deferred sibling.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from ax_cli.runtimes.hermes.runtimes import hermes_sdk
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission semantics")
+def test_read_token_file_warns_on_loose_permissions_posix(tmp_path, caplog):
+    token = tmp_path / "codex-token"
+    token.write_text("axt_loose")
+    token.chmod(0o644)
+
+    with caplog.at_level(logging.WARNING, logger="runtime.hermes_sdk"):
+        result = hermes_sdk._read_token_file(token)
+
+    assert result == "axt_loose"
+    assert any("loose permissions" in record.message for record in caplog.records)
+
+
+def test_read_token_file_skips_permission_warning_on_windows(tmp_path, caplog, monkeypatch):
+    """On Windows the mode check would warn on every read — the guard must suppress it."""
+    monkeypatch.setattr(hermes_sdk.sys, "platform", "win32")
+    token = tmp_path / "codex-token"
+    token.write_text("axt_winsafe")
+    if sys.platform != "win32":
+        token.chmod(0o644)
+
+    with caplog.at_level(logging.WARNING, logger="runtime.hermes_sdk"):
+        result = hermes_sdk._read_token_file(token)
+
+    assert result == "axt_winsafe"
+    assert not any("loose permissions" in record.message for record in caplog.records), [
+        record.message for record in caplog.records
+    ]
+
+
+def test_read_token_file_returns_empty_on_missing_path(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    assert hermes_sdk._read_token_file(missing) == ""


### PR DESCRIPTION
`_read_token_file` in the Hermes SDK runtime adapter (`ax_cli/runtimes/hermes/runtimes/hermes_sdk.py`) logged a "loose permissions" warning on every read against a token file whose mode bits weren't `0o600`. NTFS reports POSIX mode bits as `0o666`/`0o644` regardless of actual ACLs, so on Windows the warning fired on **every Codex/Hermes auth read** with no way for the user to satisfy it.

This is the same NTFS-vs-POSIX class of bug already addressed in `ax_cli/token_cache.py` and `ax_cli/config.py` (the PR that closed #20 and #3). The Hermes runtime adapter was a deferred sibling I deliberately left out of that PR to keep its scope tight.

## Fix

Wrap the existing check in `if sys.platform != "win32":`. Windows users who want owner-only access to the token file should use `icacls`. POSIX behavior is unchanged.

The sibling `_read_token_file` in `ax_cli/runtimes/hermes/runtimes/openai_sdk.py` already has no permission check, so no fix is needed there.

## Summary

Three new tests in a new `tests/test_hermes_sdk_runtime.py` file cover:

- `test_read_token_file_warns_on_loose_permissions_posix` — POSIX-only (`skipif win32`); verifies the warning still fires for a 0o644 file on Linux/macOS.
- `test_read_token_file_skips_permission_warning_on_windows` — patches `sys.platform` to `"win32"` and asserts no warning is emitted.
- `test_read_token_file_returns_empty_on_missing_path` — basic happy-path coverage for the existing OSError swallow.

## Validation

- [x] `pytest tests/test_hermes_sdk_runtime.py -v` — 2 passed, 1 skipped (POSIX-only mode assertion correctly skipped on Windows)
- [x] `ruff check` is **dirty against this file on `main` already** (two pre-existing import-sort issues at lines 233 and 356 — vendored code with its own style; deliberately not in scope here). My behavioral change does not introduce new lint findings.
- [x] `ruff format` is intentionally NOT run on `hermes_sdk.py` to avoid a noisy reformatting churn against vendored code that should track its source. The diff is 9 lines of behavioral change, nothing else.
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; this is runtime-adapter-only
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable
- [x] Manual Windows reproduction: a Hermes-managed agent reading `~/.ax/codex-token` no longer prints `Token file ... has loose permissions (mode 666). Run: chmod 600 ...` on every CLI invocation.

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

The token file is still read identically on every platform. The only difference is that Windows no longer emits a warning that Windows can't satisfy. The `chmod` recommendation in the warning still appears on POSIX where it's actionable.

## Follow-up notes

- Vendored-file lint debt (two `I001` findings in `hermes_sdk.py`) is a separate cleanup that should land alongside an upstream sync from `ax-agents`, not as drive-by reformatting in a Windows fix PR.
- If a similar permission warning ever lands in `openai_sdk.py`, apply the same `sys.platform` guard.
