### PR TITLE
feat(gateway): add `ax gateway agents inbox` for managed-agent reads

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1450,6 +1450,62 @@ def _send_from_managed_agent(
     return {"agent": entry.get("name"), "message": payload, "content": message_content}
 
 
+def _inbox_for_managed_agent(
+    *,
+    name: str,
+    limit: int = 20,
+    channel: str = "main",
+    space_id: str | None = None,
+    unread_only: bool = False,
+    mark_read: bool = False,
+) -> dict:
+    """Read a Gateway-managed agent's inbox using its Gateway-loaded credentials.
+
+    Mirrors the read side of ``_send_from_managed_agent``. Works uniformly
+    across Live Listener (claude_code_channel, hermes) and pass-through
+    templates so the operator surface is the same regardless of how the
+    agent is wired — that's the P1 the original task (``70f08787``) calls
+    out: a Live Listener seat without a channel MCP attached has no way to
+    peek its own inbox today.
+
+    Defaults are deliberately peek-friendly (``unread_only=False``,
+    ``mark_read=False``) because the typical caller is an operator
+    inspecting on the agent's behalf, not the agent consuming work.
+    """
+    registry = load_gateway_registry()
+    entry = find_agent_entry(registry, name)
+    if not entry:
+        raise LookupError(f"Managed agent not found: {name}")
+    selected_space = str(space_id or entry.get("space_id") or "").strip() or None
+    if not selected_space:
+        raise ValueError(f"Managed agent is missing a space id: @{name}")
+    client = _load_managed_agent_client(entry)
+    data = client.list_messages(
+        limit=limit,
+        channel=channel,
+        space_id=selected_space,
+        agent_id=str(entry.get("agent_id") or "") or None,
+        unread_only=unread_only,
+        mark_read=mark_read,
+    )
+    messages = data if isinstance(data, list) else data.get("messages", [])
+    record_gateway_activity(
+        "managed_inbox_polled",
+        entry=entry,
+        message_count=len(messages),
+        mark_read=mark_read,
+        space_id=selected_space,
+    )
+    return {
+        "agent": entry.get("name"),
+        "agent_id": entry.get("agent_id"),
+        "space_id": selected_space,
+        "messages": messages,
+        "unread_count": data.get("unread_count") if isinstance(data, dict) else None,
+        "marked_read_count": data.get("marked_read_count") if isinstance(data, dict) else None,
+    }
+
+
 def _gateway_test_sender_name(space_id: str) -> str:
     normalized = "".join(ch for ch in str(space_id or "") if ch.isalnum()).lower()
     suffix = normalized[:8] or "default"
@@ -4539,6 +4595,32 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         status=HTTPStatus.BAD_GATEWAY,
                     )
                 return
+            if parsed.path.startswith("/api/agents/") and parsed.path.endswith("/inbox"):
+                name = unquote(parsed.path.removeprefix("/api/agents/").removesuffix("/inbox")).strip()
+                query = parse_qs(parsed.query)
+
+                def _flag(values, default=False):
+                    if not values:
+                        return default
+                    return str(values[0]).lower() in {"1", "true", "yes", "on"}
+
+                try:
+                    inbox_payload = _inbox_for_managed_agent(
+                        name=name,
+                        limit=int((query.get("limit") or ["20"])[0]),
+                        channel=(query.get("channel") or ["main"])[0],
+                        space_id=(query.get("space_id") or [None])[0],
+                        unread_only=_flag(query.get("unread_only")),
+                        mark_read=_flag(query.get("mark_read")),
+                    )
+                except LookupError as exc:
+                    _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.NOT_FOUND)
+                    return
+                except ValueError as exc:
+                    _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                    return
+                _write_json_response(self, inbox_payload)
+                return
             if parsed.path.startswith("/api/agents/"):
                 name = unquote(parsed.path.removeprefix("/api/agents/")).strip()
                 payload = _agent_detail_payload(name, activity_limit=activity_limit)
@@ -6726,6 +6808,67 @@ def send_as_agent(
     if isinstance(result["message"], dict) and result["message"].get("id"):
         err_console.print(f"  id = {result['message']['id']}")
     err_console.print(f"  content = {result['content']}")
+
+
+@agents_app.command("inbox")
+def inbox_for_agent(
+    name: str = typer.Argument(..., help="Managed agent name"),
+    limit: int = typer.Option(20, "--limit", min=1, max=200, help="Max messages to return"),
+    channel: str = typer.Option("main", "--channel", help="Message channel"),
+    space_id: str = typer.Option(None, "--space-id", help="Override the agent's home space"),
+    unread_only: bool = typer.Option(
+        False,
+        "--unread-only/--all",
+        help="Filter to unread messages only (default: show recent regardless of read state)",
+    ),
+    mark_read: bool = typer.Option(
+        False,
+        "--mark-read/--no-mark-read",
+        help=(
+            "Mark returned messages as read. Defaults to peek (no-mark-read) so an "
+            "operator inspecting on an agent's behalf does not silently consume work."
+        ),
+    ),
+    as_json: bool = JSON_OPTION,
+):
+    """Read a Gateway-managed agent's recent inbox.
+
+    Works for both Live Listeners (claude_code_channel, hermes) and pass-through
+    agents — uses the agent's Gateway-loaded credentials, so no PAT is exposed
+    to the caller. Pairs with `ax gateway agents send` for a uniform read/write
+    surface from any operator seat without needing the channel MCP attached.
+    """
+    try:
+        result = _inbox_for_managed_agent(
+            name=name,
+            limit=limit,
+            channel=channel,
+            space_id=space_id,
+            unread_only=unread_only,
+            mark_read=mark_read,
+        )
+    except LookupError:
+        err_console.print(f"[red]Managed agent not found:[/red] {name}")
+        raise typer.Exit(1)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+    if as_json:
+        print_json(result)
+        return
+    messages = result.get("messages") or []
+    console.print(f"[bold]inbox[/bold] @{result.get('agent')}: {len(messages)} message(s)")
+    unread = result.get("unread_count")
+    if unread is not None:
+        console.print(f"  [dim]unread_count = {unread}[/dim]")
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        created = str(message.get("created_at") or "")
+        author = str(message.get("display_name") or message.get("agent_name") or message.get("sender") or "-")
+        content = str(message.get("content") or "").replace("\n", " ")
+        console.print(f"  {created} {author}: {content[:160]}")
 
 
 @agents_app.command("start")

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -319,6 +319,7 @@ class _FakeManagedSendClient:
         self.token = kwargs["token"]
         self.agent_name = kwargs.get("agent_name")
         self.agent_id = kwargs.get("agent_id")
+        self.list_messages_calls: list[dict] = []
 
     def send_message(self, space_id, content, *, agent_id=None, parent_id=None, metadata=None):
         return {
@@ -330,6 +331,45 @@ class _FakeManagedSendClient:
                 "parent_id": parent_id,
                 "metadata": metadata,
             }
+        }
+
+    def list_messages(
+        self,
+        *,
+        limit=20,
+        channel="main",
+        space_id=None,
+        agent_id=None,
+        unread_only=False,
+        mark_read=False,
+    ):
+        self.list_messages_calls.append(
+            {
+                "limit": limit,
+                "channel": channel,
+                "space_id": space_id,
+                "agent_id": agent_id,
+                "unread_only": unread_only,
+                "mark_read": mark_read,
+            }
+        )
+        return {
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "created_at": "2026-05-06T10:00:00Z",
+                    "display_name": "operator",
+                    "content": "first inbound",
+                },
+                {
+                    "id": "msg-2",
+                    "created_at": "2026-05-06T10:01:00Z",
+                    "display_name": "@nemotron",
+                    "content": "second inbound",
+                },
+            ],
+            "unread_count": 2,
+            "marked_read_count": 2 if mark_read else 0,
         }
 
 
@@ -3954,6 +3994,136 @@ def test_gateway_agents_send_blocks_identity_mismatch(monkeypatch, tmp_path):
 
     assert result.exit_code == 1, result.output
     assert "identity_mismatch" in result.output.lower() or "mismatched acting identity" in result.output.lower()
+
+
+def _seed_managed_inbox_agent(tmp_path, monkeypatch, *, agent_name="cli_god"):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "codex",
+        }
+    )
+    token_file = tmp_path / f"{agent_name}.token"
+    token_file.write_text("axp_a_agent.secret")
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [
+        {
+            "name": agent_name,
+            "agent_id": "agent-1",
+            "space_id": "space-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "claude_code_channel",
+            "template_id": "claude_code_channel",
+            "desired_state": "running",
+            "effective_state": "running",
+            "token_file": str(token_file),
+            "transport": "gateway",
+            "credential_source": "gateway",
+        }
+    ]
+    gateway_core.save_gateway_registry(registry)
+
+
+def test_gateway_agents_inbox_returns_messages_for_managed_agent(monkeypatch, tmp_path):
+    """ax-cli-dev 70f08787: a Live Listener seat must be able to peek its own inbox
+    through Gateway with no PAT exposed to the caller."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "inbox", "cli_god", "--limit", "20", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["agent"] == "cli_god"
+    assert payload["agent_id"] == "agent-1"
+    assert payload["space_id"] == "space-1"
+    assert payload["unread_count"] == 2
+    # Default --no-mark-read so peek does not consume the agent's queue.
+    assert payload["marked_read_count"] == 0
+    assert [m["id"] for m in payload["messages"]] == ["msg-1", "msg-2"]
+    recent = gateway_core.load_recent_gateway_activity()
+    assert recent[-1]["event"] == "managed_inbox_polled"
+
+
+def test_gateway_agents_inbox_human_output_prints_message_table(monkeypatch, tmp_path):
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    result = runner.invoke(app, ["gateway", "agents", "inbox", "cli_god"])
+
+    assert result.exit_code == 0, result.output
+    assert "@cli_god" in result.output
+    assert "first inbound" in result.output
+    assert "second inbound" in result.output
+    assert "unread_count = 2" in result.output
+
+
+def test_gateway_agents_inbox_mark_read_flag_propagates(monkeypatch, tmp_path):
+    """--mark-read must reach client.list_messages so the operator can opt in
+    to consuming the agent's queue when that's the explicit intent."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    captured: list[_FakeManagedSendClient] = []
+
+    class _RecordingClient(_FakeManagedSendClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured.append(self)
+
+    monkeypatch.setattr(gateway_cmd, "AxClient", _RecordingClient)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "inbox", "cli_god", "--mark-read", "--unread-only", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured, "fake client was never instantiated"
+    call = captured[-1].list_messages_calls[-1]
+    assert call["mark_read"] is True
+    assert call["unread_only"] is True
+    assert call["space_id"] == "space-1"
+    assert call["agent_id"] == "agent-1"
+
+
+def test_gateway_agents_inbox_errors_when_agent_missing(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "codex",
+        }
+    )
+    # Empty registry — no managed agent named "ghost".
+
+    result = runner.invoke(app, ["gateway", "agents", "inbox", "ghost"])
+
+    assert result.exit_code == 1
+    assert "Managed agent not found" in result.output
+    assert "ghost" in result.output
+
+
+def test_gateway_agents_inbox_helper_invocable_from_http_route(monkeypatch, tmp_path):
+    """The helper that powers the CLI must be callable in-process so the
+    /api/agents/<name>/inbox HTTP route can reuse it. Smoke-test the helper
+    directly to lock in that contract for the web UI / future remote callers."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    payload = gateway_cmd._inbox_for_managed_agent(name="cli_god", limit=5)
+
+    assert payload["agent"] == "cli_god"
+    assert payload["space_id"] == "space-1"
+    assert len(payload["messages"]) == 2
 
 
 def test_gateway_agents_test_sends_gateway_authored_probe(monkeypatch, tmp_path):


### PR DESCRIPTION
`ax gateway local inbox` is pass-through-only. A Live Listener seat (`claude_code_channel`, `hermes`, etc.) without the channel MCP attached has **no way to peek its own message history from the CLI today**, which defeats the standalone-Gateway promise (per ax-cli-dev `70f08787`).

This adds the parallel read surface: `ax gateway agents inbox <name>` works for any managed agent regardless of how it was wired, brokered through the Gateway daemon's existing managed-agent credential — **no PAT is exposed to the caller**.

## Three additions

### 1. `_inbox_for_managed_agent` (helper)

In-process helper that loads the agent's Gateway-managed credential, lists messages in its home space, and records the poll as a `managed_inbox_polled` activity event. Mirrors `_send_from_managed_agent` shape. Raises `LookupError` / `ValueError` (not `typer.Exit`) so it composes cleanly with both the CLI and the new HTTP endpoint.

### 2. `GET /api/agents/<name>/inbox` (daemon route)

Reuses the helper. Accepts `limit`, `channel`, `space_id`, `unread_only`, `mark_read` as query params. Returns:

- **404** when the agent isn't in the registry.
- **400** when its space is unresolvable.
- **200** with the same payload shape the CLI emits.

The web UI / future remote inspectors can hit this directly without any client-side credential handling.

### 3. `agents_app.command("inbox")` (CLI)

```
ax gateway agents inbox <name>
  --limit N            (default 20, 1..200)
  --channel main
  --space-id <override>
  --unread-only/--all  (default --all)
  --mark-read/--no-mark-read  (default --no-mark-read)
  --json
```

**Defaults are deliberately peek-friendly** because the typical caller is an operator inspecting on the agent's behalf, not the agent consuming work. Operators who *do* want to consume pass `--mark-read --unread-only`, matching `local inbox` semantics.

Acceptance from the task: `cli_god`, attached only to Gateway, can run `ax gateway agents inbox cli_god --limit 20` and see the same messages the channel MCP would deliver. ✅

## Summary

One helper + one HTTP route + one CLI command, ~143 LOC of new product code. Five tests in a new test cluster (~170 LOC) covering happy path, human output, flag propagation, missing-agent error, and the helper-reusability contract that the HTTP route depends on. No client changes, no schema changes, no auth-flow changes.

## Validation

- [x] `pytest tests/test_gateway_commands.py -k "agents_inbox or _inbox_for_managed or invocable_from_http" -v` — 5 passed
- [x] `pytest tests/test_gateway_commands.py` full file: same set of pre-existing failures as `main` (verified by `git stash`); my 5 new tests pass with no regressions
- [x] `ruff check ax_cli/commands/gateway.py tests/test_gateway_commands.py` — clean
- [x] `ruff format --check` on touched files — already formatted (only my own code touched; no churn elsewhere)
- [ ] `python -m build && twine check dist/*` — not run; this PR doesn't touch packaging
- [ ] `axctl auth doctor` — not run; auth flow unchanged
- [ ] `axctl qa preflight` — not applicable
- [ ] `axctl qa matrix` — not applicable

## Release Notes

- [x] This should appear in the changelog (`feat:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

`_inbox_for_managed_agent` uses the existing `_load_managed_agent_client` to reach the same credential `_send_from_managed_agent` already uses. The PAT is loaded inside Gateway, never returned in the response, never logged. Activity log records every poll for audit.

## Follow-up notes

- The task description mentioned `--since <ts>` as a future filter. `client.list_messages` doesn't accept `since` today, so it's deliberately out of scope here; can be added once the underlying API supports it (or as a client-side post-filter). I left it out rather than half-implement it.
- The web UI doesn't surface a managed-agent inbox view yet. Now that the daemon route exists, that's a one-shot frontend follow-up — no further Gateway code changes required.

Closes ax-cli-dev `70f08787`.
