### PR TITLE
refactor(config): unify CLI credential resolution behind get_authoring_client

### DIFF
--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -12,7 +12,7 @@ import typer
 from ..config import (
     _resolve_user_env,
     _user_config_path,
-    get_client,
+    get_authoring_client,
     resolve_agent_name,
     resolve_base_url,
     resolve_gateway_config,
@@ -314,7 +314,7 @@ def list_agents(
             )
             agents = data if isinstance(data, list) else data.get("agents", [])
     else:
-        client = get_client()
+        client = get_authoring_client()
         sid = resolve_space_id(client, explicit=space_id)
         if availability:
             try:
@@ -438,7 +438,7 @@ def ping_agent(
     as_json: bool = JSON_OPTION,
 ):
     """Probe whether an agent is currently listening for mention events."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
 
     try:
@@ -516,7 +516,7 @@ def discover_agents(
     as_json: bool = JSON_OPTION,
 ):
     """Discover agent mesh roles, listener state, and safe contact method."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     try:
         agents_data = client.list_agents(space_id=sid, limit=limit)
@@ -600,7 +600,7 @@ def create_agent(
     Uses the management API (user_admin JWT) when available,
     falls back to legacy /api/v1/agents for Cognito auth.
     """
-    client = get_client()
+    client = get_authoring_client()
     try:
         # Try management API first (exchange-based auth),
         # fall back to legacy /api/v1/agents if it returns HTML.
@@ -654,7 +654,7 @@ def get_agent(
     as_json: bool = JSON_OPTION,
 ):
     """Get agent details by name or UUID."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.get_agent(identifier)
     except httpx.HTTPStatusError as e:
@@ -707,7 +707,7 @@ def update_agent(
 
     _print_effective_config_line()
 
-    client = get_client()
+    client = get_authoring_client()
     fields = {}
     if description is not None:
         fields["description"] = description
@@ -754,7 +754,7 @@ def delete_agent(
         if not confirm:
             raise typer.Abort()
 
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.delete_agent(identifier)
     except httpx.HTTPStatusError as e:
@@ -765,7 +765,7 @@ def delete_agent(
 @app.command("status")
 def status(as_json: bool = JSON_OPTION):
     """Show agent presence (online/offline) in the current space."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.get_agents_presence()
     except httpx.HTTPStatusError as e:
@@ -795,7 +795,7 @@ def check(
     ``pre_send_warning``, the same CLI command renders the new fields
     transparently — no flag flip needed.
     """
-    client = get_client()
+    client = get_authoring_client()
     try:
         record = client.get_agent_presence(name_or_id)
     except httpx.HTTPStatusError as exc:
@@ -901,7 +901,7 @@ def placement_get(
     ``placement_state`` / ``policy_revision``), those fields surface
     transparently — same forward-compat pattern as ``ax agents check``.
     """
-    client = get_client()
+    client = get_authoring_client()
     try:
         record = client.get_agent_placement(name_or_id)
     except httpx.HTTPStatusError as exc:
@@ -959,7 +959,7 @@ def placement_set(
     For direct-mode agents, the change applies to the agent record but
     the running listener may need a restart to pick up the new space.
     """
-    client = get_client()
+    client = get_authoring_client()
     try:
         result = client.set_agent_placement(name_or_id, space_id=space_id, pinned=pinned)
     except httpx.HTTPStatusError as exc:
@@ -983,7 +983,7 @@ def tools(
     as_json: bool = JSON_OPTION,
 ):
     """Show enabled tools for an agent."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     try:
         data = client.get_agent_tools(sid, agent_id)
@@ -1024,7 +1024,7 @@ def avatar(
             f.write(svg)
         console.print(f"[green]Saved:[/green] {output}")
     elif set_avatar:
-        client = get_client()
+        client = get_authoring_client()
         data_uri = avatar_data_uri(agent, agent_type, size)
         _check_avatar_url_length(data_uri)
         _print_effective_config_line()

--- a/ax_cli/commands/alerts.py
+++ b/ax_cli/commands/alerts.py
@@ -34,7 +34,7 @@ from typing import Any, Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_space_id
 from ..output import JSON_OPTION, console, print_json, print_kv
 
 
@@ -444,7 +444,7 @@ def send(
     if kind_n == "reminder" and not response_required:
         response_required = True
 
-    client = get_client()
+    client = get_authoring_client()
     try:
         resolved_space = resolve_space_id(client, explicit=space_id)
     except Exception as exc:
@@ -562,7 +562,7 @@ def _post_state_change(message_id: str, new_state: str, *, as_json: bool = False
     producing an auditable, streamable state-change event.
     """
     new_state = _normalize_state(new_state)
-    client = get_client()
+    client = get_authoring_client()
 
     try:
         r = client._http.get(

--- a/ax_cli/commands/apps.py
+++ b/ax_cli/commands/apps.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_space_id
+from ..config import get_authoring_client, resolve_space_id
 from ..output import JSON_OPTION, console, handle_error, mention_prefix, print_json, print_table
 
 app = typer.Typer(name="apps", help="MCP app signal adapter", no_args_is_help=True)
@@ -411,7 +411,7 @@ def signal(
         typer.echo(f"Error: unknown app '{app_name}'. Known apps: {choices}", err=True)
         raise typer.Exit(1)
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     resolved_title = title or spec["title"]
     resolved_action = "get" if app_key == "context" and context_key and action == "list" else action

--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -15,7 +15,7 @@ from ..config import (
     _save_config,
     _save_user_config,
     diagnose_auth_config,
-    get_client,
+    get_authoring_client,
     resolve_agent_name,
     resolve_gateway_config,
     resolve_token,
@@ -402,7 +402,7 @@ def whoami(as_json: bool = JSON_OPTION):
                 )
         return
 
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.whoami()
     except httpx.HTTPStatusError as e:

--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -22,7 +22,7 @@ import httpx
 import typer
 
 from .. import gateway as gateway_core
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_space_id
 from ..mentions import merge_explicit_mentions_metadata
 from ..output import JSON_OPTION, console, print_json
 from .listen import _is_self_authored, _iter_sse, _remember_reply_anchor, _should_respond, _strip_mention
@@ -1213,7 +1213,7 @@ def channel(
     if ctx.invoked_subcommand:
         return
     _load_channel_env()
-    client = get_client()
+    client = get_authoring_client()
     agent_name = agent or resolve_agent_name(client=client)
     if not agent_name:
         console.print(

--- a/ax_cli/commands/context.py
+++ b/ax_cli/commands/context.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 import httpx
 import typer
 
-from ..config import get_client, resolve_gateway_config, resolve_space_id
+from ..config import get_authoring_client, resolve_gateway_config, resolve_space_id
 from ..context_keys import build_upload_context_key
 from ..output import JSON_OPTION, handle_error, mention_prefix, print_json, print_kv, print_table
 
@@ -189,7 +189,7 @@ def _load_context_artifact(
 ) -> dict:
     import hashlib
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
 
     data = client.get_context(key, space_id=sid)
@@ -249,7 +249,7 @@ def upload_file(
         ax context upload-file ./arch.png --key infra-diagram --vault
         ax context upload-file ./data.csv --ttl 3600 --mention @demo-agent
     """
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
 
     # Upload the file
@@ -351,7 +351,7 @@ def fetch_url(
     import json
     from urllib.parse import urlparse
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
 
     # Derive a default key from the URL
@@ -473,7 +473,7 @@ def promote_ctx(
     Forward-compat: when backend extends the artifact_type enum or adds
     additional promote options, --artifact-type passes through unchanged.
     """
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     try:
         result = client.promote_context(sid, key, artifact_type=artifact_type, agent_id=agent_id)
@@ -497,7 +497,7 @@ def set_ctx(
     as_json: bool = JSON_OPTION,
 ):
     """Set a key-value pair in ephemeral context."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     try:
         data = client.set_context(sid, key, value, ttl=ttl)
@@ -535,7 +535,7 @@ def get_ctx(
             print_kv(data)
         return
 
-    client = get_client()
+    client = get_authoring_client()
     sid = _optional_space_id(client, space_id)
     try:
         data = client.get_context(key, space_id=sid)
@@ -565,7 +565,7 @@ def list_ctx(
             space_id=space_id,
         )
     else:
-        client = get_client()
+        client = get_authoring_client()
         sid = _optional_space_id(client, space_id)
         try:
             data = client.list_context(prefix=prefix, space_id=sid)
@@ -604,7 +604,7 @@ def delete_ctx(
     space_id: Optional[str] = typer.Option(None, "--space-id", help="Override default space"),
 ):
     """Delete a context entry."""
-    client = get_client()
+    client = get_authoring_client()
     sid = _optional_space_id(client, space_id)
     try:
         client.delete_context(key, space_id=sid)
@@ -620,7 +620,7 @@ def download_file(
     space_id: Optional[str] = typer.Option(None, "--space-id", help="Override default space"),
 ):
     """Download a file from context to local disk."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
 
     try:

--- a/ax_cli/commands/credentials.py
+++ b/ax_cli/commands/credentials.py
@@ -7,7 +7,7 @@ All operations are API-first — same as what the UI does.
 import httpx
 import typer
 
-from ..config import get_client
+from ..config import get_authoring_client
 from ..output import EXIT_NOT_OK, JSON_OPTION, console, handle_error, print_json, print_table
 
 app = typer.Typer(name="credentials", help="Credential management (PATs, enrollment tokens)", no_args_is_help=True)
@@ -99,7 +99,7 @@ def issue_agent_pat(
         ax credentials issue-agent-pat my-bot --audience mcp
         ax credentials issue-agent-pat my-bot --name "prod-key" --expires 30 --audience both
     """
-    client = get_client()
+    client = get_authoring_client()
 
     # Resolve agent name to ID if needed
     import re
@@ -154,7 +154,7 @@ def issue_enrollment(
 
     The agent is created and bound automatically.
     """
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.mgmt_issue_enrollment(
             name=name,
@@ -187,7 +187,7 @@ def revoke(
         if not confirm:
             raise typer.Abort()
 
-    client = get_client()
+    client = get_authoring_client()
     try:
         client.mgmt_revoke_credential(credential_id)
     except httpx.HTTPStatusError as e:
@@ -201,7 +201,7 @@ def audit(
     strict: bool = typer.Option(False, "--strict", help="Exit non-zero when any agent has more than two active PATs"),
 ):
     """Audit active agent PAT counts without minting or revoking credentials."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         creds = client.mgmt_list_credentials()
     except httpx.HTTPStatusError as e:
@@ -241,7 +241,7 @@ def audit(
 @app.command("list")
 def list_credentials(as_json: bool = JSON_OPTION):
     """List all credentials you own."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         creds = client.mgmt_list_credentials()
     except httpx.HTTPStatusError as e:

--- a/ax_cli/commands/events.py
+++ b/ax_cli/commands/events.py
@@ -7,7 +7,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_space_id
+from ..config import get_authoring_client, resolve_space_id
 from ..output import JSON_OPTION, console
 
 app = typer.Typer(name="events", help="Event streaming", no_args_is_help=True)
@@ -22,7 +22,7 @@ def stream(
     as_json: bool = JSON_OPTION,
 ):
     """Stream SSE events in real-time. Use --filter routing to see only routing events."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client)
 
     filter_types: set[str] | None = None

--- a/ax_cli/commands/handoff.py
+++ b/ax_cli/commands/handoff.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_space_id
 from ..output import JSON_OPTION, console, handle_error, print_json
 from .watch import _iter_sse
 
@@ -561,7 +561,7 @@ def run(
         typer.echo(f"Error: unknown intent '{intent}'. Use one of: {allowed}", err=True)
         raise typer.Exit(1)
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     agent_name = agent.lstrip("@")
     current_agent_name = resolve_agent_name(client=client) or ""

--- a/ax_cli/commands/heartbeat.py
+++ b/ax_cli/commands/heartbeat.py
@@ -35,7 +35,7 @@ from typing import Any, Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name
+from ..config import get_authoring_client, resolve_agent_name
 from ..output import JSON_OPTION, console, print_json, print_table
 
 app = typer.Typer(name="heartbeat", help="Local-first agent heartbeat primitive", no_args_is_help=True)
@@ -230,7 +230,7 @@ def send(
 
     if not skip_push:
         try:
-            client = get_client()
+            client = get_authoring_client()
             try:
                 store["agent_name"] = resolve_agent_name(client=client)
             except Exception:
@@ -323,7 +323,7 @@ def list_history(
 def _probe_online(timeout: float = 2.0) -> tuple[bool, str | None]:
     """Cheap online probe by attempting a real heartbeat."""
     try:
-        client = get_client()
+        client = get_authoring_client()
     except Exception as exc:
         return False, f"client unavailable: {exc}"
     base = getattr(client, "_base_url", None) or getattr(client, "base_url", None)
@@ -431,7 +431,7 @@ def push(
 
     latest = unpushed[-1]
     try:
-        client = get_client()
+        client = get_authoring_client()
     except Exception as exc:
         if as_json:
             print_json({"file": str(path), "pushed": [], "error": f"client unavailable: {exc}"})
@@ -496,7 +496,7 @@ def watch(
     while True:
         tick += 1
         try:
-            client = get_client()
+            client = get_authoring_client()
             agent_name = None
             try:
                 agent_name = resolve_agent_name(client=client)

--- a/ax_cli/commands/keys.py
+++ b/ax_cli/commands/keys.py
@@ -5,7 +5,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client
+from ..config import get_authoring_client
 from ..output import JSON_OPTION, handle_error, print_json, print_table
 
 app = typer.Typer(name="keys", help="API key management", no_args_is_help=True)
@@ -20,7 +20,7 @@ def create(
     as_json: bool = JSON_OPTION,
 ):
     """Create a new API key."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.create_key(name, allowed_agent_ids=agent_id or None)
     except httpx.HTTPStatusError as e:
@@ -38,7 +38,7 @@ def create(
 @app.command("list")
 def list_keys(as_json: bool = JSON_OPTION):
     """List all API keys."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.list_keys()
     except httpx.HTTPStatusError as e:
@@ -57,7 +57,7 @@ def list_keys(as_json: bool = JSON_OPTION):
 @app.command("revoke")
 def revoke(credential_id: str = typer.Argument(..., help="Credential ID to revoke")):
     """Revoke an API key."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         client.revoke_key(credential_id)
     except httpx.HTTPStatusError as e:
@@ -71,7 +71,7 @@ def rotate(
     as_json: bool = JSON_OPTION,
 ):
     """Rotate an API key — issues new token, revokes old."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.rotate_key(credential_id)
     except httpx.HTTPStatusError as e:

--- a/ax_cli/commands/listen.py
+++ b/ax_cli/commands/listen.py
@@ -25,7 +25,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_space_id
 from ..output import console
 
 app = typer.Typer(name="listen", help="Listen for @mentions via SSE", no_args_is_help=False)
@@ -380,7 +380,7 @@ def listen(
       ax listen --dry-run                    # Watch only
       ax listen --agent mybot --exec ./bot   # Named agent
     """
-    client = get_client()
+    client = get_authoring_client()
     agent_name = agent or resolve_agent_name(client=client)
     if not agent_name:
         console.print(

--- a/ax_cli/commands/messages.py
+++ b/ax_cli/commands/messages.py
@@ -10,7 +10,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_gateway_config, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_gateway_config, resolve_space_id
 from ..context_keys import build_upload_context_key
 from ..mentions import merge_explicit_mentions_metadata
 from ..output import JSON_OPTION, console, handle_error, print_json, print_kv, print_table
@@ -872,7 +872,7 @@ def send(
                 console.print("[dim]Gateway-native send accepted; reply waiting for this path is not wired yet.[/dim]")
         return
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
 
     # --act-as: override sender identity (requires scoped token)
@@ -1097,7 +1097,7 @@ def list_messages(
             args["mark_read"] = True
         data = _gateway_local_call(gateway_cfg=gateway_cfg, method="list_messages", args=args, space_id=space_id)
     else:
-        client = get_client()
+        client = get_authoring_client()
         sid = resolve_space_id(client, explicit=space_id)
         try:
             kwargs = {"limit": limit, "channel": channel, "space_id": sid}
@@ -1146,7 +1146,7 @@ def mark_read(
         typer.echo("Error: use either a message ID or --all, not both.", err=True)
         raise typer.Exit(1)
 
-    client = get_client()
+    client = get_authoring_client()
     try:
         if all_messages:
             data = client.mark_all_messages_read()
@@ -1174,7 +1174,7 @@ def get(
             args={"message_id": message_id},
         )
     else:
-        client = get_client()
+        client = get_authoring_client()
         try:
             data = client.get_message(_resolve_message_id(client, message_id))
         except httpx.HTTPStatusError as e:
@@ -1192,7 +1192,7 @@ def edit(
     as_json: bool = JSON_OPTION,
 ):
     """Edit a message."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.edit_message(_resolve_message_id(client, message_id), content)
     except httpx.HTTPStatusError as e:
@@ -1209,7 +1209,7 @@ def delete(
     as_json: bool = JSON_OPTION,
 ):
     """Delete a message."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         resolved_message_id = _resolve_message_id(client, message_id)
         client.delete_message(resolved_message_id)
@@ -1236,7 +1236,7 @@ def search(
             args={"query": query, "limit": limit},
         )
     else:
-        client = get_client()
+        client = get_authoring_client()
         try:
             data = client.search_messages(query, limit=limit)
         except httpx.HTTPStatusError as e:

--- a/ax_cli/commands/qa.py
+++ b/ax_cli/commands/qa.py
@@ -20,7 +20,7 @@ from ..config import (
     _normalize_user_env,
     _user_config_path,
     diagnose_auth_config,
-    get_client,
+    get_authoring_client,
     resolve_space_id,
 )
 from ..context_keys import build_upload_context_key
@@ -371,7 +371,7 @@ def _run_widget_fixtures(
     include_media_message: bool,
     evidence_file: str | None,
 ) -> dict[str, Any]:
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space_id)
     whoami_payload = client.whoami()
     resolved_run_id = run_id or f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
@@ -678,7 +678,7 @@ def _run_contracts(
         selected_env = str(env_cfg.get("environment") or env_name)
         sid = _resolve_env_space_id(client, env_cfg, explicit=space_id)
     else:
-        client = get_client()
+        client = get_authoring_client()
         sid = resolve_space_id(client, explicit=space_id)
     checks: list[dict[str, Any]] = []
 

--- a/ax_cli/commands/reminders.py
+++ b/ax_cli/commands/reminders.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_space_id
 from ..output import JSON_OPTION, console, print_json, print_table
 from .alerts import (
     _build_alert_metadata,
@@ -218,7 +218,7 @@ def add(
         resolved_space = space_id
     else:
         try:
-            client = get_client()
+            client = get_authoring_client()
             resolved_space = resolve_space_id(client, explicit=None)
         except Exception as exc:
             typer.echo(
@@ -586,7 +586,7 @@ def run(
 
     path = _policy_file(policy_file)
     all_results: list[dict[str, Any]] = []
-    client = get_client()
+    client = get_authoring_client()
 
     while True:
         store = _load_store(path)
@@ -673,7 +673,7 @@ def run(
 def _probe_online(timeout: float = 2.0) -> tuple[bool, str | None]:
     """Cheap online probe. Returns (is_online, reason_if_offline)."""
     try:
-        client = get_client()
+        client = get_authoring_client()
     except Exception as exc:
         return False, f"client unavailable: {exc}"
     base = getattr(client, "_base_url", None) or getattr(client, "base_url", None)
@@ -999,7 +999,7 @@ def drafts_send(
     path = _policy_file(policy_file)
     store = _load_store(path)
     draft = _find_draft(store, draft_id)
-    client = get_client()
+    client = get_authoring_client()
     try:
         result = client.send_message(
             str(draft.get("space_id")),

--- a/ax_cli/commands/spaces.py
+++ b/ax_cli/commands/spaces.py
@@ -5,7 +5,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_gateway_config, resolve_space_id, save_space_id
+from ..config import get_authoring_client, resolve_gateway_config, resolve_space_id, save_space_id
 from ..output import JSON_OPTION, console, handle_error, print_json, print_kv, print_table
 
 app = typer.Typer(name="spaces", help="Space management", no_args_is_help=True)
@@ -69,7 +69,7 @@ def list_spaces(
 
         spaces = _gateway_local_call(gateway_cfg=gateway_cfg, method="list_spaces")
     else:
-        client = get_client()
+        client = get_authoring_client()
         try:
             spaces = client.list_spaces()
         except httpx.HTTPStatusError as e:
@@ -94,7 +94,7 @@ def create(
     as_json: bool = JSON_OPTION,
 ):
     """Create a new space."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         result = client.create_space(name, description=description, visibility=visibility)
     except httpx.HTTPStatusError as e:
@@ -117,7 +117,7 @@ def use_space(
     as_json: bool = JSON_OPTION,
 ):
     """Set the current CLI space by id, slug, or name."""
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space)
     space_row = _find_space(client, sid) or {}
     label = _space_label(space_row, sid)
@@ -147,7 +147,7 @@ def get_space(
     as_json: bool = JSON_OPTION,
 ):
     """Get space details."""
-    client = get_client()
+    client = get_authoring_client()
     try:
         data = client.get_space(space_id)
     except httpx.HTTPStatusError as e:
@@ -164,7 +164,7 @@ def members(
     as_json: bool = JSON_OPTION,
 ):
     """List members of a space."""
-    client = get_client()
+    client = get_authoring_client()
     sid = space_id or resolve_space_id(client)
     try:
         data = client.list_space_members(sid)

--- a/ax_cli/commands/tasks.py
+++ b/ax_cli/commands/tasks.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import httpx
 import typer
 
-from ..config import get_client, resolve_gateway_config, resolve_space_id
+from ..config import get_authoring_client, resolve_gateway_config, resolve_space_id
 from ..output import JSON_OPTION, console, handle_error, mention_prefix, print_json, print_kv, print_table
 from .messages import _gateway_local_call, _gateway_local_connect
 
@@ -312,7 +312,7 @@ def create(
                 console.print("[yellow]Note:[/yellow] Gateway task notifications are not wired yet; task was created.")
         return
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space)
     space_info = _space_summary(client, sid)
     assignee_id = _resolve_assignee_id(client, assign_to, space_id=sid)
@@ -394,7 +394,7 @@ def list_tasks(
             )
         return
 
-    client = get_client()
+    client = get_authoring_client()
     sid = resolve_space_id(client, explicit=space)
     space_info = _space_summary(client, sid)
     try:
@@ -431,7 +431,7 @@ def get(
             args={"task_id": task_id},
         )
     else:
-        client = get_client()
+        client = get_authoring_client()
         try:
             data = client.get_task(task_id)
         except httpx.HTTPStatusError as e:
@@ -478,7 +478,7 @@ def update(
             args={"task_id": task_id, **fields},
         )
     else:
-        client = get_client()
+        client = get_authoring_client()
         if assign_to is not None:
             fields["assignee_id"] = _resolve_update_assignee_id(client, task_id, assign_to)
         try:

--- a/ax_cli/commands/upload.py
+++ b/ax_cli/commands/upload.py
@@ -7,7 +7,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_space_id
+from ..config import get_authoring_client, resolve_space_id
 from ..context_keys import build_upload_context_key
 from ..output import JSON_OPTION, console, handle_error, mention_prefix, print_json
 
@@ -67,7 +67,7 @@ def upload_file(
         ax upload file data.csv --key "sales-q1" --vault
         ax upload file arch.png --no-message --quiet   # context only, print ID
     """
-    client = get_client()
+    client = get_authoring_client()
     space_id = resolve_space_id(client)
     path = Path(file_path).expanduser().resolve()
 

--- a/ax_cli/commands/watch.py
+++ b/ax_cli/commands/watch.py
@@ -25,7 +25,7 @@ from typing import Optional
 import httpx
 import typer
 
-from ..config import get_client, resolve_agent_name, resolve_space_id
+from ..config import get_authoring_client, resolve_agent_name, resolve_space_id
 from ..output import console
 
 app = typer.Typer(name="watch", help="Wait for messages matching a condition", no_args_is_help=False)
@@ -220,7 +220,7 @@ def watch(
 
     Exit codes: 0 = condition met, 1 = timeout, 2 = error
     """
-    client = get_client()
+    client = get_authoring_client()
     agent_name = resolve_agent_name()
     space_id = resolve_space_id(client)
 

--- a/ax_cli/config.py
+++ b/ax_cli/config.py
@@ -1362,6 +1362,48 @@ def get_client() -> AxClient:
     )
 
 
+def get_authoring_client() -> AxClient:
+    """Return a credential-bearing AxClient for the invoking principal.
+
+    Single entry point command modules should use to obtain a client.
+    Resolution order:
+
+    1. Gateway-brokered workspace: when ``resolve_gateway_config()`` returns a
+       config with an ``agent_name`` and the local Gateway registry has a
+       matching entry, return that managed-agent's AxClient. This is the path
+       that lets ``ax tasks create``, ``ax agents list``, etc. work from a
+       Gateway-managed shell with no local PAT.
+    2. Otherwise, fall back to the legacy ``get_client()`` path, which reads a
+       local PAT from config / env. ``get_client()`` exits with its existing
+       actionable error if no credential is present.
+
+    The function preserves ``get_client()`` for backwards compatibility — any
+    caller still using it keeps working. New call sites should prefer
+    ``get_authoring_client()`` so the larger Gateway-as-MCP transport swap can
+    happen behind a single entry point in a follow-up.
+
+    Don't silently fall back when both paths fail: ``get_client()`` already
+    raises ``typer.Exit`` with operator-actionable guidance, so propagate it.
+    """
+    gateway_cfg = resolve_gateway_config()
+    agent_name = (gateway_cfg or {}).get("agent_name")
+    if gateway_cfg and agent_name:
+        # Lazy imports avoid the circular dependency: ax_cli.commands.gateway
+        # and ax_cli.gateway both depend on ax_cli.config at module load.
+        from ax_cli.commands.gateway import _load_managed_agent_client
+        from ax_cli.gateway import find_agent_entry, load_gateway_registry
+
+        registry = load_gateway_registry()
+        entry = find_agent_entry(registry, agent_name)
+        if entry:
+            return _load_managed_agent_client(entry)
+        # Brokered workspace but the registry doesn't have the agent — fall
+        # through to get_client(), whose error message points the operator at
+        # `ax gateway local ... --workdir <path>` to register.
+
+    return get_client()
+
+
 def get_user_client() -> AxClient:
     """Return a user-authored client for setup/management operations."""
     token = resolve_user_token()

--- a/tests/test_agents_check.py
+++ b/tests/test_agents_check.py
@@ -28,19 +28,21 @@ class _FakeClient:
 
 
 def _install(monkeypatch, client: _FakeClient) -> None:
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: client)
 
 
 def test_check_renders_basic_presence_shape(monkeypatch):
     """Today's backend returns the basic presence shape — CLI renders it cleanly."""
-    fake = _FakeClient({
-        "agent_id": "abc-123",
-        "name": "frontend_sentinel",
-        "presence": "online",
-        "responsive": True,
-        "last_active": "2026-04-25T15:00:00Z",
-        "agent_type": "assistant",
-    })
+    fake = _FakeClient(
+        {
+            "agent_id": "abc-123",
+            "name": "frontend_sentinel",
+            "presence": "online",
+            "responsive": True,
+            "last_active": "2026-04-25T15:00:00Z",
+            "agent_type": "assistant",
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "check", "frontend_sentinel", "--json"])
@@ -53,28 +55,30 @@ def test_check_renders_basic_presence_shape(monkeypatch):
 
 def test_check_renders_avail_contract_v4_dto_forward_compat(monkeypatch):
     """When backend ships the AVAIL-CONTRACT v4 fields, CLI renders them transparently."""
-    fake = _FakeClient({
-        "agent_id": "abc-123",
-        "name": "backend_sentinel",
-        "presence": "offline",
-        "responsive": False,
-        "last_active": "2026-04-25T14:00:00Z",
-        "agent_type": "assistant",
-        # Forward-compat AVAIL-CONTRACT v4 fields
-        "expected_response": "warming",
-        "badge_state": "routable_delayed",
-        "badge_label": "Warming",
-        "badge_color": "info",
-        "connection_path": "gateway_managed",
-        "confidence": "medium",
-        "unavailable_reason": None,
-        "status_explanation": "On-demand. Last warmed 12 min ago. A new mention will spawn the runtime.",
-        "pre_send_warning": {
-            "severity": "info",
-            "title": "Delivery may be delayed",
-            "body": "This agent is on-demand; a new mention will warm the runtime.",
-        },
-    })
+    fake = _FakeClient(
+        {
+            "agent_id": "abc-123",
+            "name": "backend_sentinel",
+            "presence": "offline",
+            "responsive": False,
+            "last_active": "2026-04-25T14:00:00Z",
+            "agent_type": "assistant",
+            # Forward-compat AVAIL-CONTRACT v4 fields
+            "expected_response": "warming",
+            "badge_state": "routable_delayed",
+            "badge_label": "Warming",
+            "badge_color": "info",
+            "connection_path": "gateway_managed",
+            "confidence": "medium",
+            "unavailable_reason": None,
+            "status_explanation": "On-demand. Last warmed 12 min ago. A new mention will spawn the runtime.",
+            "pre_send_warning": {
+                "severity": "info",
+                "title": "Delivery may be delayed",
+                "body": "This agent is on-demand; a new mention will warm the runtime.",
+            },
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "check", "backend_sentinel", "--json"])
@@ -92,18 +96,20 @@ def test_check_renders_avail_contract_v4_dto_forward_compat(monkeypatch):
 
 def test_check_human_output_renders_badge_label_when_present(monkeypatch):
     """Human-readable output uses the rich badge when backend provides it."""
-    fake = _FakeClient({
-        "agent_id": "abc-123",
-        "name": "night_owl",
-        "presence": "online",
-        "responsive": True,
-        "last_active": "2026-04-25T15:00:00Z",
-        "badge_state": "live",
-        "badge_label": "Live",
-        "expected_response": "immediate",
-        "connection_path": "gateway_managed",
-        "confidence": "high",
-    })
+    fake = _FakeClient(
+        {
+            "agent_id": "abc-123",
+            "name": "night_owl",
+            "presence": "online",
+            "responsive": True,
+            "last_active": "2026-04-25T15:00:00Z",
+            "badge_state": "live",
+            "badge_label": "Live",
+            "expected_response": "immediate",
+            "connection_path": "gateway_managed",
+            "confidence": "high",
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "check", "night_owl"])
@@ -116,13 +122,15 @@ def test_check_human_output_renders_badge_label_when_present(monkeypatch):
 
 def test_check_human_output_falls_back_to_basic_presence(monkeypatch):
     """When backend has no v4 fields, render basic ONLINE/OFFLINE."""
-    fake = _FakeClient({
-        "agent_id": "abc-123",
-        "name": "old_agent",
-        "presence": "offline",
-        "responsive": False,
-        "last_active": None,
-    })
+    fake = _FakeClient(
+        {
+            "agent_id": "abc-123",
+            "name": "old_agent",
+            "presence": "offline",
+            "responsive": False,
+            "last_active": None,
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "check", "old_agent"])
@@ -133,20 +141,22 @@ def test_check_human_output_falls_back_to_basic_presence(monkeypatch):
 
 def test_check_renders_pre_send_warning_when_present(monkeypatch):
     """pre_send_warning renders as a colored callout below the fields table."""
-    fake = _FakeClient({
-        "agent_id": "abc-123",
-        "name": "stuck_agent",
-        "presence": "online",
-        "badge_state": "blocked",
-        "badge_label": "Stuck",
-        "expected_response": "unlikely",
-        "unavailable_reason": "runtime_stuck",
-        "pre_send_warning": {
-            "severity": "warning",
-            "title": "Agent appears stuck",
-            "body": "Heartbeat hasn't fired in 10 minutes. Send anyway?",
-        },
-    })
+    fake = _FakeClient(
+        {
+            "agent_id": "abc-123",
+            "name": "stuck_agent",
+            "presence": "online",
+            "badge_state": "blocked",
+            "badge_label": "Stuck",
+            "expected_response": "unlikely",
+            "unavailable_reason": "runtime_stuck",
+            "pre_send_warning": {
+                "severity": "warning",
+                "title": "Agent appears stuck",
+                "body": "Heartbeat hasn't fired in 10 minutes. Send anyway?",
+            },
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "check", "stuck_agent"])
@@ -165,7 +175,7 @@ def test_check_unknown_agent_returns_nonzero(monkeypatch):
         def get_agent_presence(self, _id):
             raise RuntimeError("agent not found: ghost")
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: _NotFoundClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: _NotFoundClient())
     result = runner.invoke(app, ["agents", "check", "ghost", "--json"])
     assert result.exit_code != 0
     assert "ghost" in result.output
@@ -279,19 +289,21 @@ def test_get_agent_presence_prefers_state_endpoint_and_unwraps_envelope():
                     return self._data
 
             if path.endswith("/state"):
-                return _R({
-                    "agent_state": {
-                        "agent_id": "uuid-zzz",
-                        "name": "richy",
-                        "expected_response": "immediate",
-                        "badge_state": "live",
-                        "badge_label": "Live",
-                        "connection_path": "gateway_managed",
-                        "confidence": "high",
-                    },
-                    "raw_presence": {"sources": ["gateway"]},
-                    "control": {"enabled": True, "quarantined": False},
-                })
+                return _R(
+                    {
+                        "agent_state": {
+                            "agent_id": "uuid-zzz",
+                            "name": "richy",
+                            "expected_response": "immediate",
+                            "badge_state": "live",
+                            "badge_label": "Live",
+                            "connection_path": "gateway_managed",
+                            "confidence": "high",
+                        },
+                        "raw_presence": {"sources": ["gateway"]},
+                        "control": {"enabled": True, "quarantined": False},
+                    }
+                )
             raise AssertionError(f"unexpected path {path}")
 
     client = AxClient.__new__(AxClient)

--- a/tests/test_agents_commands.py
+++ b/tests/test_agents_commands.py
@@ -24,7 +24,7 @@ def test_agents_list_surfaces_control_state(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["agents", "list"])
@@ -61,7 +61,7 @@ def test_agents_ping_does_not_send_when_control_blocks_delivery(monkeypatch):
             calls["sent"] = True
             return {"message": {"id": "msg-1"}}
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["agents", "ping", "aX", "--json"])
@@ -100,7 +100,7 @@ def test_agents_ping_classifies_reply_as_event_listener(monkeypatch):
         calls["wait"] = kwargs
         return {"id": "reply-1", "content": f"received {kwargs['token']}", "display_name": "demo-agent"}
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.agents.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.agents._wait_for_handoff_reply", fake_wait)
@@ -135,7 +135,7 @@ def test_agents_ping_classifies_timeout_as_unknown(monkeypatch):
         def send_message(self, space_id, content):
             return {"message": {"id": "msg-1"}}
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.agents.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.agents._wait_for_handoff_reply", lambda client, **kwargs: None)
@@ -153,7 +153,7 @@ def test_agents_ping_unknown_agent_fails(monkeypatch):
         def list_agents(self, *, space_id=None, limit=None):
             return {"agents": [{"id": "agent-1", "name": "demo-agent"}]}
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["agents", "ping", "missing"])
@@ -194,7 +194,7 @@ def test_agents_discover_infers_roles_without_ping(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.agents.resolve_agent_name", lambda client=None: "ChatGPT")
 
@@ -230,7 +230,7 @@ def test_agents_discover_marks_control_blocked_agents_without_ping(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.agents.resolve_agent_name", lambda client=None: "ChatGPT")
 
@@ -274,7 +274,7 @@ def test_agents_discover_with_ping_classifies_listener(monkeypatch):
         calls["wait"] = kwargs
         return {"id": "reply-1", "content": kwargs["token"], "display_name": "backend_sentinel"}
 
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.agents.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.agents._wait_for_handoff_reply", fake_wait)

--- a/tests/test_agents_list_availability.py
+++ b/tests/test_agents_list_availability.py
@@ -20,6 +20,7 @@ class _FakeClient:
 
     def list_agents_availability(self, **_kw):
         if self._raise_404:
+
             class _Resp:
                 status_code = 404
                 text = "not found"
@@ -32,15 +33,19 @@ class _FakeClient:
 
 
 def _install(monkeypatch, client):
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: client)
     monkeypatch.setattr("ax_cli.commands.agents.resolve_space_id", lambda c, explicit=None: explicit or "space-abc")
 
 
 def test_list_default_path_uses_legacy_endpoint(monkeypatch):
     """No --availability: hits /agents and renders the legacy 3-column table."""
-    fake = _FakeClient(list_payload={"agents": [
-        {"id": "a-1", "name": "frontend_sentinel", "status": "active"},
-    ]})
+    fake = _FakeClient(
+        list_payload={
+            "agents": [
+                {"id": "a-1", "name": "frontend_sentinel", "status": "active"},
+            ]
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "list", "--json"])
@@ -51,34 +56,36 @@ def test_list_default_path_uses_legacy_endpoint(monkeypatch):
 
 def test_list_availability_renders_v4_fields(monkeypatch):
     """--availability: hits /availability, unwraps agent_state envelopes, renders v4 columns."""
-    fake = _FakeClient(availability_payload=[
-        {
-            "agent_state": {
-                "agent_id": "a-1",
-                "name": "frontend_sentinel",
-                "badge_state": "live",
-                "badge_label": "Live",
-                "connection_path": "gateway_managed",
-                "expected_response": "immediate",
-                "confidence": "high",
-                "last_seen_at": "2026-04-25T17:00:00Z",
+    fake = _FakeClient(
+        availability_payload=[
+            {
+                "agent_state": {
+                    "agent_id": "a-1",
+                    "name": "frontend_sentinel",
+                    "badge_state": "live",
+                    "badge_label": "Live",
+                    "connection_path": "gateway_managed",
+                    "expected_response": "immediate",
+                    "confidence": "high",
+                    "last_seen_at": "2026-04-25T17:00:00Z",
+                },
+                "raw_presence": {"sources": ["gateway"]},
+                "control": {"enabled": True},
             },
-            "raw_presence": {"sources": ["gateway"]},
-            "control": {"enabled": True},
-        },
-        {
-            "agent_state": {
-                "agent_id": "a-2",
-                "name": "backend_sentinel",
-                "badge_state": "routable_delayed",
-                "badge_label": "Warming",
-                "connection_path": "gateway_managed",
-                "expected_response": "warming",
-                "confidence": "medium",
-                "last_seen_at": "2026-04-25T16:55:00Z",
+            {
+                "agent_state": {
+                    "agent_id": "a-2",
+                    "name": "backend_sentinel",
+                    "badge_state": "routable_delayed",
+                    "badge_label": "Warming",
+                    "connection_path": "gateway_managed",
+                    "expected_response": "warming",
+                    "confidence": "medium",
+                    "last_seen_at": "2026-04-25T16:55:00Z",
+                },
             },
-        },
-    ])
+        ]
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "list", "--availability", "--json"])
@@ -95,30 +102,32 @@ def test_list_availability_renders_v4_fields(monkeypatch):
 
 def test_list_availability_human_output_renders_columns(monkeypatch):
     """Human-readable --availability output includes badge + path columns."""
-    fake = _FakeClient(availability_payload=[
-        {
-            "agent_state": {
-                "agent_id": "a-1",
-                "name": "night_owl",
-                "badge_state": "live",
-                "badge_label": "Live",
-                "connection_path": "gateway_managed",
-                "expected_response": "immediate",
-                "confidence": "high",
+    fake = _FakeClient(
+        availability_payload=[
+            {
+                "agent_state": {
+                    "agent_id": "a-1",
+                    "name": "night_owl",
+                    "badge_state": "live",
+                    "badge_label": "Live",
+                    "connection_path": "gateway_managed",
+                    "expected_response": "immediate",
+                    "confidence": "high",
+                },
             },
-        },
-        {
-            "agent_state": {
-                "agent_id": "a-2",
-                "name": "ax_concierge",
-                "badge_state": "routable_delayed",
-                "badge_label": "Dispatch",
-                "connection_path": "mcp_only",
-                "expected_response": "dispatch_delayed",
-                "confidence": "medium",
+            {
+                "agent_state": {
+                    "agent_id": "a-2",
+                    "name": "ax_concierge",
+                    "badge_state": "routable_delayed",
+                    "badge_label": "Dispatch",
+                    "connection_path": "mcp_only",
+                    "expected_response": "dispatch_delayed",
+                    "confidence": "medium",
+                },
             },
-        },
-    ])
+        ]
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "list", "--availability"])

--- a/tests/test_agents_placement.py
+++ b/tests/test_agents_placement.py
@@ -44,14 +44,20 @@ class _FakeClient:
 
 
 def _install(monkeypatch, client):
-    monkeypatch.setattr("ax_cli.commands.agents.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.agents.get_authoring_client", lambda: client)
 
 
 def test_get_renders_basic_placement(monkeypatch):
-    fake = _FakeClient(agent_record={"agent": {
-        "id": "a-1", "name": "frontend_sentinel",
-        "space_id": "space-prod", "pinned": True,
-    }})
+    fake = _FakeClient(
+        agent_record={
+            "agent": {
+                "id": "a-1",
+                "name": "frontend_sentinel",
+                "space_id": "space-prod",
+                "pinned": True,
+            }
+        }
+    )
     _install(monkeypatch, fake)
 
     result = runner.invoke(app, ["agents", "placement", "get", "frontend_sentinel", "--json"])
@@ -63,10 +69,16 @@ def test_get_renders_basic_placement(monkeypatch):
 
 
 def test_get_human_output_renders_table(monkeypatch):
-    fake = _FakeClient(agent_record={"agent": {
-        "id": "a-1", "name": "demo-bot",
-        "space_id": "space-abc", "pinned": False,
-    }})
+    fake = _FakeClient(
+        agent_record={
+            "agent": {
+                "id": "a-1",
+                "name": "demo-bot",
+                "space_id": "space-abc",
+                "pinned": False,
+            }
+        }
+    )
     _install(monkeypatch, fake)
     result = runner.invoke(app, ["agents", "placement", "get", "demo-bot"])
     assert result.exit_code == 0, result.output
@@ -75,12 +87,17 @@ def test_get_human_output_renders_table(monkeypatch):
 
 
 def test_get_renders_allowed_spaces_when_present(monkeypatch):
-    fake = _FakeClient(agent_record={"agent": {
-        "id": "a-1", "name": "multi-space",
-        "space_id": "space-default",
-        "pinned": False,
-        "allowed_spaces": ["space-a", "space-b", "space-c"],
-    }})
+    fake = _FakeClient(
+        agent_record={
+            "agent": {
+                "id": "a-1",
+                "name": "multi-space",
+                "space_id": "space-default",
+                "pinned": False,
+                "allowed_spaces": ["space-a", "space-b", "space-c"],
+            }
+        }
+    )
     _install(monkeypatch, fake)
     result = runner.invoke(app, ["agents", "placement", "get", "multi-space"])
     assert result.exit_code == 0, result.output
@@ -90,18 +107,23 @@ def test_get_renders_allowed_spaces_when_present(monkeypatch):
 
 def test_get_forward_compat_v4_placement_fields(monkeypatch):
     """When backend ships GATEWAY-PLACEMENT-POLICY-001 fields, CLI renders them transparently."""
-    fake = _FakeClient(agent_record={"agent": {
-        "id": "a-1", "name": "future-bot",
-        "space_id": "space-curr",
-        "pinned": False,
-        "placement": {
-            "policy_kind": "allowed",
-            "current_space": "space-curr",
-            "current_space_set_by": "ax_ui",
-            "policy_revision": 3,
-        },
-        "placement_state": "acked",
-    }})
+    fake = _FakeClient(
+        agent_record={
+            "agent": {
+                "id": "a-1",
+                "name": "future-bot",
+                "space_id": "space-curr",
+                "pinned": False,
+                "placement": {
+                    "policy_kind": "allowed",
+                    "current_space": "space-curr",
+                    "current_space_set_by": "ax_ui",
+                    "policy_revision": 3,
+                },
+                "placement_state": "acked",
+            }
+        }
+    )
     _install(monkeypatch, fake)
     result = runner.invoke(app, ["agents", "placement", "get", "future-bot"])
     assert result.exit_code == 0, result.output
@@ -138,9 +160,16 @@ def test_set_default_unpinned(monkeypatch):
 
 
 def test_set_human_output_confirms(monkeypatch):
-    fake = _FakeClient(set_response={"agent": {
-        "id": "a-1", "name": "demo-bot", "space_id": "s-2", "pinned": True,
-    }})
+    fake = _FakeClient(
+        set_response={
+            "agent": {
+                "id": "a-1",
+                "name": "demo-bot",
+                "space_id": "s-2",
+                "pinned": True,
+            }
+        }
+    )
     _install(monkeypatch, fake)
     result = runner.invoke(
         app,
@@ -155,6 +184,7 @@ def test_set_human_output_confirms(monkeypatch):
 
 def test_set_surfaces_403_clearly(monkeypatch):
     """Backend returns 403 when user isn't a member of target space — CLI surfaces it."""
+
     class _Resp:
         status_code = 403
         text = '{"detail":"User is not a member of target space"}'
@@ -170,9 +200,14 @@ def test_set_surfaces_403_clearly(monkeypatch):
 
 
 def test_get_missing_space_id_renders_dash(monkeypatch):
-    fake = _FakeClient(agent_record={"agent": {
-        "id": "a-1", "name": "no-space-bot",
-    }})
+    fake = _FakeClient(
+        agent_record={
+            "agent": {
+                "id": "a-1",
+                "name": "no-space-bot",
+            }
+        }
+    )
     _install(monkeypatch, fake)
     result = runner.invoke(app, ["agents", "placement", "get", "no-space-bot"])
     assert result.exit_code == 0, result.output

--- a/tests/test_alerts_commands.py
+++ b/tests/test_alerts_commands.py
@@ -99,7 +99,7 @@ class _FakeClient:
 
 
 def _install_fake_client(monkeypatch, client: _FakeClient) -> None:
-    monkeypatch.setattr("ax_cli.commands.alerts.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.alerts.get_authoring_client", lambda: client)
     monkeypatch.setattr(
         "ax_cli.commands.alerts.resolve_space_id",
         lambda _client, *, explicit=None: "space-abc",

--- a/tests/test_apps_commands.py
+++ b/tests/test_apps_commands.py
@@ -55,7 +55,7 @@ def test_apps_signal_writes_context_widget_metadata(monkeypatch):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.apps.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.apps.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.apps.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -149,7 +149,7 @@ def test_apps_signal_flattens_wrapped_context_payload(monkeypatch):
             calls["content"] = content
             return {"id": "msg-2"}
 
-    monkeypatch.setattr("ax_cli.commands.apps.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.apps.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.apps.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -221,7 +221,7 @@ def test_apps_signal_whoami_builds_identity_widget_payload(monkeypatch):
             }
             return {"id": "msg-identity"}
 
-    monkeypatch.setattr("ax_cli.commands.apps.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.apps.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.apps.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -299,7 +299,7 @@ def test_apps_signal_agents_hydrates_dashboard_payload(monkeypatch):
             }
             return {"id": "msg-agents"}
 
-    monkeypatch.setattr("ax_cli.commands.apps.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.apps.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.apps.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["apps", "signal", "agents", "--summary", "Available agents", "--json"])
@@ -360,7 +360,7 @@ def test_apps_signal_spaces_hydrates_navigator_payload(monkeypatch):
             }
             return {"id": "msg-spaces"}
 
-    monkeypatch.setattr("ax_cli.commands.apps.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.apps.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.apps.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["apps", "signal", "spaces", "--summary", "Spaces ready", "--json"])
@@ -414,7 +414,7 @@ def test_apps_signal_tasks_hydrates_board_payload(monkeypatch):
             }
             return {"id": "msg-tasks"}
 
-    monkeypatch.setattr("ax_cli.commands.apps.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.apps.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.apps.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["apps", "signal", "tasks", "--summary", "Task board ready", "--json"])

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -286,7 +286,7 @@ def test_auth_whoami_reports_runtime_config(monkeypatch, tmp_path):
                 },
             }
 
-    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: "codex")
     monkeypatch.setattr(auth, "_local_config_dir", lambda: None)
 
@@ -324,7 +324,7 @@ def test_auth_whoami_does_not_crash_on_multi_space_user(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: None)
     monkeypatch.setattr(auth, "resolve_gateway_config", lambda: {})
     monkeypatch.setattr(auth, "_local_config_dir", lambda: None)
@@ -354,7 +354,7 @@ def test_auth_whoami_resolves_single_space_for_unbound_user(monkeypatch):
         def list_spaces(self):
             return {"spaces": [{"id": "the-only-space", "name": "Solo"}]}
 
-    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: None)
     monkeypatch.setattr(auth, "resolve_gateway_config", lambda: {})
     monkeypatch.setattr(auth, "_local_config_dir", lambda: None)
@@ -379,7 +379,7 @@ def test_auth_whoami_uses_explicit_space_from_env(monkeypatch):
         def list_spaces(self):
             raise AssertionError("list_spaces should not be called when AX_SPACE_ID is set")
 
-    monkeypatch.setattr(auth, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(auth, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(auth, "resolve_agent_name", lambda *, client: None)
     monkeypatch.setattr(auth, "resolve_gateway_config", lambda: {})
     monkeypatch.setattr(auth, "_local_config_dir", lambda: None)

--- a/tests/test_authoring_client.py
+++ b/tests/test_authoring_client.py
@@ -1,0 +1,193 @@
+"""Regression: ``get_authoring_client()`` is the single entry point for a
+credential-bearing AxClient and resolves correctly across the two
+credential paths.
+
+Per issue #142 (Phase 3 of the Gateway-as-MCP plan), every command that
+talks to aX or the local Gateway should obtain its client through one
+factory. This module locks the resolver behavior:
+
+  - In a Gateway-brokered workspace (``[gateway]`` + ``[agent]`` blocks in
+    ``.ax/config.toml`` and a registry entry for the agent), the factory
+    returns a managed-agent AxClient. This is what unblocks
+    ``ax tasks create`` from a Gateway-managed shell with no local PAT.
+  - In a non-brokered workspace with a local PAT, the factory returns the
+    same client ``get_client()`` would have returned. Behavior preserved.
+  - With neither a brokered registry entry nor a local credential, the
+    factory exits with ``get_client()``'s actionable error rather than
+    silently falling back.
+
+Phase 4 will swap the implementation behind this entry point. These
+tests pin the contract Phase 4 must preserve.
+"""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from ax_cli import config as ax_config
+from ax_cli import gateway as gateway_core
+from ax_cli.client import AxClient
+
+# ---- Fixture helpers (shape mirrors tests/test_agents_test_invoking_principal.py) ----
+
+
+def _make_registry_agent(*, name, agent_id, token_file, space_id="space-1"):
+    return {
+        "name": name,
+        "agent_id": agent_id,
+        "space_id": space_id,
+        "active_space_id": space_id,
+        "default_space_id": space_id,
+        "base_url": "https://paxai.app",
+        "runtime_type": "echo",
+        "template_id": "echo_test",
+        "desired_state": "running",
+        "effective_state": "running",
+        "transport": "gateway",
+        "credential_source": "gateway",
+        "allowed_spaces": [{"space_id": space_id, "name": "Test Space", "is_default": True}],
+        "token_file": str(token_file),
+    }
+
+
+def _seed_session_and_registry(tmp_path, monkeypatch, *, agents):
+    config_dir = tmp_path / "_gw_config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "operator",
+        }
+    )
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = list(agents)
+    for entry in registry["agents"]:
+        gateway_core.ensure_gateway_identity_binding(registry, entry, session=gateway_core.load_gateway_session())
+    gateway_core.save_gateway_registry(registry)
+
+
+def _write_workspace_gateway_config(tmp_path, *, agent_name):
+    """Write a workspace-local ``.ax/config.toml`` so ``resolve_gateway_config()``
+    sees the workspace as Gateway-brokered.
+
+    Uses TOML *literal* strings (single quotes) for paths so Windows
+    backslashes (``C:\\Users\\...``) aren't parsed as escape sequences.
+    """
+    local_ax = tmp_path / ".ax"
+    local_ax.mkdir(exist_ok=True)
+    (local_ax / "config.toml").write_text(
+        "[gateway]\n"
+        'mode = "local"\n'
+        'url = "http://127.0.0.1:8765"\n'
+        "\n"
+        "[agent]\n"
+        f"agent_name = '{agent_name}'\n"
+        f"workdir = '{tmp_path}'\n"
+    )
+
+
+def _clear_token_env(monkeypatch):
+    """Strip every env var the legacy resolver consults so a 'no PAT' shell
+    really means no PAT. Order matters here — ``get_client()`` checks several."""
+    for var in (
+        "AX_TOKEN",
+        "AX_API_TOKEN",
+        "AX_USER_TOKEN",
+        "AX_AGENT_TOKEN",
+        "AX_PAT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---- Test 1: Gateway-brokered workspace returns a managed-agent client ----
+
+
+def test_brokered_workspace_returns_managed_agent_client(tmp_path, monkeypatch):
+    """A workspace with ``[gateway]`` + ``[agent]`` blocks and a matching
+    registry entry must yield the managed-agent AxClient — no local PAT
+    required. This is the core unblock for ``ax tasks create`` from a
+    Gateway-managed shell."""
+    agent_token = tmp_path / "cli_god.token"
+    agent_token.write_text("axp_a_managed.secret")
+    _seed_session_and_registry(
+        tmp_path,
+        monkeypatch,
+        agents=[
+            _make_registry_agent(name="cli_god", agent_id="agent-cli-god", token_file=agent_token),
+        ],
+    )
+    _write_workspace_gateway_config(tmp_path, agent_name="cli_god")
+    monkeypatch.chdir(tmp_path)
+    _clear_token_env(monkeypatch)
+
+    client = ax_config.get_authoring_client()
+
+    assert isinstance(client, AxClient)
+    # The managed-agent client carries the agent's identity, not a user PAT
+    assert client.agent_name == "cli_god"
+    assert client.agent_id == "agent-cli-god"
+    # Token came from the registry entry's on-disk token file
+    assert client.token == "axp_a_managed.secret"
+
+
+# ---- Test 2: Non-brokered workspace returns the legacy client unchanged ----
+
+
+def test_non_brokered_workspace_returns_legacy_client(tmp_path, monkeypatch):
+    """Without a ``[gateway]`` block, the factory must defer to ``get_client()``
+    and return whatever it returns. Behavior preserved for every shell that
+    isn't Gateway-managed."""
+    monkeypatch.chdir(tmp_path)
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv("AX_TOKEN", "axp_a_legacy.secret")
+    monkeypatch.setenv("AX_BASE_URL", "https://paxai.app")
+
+    client = ax_config.get_authoring_client()
+
+    assert isinstance(client, AxClient)
+    assert client.token == "axp_a_legacy.secret"
+    assert client.base_url == "https://paxai.app"
+
+
+# ---- Test 3: Neither path resolves -> clear, actionable error (no silent fallback) ----
+
+
+def test_no_brokered_entry_and_no_token_raises_clear_error(tmp_path, monkeypatch, capsys):
+    """Workspace declares Gateway-brokered, but no registry entry and no
+    local PAT. The factory must propagate ``get_client()``'s actionable
+    error rather than silently returning anything."""
+    _seed_session_and_registry(tmp_path, monkeypatch, agents=[])  # empty registry
+    _write_workspace_gateway_config(tmp_path, agent_name="missing_agent")
+    monkeypatch.chdir(tmp_path)
+    _clear_token_env(monkeypatch)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        ax_config.get_authoring_client()
+
+    # ``get_client()`` exits with code 1 and an operator-actionable message
+    assert excinfo.value.exit_code == 1
+    err_text = capsys.readouterr().err.lower()
+    assert "no api credential" in err_text or "no credential" in err_text
+    # The error should point the operator at the Gateway path explicitly
+    assert "gateway" in err_text
+
+
+# ---- Bonus: backwards-compat sanity — get_client still works as before ----
+
+
+def test_get_client_preserved_for_backwards_compat(tmp_path, monkeypatch):
+    """Issue #142 explicitly requires ``get_client`` not be renamed or
+    removed. This pins that any code still importing ``get_client`` keeps
+    working."""
+    monkeypatch.chdir(tmp_path)
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv("AX_TOKEN", "axp_a_legacy.secret")
+    monkeypatch.setenv("AX_BASE_URL", "https://paxai.app")
+
+    legacy = ax_config.get_client()
+
+    assert isinstance(legacy, AxClient)
+    assert legacy.token == "axp_a_legacy.secret"

--- a/tests/test_authoring_client_migration.py
+++ b/tests/test_authoring_client_migration.py
@@ -1,0 +1,221 @@
+"""Regression: structural invariants of the get_authoring_client() migration.
+
+Issue #142 Phase 3 introduces ``get_authoring_client()`` as the single entry
+point for resolving a credential-bearing AxClient, and migrates the
+~67 ``get_client()`` call sites across 19 command modules to use it.
+
+This module pins the structural side of that migration (the behavioral
+side is in ``tests/test_authoring_client.py``). It exists so that a future
+refactor or a new command landing on ``main`` cannot silently regress the
+contract by reaching for the legacy resolver.
+
+What is locked
+==============
+
+  - ``ax_cli.config.get_authoring_client`` is the canonical factory and
+    is callable.
+  - ``ax_cli.config.get_client`` is preserved for backwards compatibility
+    (the issue explicitly required not removing it).
+  - Every migrated command module imports and uses
+    ``get_authoring_client``; none of them call ``get_client()`` directly.
+  - ``commands/gateway.py`` continues to expose the two helpers that
+    ``get_authoring_client()`` lazy-imports
+    (``_load_gateway_user_client`` and ``_load_managed_agent_client``).
+    Renaming or removing them would break the factory at runtime.
+
+What is intentionally NOT locked here
+=====================================
+
+Jake's smoke test 5 in #142 also lists ``_load_gateway_user_client``,
+``_load_managed_agent_client``, ``_gateway_local_call``, and
+``AxClient(...)`` as patterns that should disappear from migrated
+modules. Phase 3 leaves several of those in place on purpose:
+
+  - ``commands/gateway.py`` defines and legitimately uses the two
+    ``_load_*`` helpers for bootstrap-user and explicit named-agent
+    operations (``ax gateway login``, ``ax gateway agents add``,
+    ``ax gateway agents send <name>``). These resolve identities other
+    than the invoking principal and are out of scope for the factory.
+  - ``commands/auth.py`` retains four ``AxClient(...)`` constructions
+    plus one ``_gateway_local_call(method="whoami")``. They probe
+    explicit credentials (``whoami`` against a candidate token), which
+    is fundamentally a different operation from "give me a client for
+    the invoking principal."
+  - ``commands/qa.py`` retains one ``AxClient(...)`` for the QA
+    test-environment auth flow with explicit credentials.
+  - ``commands/messages.py`` defines ``_gateway_local_call`` itself and
+    is its primary caller. ``tasks.py``, ``agents.py``, ``context.py``,
+    and ``spaces.py`` still dispatch through it inside their
+    ``if gateway_cfg:`` branches.
+
+Collapsing the ``if gateway_cfg: _gateway_local_call(...) else:
+client.method(...)`` branches into a single
+``client = get_authoring_client(); client.method(...)`` is restructural
+(it removes the daemon-proxy intermediate hop and changes wire-level
+behavior in brokered shells) and lands in a follow-up PR. The pin in
+this file is intentionally narrower than Jake's smoke test 5 so the
+deferred work is visible rather than hidden.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from ax_cli import config as ax_config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMMANDS_DIR = REPO_ROOT / "ax_cli" / "commands"
+
+# The 19 modules from #142's "What to migrate" list, minus
+# ``commands/gateway.py``. See module docstring for why gateway.py is
+# excluded — it implements the gateway command suite itself and uses
+# explicit-identity helpers that resolve identities other than the
+# invoking principal.
+MIGRATED_MODULES = (
+    "agents",
+    "alerts",
+    "apps",
+    "auth",
+    "channel",
+    "context",
+    "credentials",
+    "events",
+    "handoff",
+    "heartbeat",
+    "keys",
+    "listen",
+    "messages",
+    "qa",
+    "reminders",
+    "spaces",
+    "tasks",
+    "upload",
+    "watch",
+)
+
+
+def _module_path(name: str) -> Path:
+    return COMMANDS_DIR / f"{name}.py"
+
+
+def _parse(name: str) -> ast.AST:
+    return ast.parse(_module_path(name).read_text(encoding="utf-8"))
+
+
+def _direct_calls(tree: ast.AST, func_name: str) -> list[int]:
+    """Return line numbers of every ``func_name()`` call in ``tree``
+    where ``func_name`` is a module-level name (i.e. not an attribute
+    access like ``ax_config.get_client()``).
+
+    Catches the migration target — ``client = get_client()`` after
+    ``from ..config import get_client``. Misses qualified calls on
+    purpose; those are part of test infrastructure (e.g.
+    ``test_authoring_client.py``'s backwards-compat test).
+    """
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == func_name:
+            hits.append(node.lineno)
+    return hits
+
+
+# ---- Test 1: factory is exported and callable -------------------------------
+
+
+def test_get_authoring_client_is_exported_and_callable() -> None:
+    """The factory must live on ``ax_cli.config`` so command modules can
+    import it from the public surface."""
+    assert hasattr(ax_config, "get_authoring_client"), (
+        "ax_cli.config.get_authoring_client is missing. The migration in "
+        "#142 introduced this as the single entry point for credential "
+        "resolution; every migrated module imports it."
+    )
+    assert callable(ax_config.get_authoring_client)
+
+
+# ---- Test 2: get_client preserved for backwards compatibility ---------------
+
+
+def test_get_client_preserved_in_config() -> None:
+    """Issue #142 explicitly required ``get_client`` not be renamed or
+    removed. Legacy callers (and ``get_authoring_client`` itself, on the
+    fallback path) still reach for it."""
+    assert hasattr(ax_config, "get_client"), (
+        "ax_cli.config.get_client was removed. The issue requires it stay "
+        "as a public function for backwards compatibility — get_authoring_"
+        "client falls through to it on the non-brokered path."
+    )
+    assert callable(ax_config.get_client)
+
+
+# ---- Test 3: no migrated module calls get_client() directly -----------------
+
+
+@pytest.mark.parametrize("module_name", MIGRATED_MODULES)
+def test_migrated_module_does_not_call_get_client_directly(module_name: str) -> None:
+    """Hard contract: every credential-resolution call site in a migrated
+    module must go through ``get_authoring_client()``.
+
+    Catches the easy regression where a new command lands on main with
+    ``client = get_client()`` and silently breaks in Gateway-brokered
+    shells (which is the exact failure mode that motivated #142).
+    """
+    tree = _parse(module_name)
+    hits = _direct_calls(tree, "get_client")
+    assert not hits, (
+        f"ax_cli/commands/{module_name}.py calls get_client() directly at "
+        f"line(s) {hits}. Use get_authoring_client() instead so the call "
+        f"resolves correctly in Gateway-brokered shells."
+    )
+
+
+# ---- Test 4: every migrated module uses get_authoring_client() --------------
+
+
+@pytest.mark.parametrize("module_name", MIGRATED_MODULES)
+def test_migrated_module_uses_get_authoring_client(module_name: str) -> None:
+    """Positive lock: each migrated module must contain at least one
+    call to ``get_authoring_client()``.
+
+    Without this, a future refactor could quietly remove the factory
+    call from a module entirely (e.g. by inlining a different resolver)
+    and the negative test above wouldn't catch it.
+    """
+    tree = _parse(module_name)
+    hits = _direct_calls(tree, "get_authoring_client")
+    assert hits, (
+        f"ax_cli/commands/{module_name}.py does not call "
+        f"get_authoring_client(). Every migrated module is expected to "
+        f"resolve its CLI client through this factory."
+    )
+
+
+# ---- Test 5: gateway.py keeps the lazy-import targets alive -----------------
+
+
+def test_gateway_command_module_exposes_lazy_import_targets() -> None:
+    """``get_authoring_client()`` lazy-imports two helpers from
+    ``ax_cli.commands.gateway`` to break the otherwise-circular module
+    graph. If either symbol is renamed or removed, the factory raises
+    at first call instead of at import time, which is much harder to
+    debug.
+
+    Lock the names at the module's top-level surface.
+    """
+    from ax_cli.commands import gateway as gateway_cmd
+
+    assert hasattr(gateway_cmd, "_load_gateway_user_client"), (
+        "ax_cli.commands.gateway._load_gateway_user_client is missing. "
+        "get_authoring_client() reaches for it via lazy import to load "
+        "the bootstrap-user client; renaming it breaks brokered shells."
+    )
+    assert hasattr(gateway_cmd, "_load_managed_agent_client"), (
+        "ax_cli.commands.gateway._load_managed_agent_client is missing. "
+        "get_authoring_client() reaches for it via lazy import to load "
+        "a managed-agent client; renaming it breaks brokered shells."
+    )
+    assert callable(gateway_cmd._load_gateway_user_client)
+    assert callable(gateway_cmd._load_managed_agent_client)

--- a/tests/test_avatar_day.py
+++ b/tests/test_avatar_day.py
@@ -100,7 +100,7 @@ def test_build_avatar_data_uri_from_file_png(tmp_path):
 
 def test_update_avatar_url_flag_passes_through(monkeypatch, tmp_path):
     fake = _FakeClient(_RecordingHttp())
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     small_uri = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
     assert len(small_uri) <= AVATAR_URL_MAX_LENGTH
@@ -112,7 +112,7 @@ def test_update_avatar_url_flag_passes_through(monkeypatch, tmp_path):
 
 def test_update_avatar_file_flag_reads_and_encodes(monkeypatch, tmp_path):
     fake = _FakeClient(_RecordingHttp())
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     svg = b'<svg xmlns="http://www.w3.org/2000/svg"/>'
     f = tmp_path / "a.svg"
@@ -143,7 +143,7 @@ def test_update_avatar_mutually_exclusive(monkeypatch):
 
 def test_update_avatar_file_rejected_over_cap(monkeypatch, tmp_path):
     fake = _FakeClient(_RecordingHttp())
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     big = tmp_path / "big.svg"
     big.write_bytes(b"x" * 4096)  # > cap when encoded
@@ -160,7 +160,7 @@ def test_update_avatar_file_rejected_over_cap(monkeypatch, tmp_path):
 def test_avatar_set_uses_put_not_patch(monkeypatch):
     http = _RecordingHttp(status_code=200, response_json={"id": "agent-1", "name": "axolotl"})
     fake = _FakeClient(http)
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     # Provide a tiny in-process avatar generator to avoid drawing a real SVG
     tiny_svg = b"<svg/>"
@@ -189,7 +189,7 @@ def test_avatar_set_uses_put_not_patch(monkeypatch):
 def test_avatar_set_rejects_oversized_uri(monkeypatch):
     http = _RecordingHttp()
     fake = _FakeClient(http)
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     monkeypatch.setattr("ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>")
     # Intentionally produce an over-cap data URI
@@ -217,7 +217,7 @@ def test_update_prints_effective_config_to_stderr(monkeypatch):
     """The config preamble MUST land on stderr so --json consumers and
     pipes don't see it. See friction §2 + PR #65 review."""
     fake = _FakeClient(_RecordingHttp())
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     result = split_runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi"])
     assert result.exit_code == 0, result.stderr
@@ -232,7 +232,7 @@ def test_avatar_set_prints_effective_config_to_stderr(monkeypatch):
     """Same stderr invariant for `ax agents avatar --set`."""
     http = _RecordingHttp(status_code=200, response_json={"id": "agent-1", "name": "axolotl"})
     fake = _FakeClient(http)
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
     monkeypatch.setattr("ax_cli.avatar.generate_avatar", lambda *a, **k: "<svg/>")
     small = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
     monkeypatch.setattr("ax_cli.avatar.avatar_data_uri", lambda *a, **k: small)
@@ -249,7 +249,7 @@ def test_update_json_stdout_is_clean_of_config_preamble(monkeypatch):
     import json as _json
 
     fake = _FakeClient(_RecordingHttp())
-    monkeypatch.setattr(agents_cmd, "get_client", lambda: fake)
+    monkeypatch.setattr(agents_cmd, "get_authoring_client", lambda: fake)
 
     result = split_runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi", "--json"])
     assert result.exit_code == 0, result.stderr

--- a/tests/test_context_commands.py
+++ b/tests/test_context_commands.py
@@ -57,7 +57,7 @@ def test_context_download_uses_base_url_and_auth_headers(monkeypatch, tmp_path):
             calls["params"] = params
             return FakeResponse()
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr(context.httpx, "Client", FakeHttpClient)
 
@@ -115,7 +115,7 @@ def test_context_download_rejects_html_shell_for_binary_payload(monkeypatch, tmp
         def get(self, url, params=None):
             return FakeResponse()
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr(context.httpx, "Client", FakeHttpClient)
 
@@ -173,7 +173,7 @@ def test_context_load_fetches_to_preview_cache(monkeypatch, tmp_path):
             calls["params"] = params
             return FakeResponse()
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr(context.httpx, "Client", FakeHttpClient)
 
@@ -235,7 +235,7 @@ def test_context_load_can_include_text_content(monkeypatch, tmp_path):
         def get(self, url, params=None):
             return FakeResponse()
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr(context.httpx, "Client", FakeHttpClient)
 
@@ -297,7 +297,7 @@ def test_context_upload_file_vault_stores_context_before_promote(monkeypatch, tm
             }
             return {"status": "created", "key": key}
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -342,7 +342,7 @@ def test_context_upload_file_mention_sends_context_signal(monkeypatch, tmp_path)
             calls["message"] = {"space_id": space_id, "content": content}
             return {"id": "msg-1"}
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -369,7 +369,7 @@ def test_context_set_mention_sends_context_signal(monkeypatch):
             calls["message"] = {"space_id": space_id, "content": content}
             return {"id": "msg-1"}
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -410,7 +410,7 @@ def test_context_fetch_url_upload_stores_renderable_file_upload(monkeypatch):
             calls["context"] = {"space_id": space_id, "key": key, "value": value, "ttl": ttl}
             return {"status": "stored"}
 
-    monkeypatch.setattr(context, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(context, "get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr(context, "resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr(context.httpx, "get", lambda *args, **kwargs: FakeResponse())
 

--- a/tests/test_context_promote.py
+++ b/tests/test_context_promote.py
@@ -39,7 +39,7 @@ class _FakeClient:
 
 
 def _install(monkeypatch, client):
-    monkeypatch.setattr("ax_cli.commands.context.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.context.get_authoring_client", lambda: client)
     monkeypatch.setattr(
         "ax_cli.commands.context.resolve_space_id",
         lambda c, explicit=None: explicit or "space-default",

--- a/tests/test_credentials_commands.py
+++ b/tests/test_credentials_commands.py
@@ -61,7 +61,7 @@ def test_credentials_audit_json_reports_rotation_and_cleanup(monkeypatch):
                 _credential("agent-cleanup", "cleanup-3"),
             ]
 
-    monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.credentials.get_authoring_client", lambda: FakeClient())
 
     result = runner.invoke(app, ["credentials", "audit", "--json"])
 
@@ -77,7 +77,7 @@ def test_credentials_audit_strict_fails_only_for_cleanup_required(monkeypatch):
         def mgmt_list_credentials(self):
             return [_credential("agent-rotate", "rotate-1"), _credential("agent-rotate", "rotate-2")]
 
-    monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: RotationWindowClient())
+    monkeypatch.setattr("ax_cli.commands.credentials.get_authoring_client", lambda: RotationWindowClient())
 
     rotation_result = runner.invoke(app, ["credentials", "audit", "--strict", "--json"])
     assert rotation_result.exit_code == 0, rotation_result.output
@@ -90,7 +90,7 @@ def test_credentials_audit_strict_fails_only_for_cleanup_required(monkeypatch):
                 _credential("agent-cleanup", "cleanup-3"),
             ]
 
-    monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: CleanupClient())
+    monkeypatch.setattr("ax_cli.commands.credentials.get_authoring_client", lambda: CleanupClient())
 
     cleanup_result = runner.invoke(app, ["credentials", "audit", "--strict", "--json"])
     assert cleanup_result.exit_code == 2, cleanup_result.output

--- a/tests/test_doctor_probe_and_recovery.py
+++ b/tests/test_doctor_probe_and_recovery.py
@@ -251,7 +251,7 @@ def test_tasks_list_json_does_not_leak_axp_in_stdout(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["tasks", "list", "--json"])

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -195,7 +195,7 @@ def test_handoff_loop_repeats_until_completion_promise(monkeypatch):
         {"id": "reply-2", "content": "<promise>DONE</promise>", "display_name": "demo-agent"},
     ]
 
-    monkeypatch.setattr("ax_cli.commands.handoff.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.handoff.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.handoff.uuid.uuid4", lambda: type("UUID", (), {"hex": "abc123456789"})())
@@ -250,7 +250,7 @@ def test_handoff_loop_stops_at_max_rounds_without_promise(monkeypatch):
         {"id": "reply-2", "content": "round two", "display_name": "demo-agent"},
     ]
 
-    monkeypatch.setattr("ax_cli.commands.handoff.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.handoff.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.handoff._wait_for_handoff_reply", lambda *args, **kwargs: replies.pop(0))
@@ -287,7 +287,7 @@ def test_handoff_loop_timeout_after_progress_uses_loop_timeout_status(monkeypatc
 
     replies = [{"id": "reply-1", "content": "round one", "display_name": "demo-agent"}, None]
 
-    monkeypatch.setattr("ax_cli.commands.handoff.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.handoff.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.handoff._wait_for_handoff_reply", lambda *args, **kwargs: replies.pop(0))
@@ -334,7 +334,7 @@ def test_handoff_default_adaptive_wait_queues_when_probe_times_out(monkeypatch):
         wait_calls.append(kwargs)
         return None
 
-    monkeypatch.setattr("ax_cli.commands.handoff.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.handoff.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.handoff._wait_for_handoff_reply", fake_wait)
@@ -376,7 +376,7 @@ def test_handoff_default_adaptive_wait_continues_when_probe_replies(monkeypatch)
         {"id": "handoff-reply", "content": "reviewed", "display_name": "demo-agent"},
     ]
 
-    monkeypatch.setattr("ax_cli.commands.handoff.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.handoff.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr("ax_cli.commands.handoff._wait_for_handoff_reply", lambda *args, **kwargs: replies.pop(0))
@@ -407,7 +407,7 @@ def test_handoff_no_adaptive_wait_skips_contact_probe(monkeypatch):
             calls["messages"].append({"space_id": space_id, "content": content, "parent_id": parent_id})
             return {"message": {"id": message_id}}
 
-    monkeypatch.setattr("ax_cli.commands.handoff.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.handoff.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.handoff.resolve_agent_name", lambda client=None: "ChatGPT")
     monkeypatch.setattr(

--- a/tests/test_heartbeat_commands.py
+++ b/tests/test_heartbeat_commands.py
@@ -36,7 +36,7 @@ class _FakeClient:
 
 
 def _install_runtime(monkeypatch, client: _FakeClient) -> None:
-    monkeypatch.setattr("ax_cli.commands.heartbeat.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.heartbeat.get_authoring_client", lambda: client)
     monkeypatch.setattr("ax_cli.commands.heartbeat.resolve_agent_name", lambda client=None: "orion")
 
 
@@ -105,7 +105,7 @@ def test_send_skip_push_records_local_only(monkeypatch, tmp_path):
         def send_heartbeat(self, *_a, **_kw):
             raise AssertionError("should not be called when --skip-push")
 
-    monkeypatch.setattr("ax_cli.commands.heartbeat.get_client", lambda: _ExplodingClient())
+    monkeypatch.setattr("ax_cli.commands.heartbeat.get_authoring_client", lambda: _ExplodingClient())
     monkeypatch.setattr("ax_cli.commands.heartbeat.resolve_agent_name", lambda client=None: "orion")
 
     store_file = tmp_path / "heartbeats.json"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -62,7 +62,7 @@ def test_send_file_stores_context_and_includes_context_key(monkeypatch, tmp_path
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
 
@@ -137,7 +137,9 @@ def test_send_uses_gateway_native_identity_without_space_override(monkeypatch):
     )
     monkeypatch.setattr("ax_cli.commands.messages._local_process_fingerprint", lambda **kwargs: {"fingerprint": "fp"})
     monkeypatch.setattr("ax_cli.commands.messages.httpx.post", fake_post)
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: (_ for _ in ()).throw(AssertionError("direct client")))
+    monkeypatch.setattr(
+        "ax_cli.commands.messages.get_authoring_client", lambda: (_ for _ in ()).throw(AssertionError("direct client"))
+    )
 
     result = runner.invoke(app, ["send", "hello from backend", "--no-wait", "--json"])
 
@@ -247,7 +249,7 @@ def test_messages_list_shows_short_ids_but_json_keeps_full_ids(monkeypatch):
                 ]
             }
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
 
     table_result = runner.invoke(app, ["messages", "list"])
@@ -286,7 +288,7 @@ def test_messages_list_can_request_unread_and_mark_read(monkeypatch):
                 "marked_read_count": 1,
             }
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["messages", "list", "--unread", "--mark-read"])
@@ -311,8 +313,10 @@ def test_messages_list_accepts_space_slug_alias(monkeypatch):
             calls["space_id"] = space_id
             return {"messages": []}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
-    monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: f"resolved:{explicit}")
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
+    monkeypatch.setattr(
+        "ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: f"resolved:{explicit}"
+    )
 
     result = runner.invoke(app, ["messages", "list", "--space", "ax-cli-dev", "--json"])
 
@@ -330,8 +334,10 @@ def test_send_accepts_space_slug_alias(monkeypatch):
             calls["message"] = {"space_id": space_id, "content": content}
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
-    monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: f"resolved:{explicit}")
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
+    monkeypatch.setattr(
+        "ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: f"resolved:{explicit}"
+    )
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
 
     result = runner.invoke(app, ["send", "checkpoint", "--space", "ax-cli-dev", "--no-wait", "--json"])
@@ -351,7 +357,7 @@ def test_messages_read_marks_single_message(monkeypatch):
             calls["message_id"] = message_id
             return {"status": "success", "message_id": message_id}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["messages", "read", "12345678", "--json"])
@@ -368,7 +374,7 @@ def test_messages_read_all_marks_space_read(monkeypatch):
             calls["all"] = True
             return {"status": "success", "marked_read": 2}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
 
     result = runner.invoke(app, ["messages", "read", "--all", "--json"])
 
@@ -415,7 +421,7 @@ def test_messages_get_resolves_short_id_prefix(monkeypatch):
             calls["get_id"] = requested_id
             return {"id": requested_id, "content": "hello"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["messages", "get", "12345678", "--json"])
@@ -448,7 +454,7 @@ def test_messages_send_resolves_short_parent_id(monkeypatch):
             }
             return {"id": "reply-message-id"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
 
@@ -489,7 +495,7 @@ def test_send_to_prepends_missing_mention(monkeypatch):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
 
@@ -515,7 +521,7 @@ def test_send_ask_ax_prepends_ax_mention(monkeypatch):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
 
@@ -535,7 +541,7 @@ def test_send_ask_ax_does_not_duplicate_existing_ax_mention(monkeypatch):
             calls["message"] = {"content": content}
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
 
@@ -577,7 +583,7 @@ def test_send_to_does_not_duplicate_existing_mention_and_waits_for_target(monkey
         }
         return {"id": "reply-1", "content": "ack"}
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: None)
     monkeypatch.setattr("ax_cli.commands.messages._wait_for_reply", fake_wait)
@@ -603,7 +609,7 @@ def test_send_prints_sender_identity_in_human_output(monkeypatch):
                 }
             }
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: "codex")
 
@@ -642,7 +648,7 @@ def test_send_prints_gateway_reply_note_in_human_output(monkeypatch):
             },
         }
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda client=None: "codex")
     monkeypatch.setattr("ax_cli.commands.messages._wait_for_reply", fake_wait)
@@ -737,7 +743,7 @@ def test_messages_edit_and_delete_resolve_short_id_prefix(monkeypatch):
         def delete_message(self, requested_id):
             calls["delete_id"] = requested_id
 
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda client, explicit=None: "space-1")
 
     edit_result = runner.invoke(app, ["messages", "edit", "12345678", "updated", "--json"])

--- a/tests/test_pending_reply_warning.py
+++ b/tests/test_pending_reply_warning.py
@@ -144,9 +144,7 @@ def test_print_pending_reply_warning_singular_with_one_sender(capsys):
 
 
 def test_print_pending_reply_warning_plural_with_multiple_senders(capsys):
-    print_pending_reply_warning(
-        {"count": 4, "message_ids": ["x"], "newest_senders": ["alice", "bob", "carol"]}
-    )
+    print_pending_reply_warning({"count": 4, "message_ids": ["x"], "newest_senders": ["alice", "bob", "carol"]})
     flat = " ".join(_strip_ansi(capsys.readouterr().out).split())
     assert "4 pending replies" in flat
     assert "newest from @alice" in flat
@@ -212,7 +210,7 @@ class _FakeSendClient:
 
 
 def _patch_send_client(monkeypatch, fake_client):
-    monkeypatch.setattr("ax_cli.commands.messages.get_client", lambda: fake_client)
+    monkeypatch.setattr("ax_cli.commands.messages.get_authoring_client", lambda: fake_client)
     monkeypatch.setattr("ax_cli.commands.messages.resolve_gateway_config", lambda: None)
     monkeypatch.setattr("ax_cli.commands.messages.resolve_space_id", lambda *a, **kw: "space-1")
     monkeypatch.setattr("ax_cli.commands.messages.resolve_agent_name", lambda **kw: "cli_god")

--- a/tests/test_qa_contracts.py
+++ b/tests/test_qa_contracts.py
@@ -96,7 +96,7 @@ def _json_output(result):
 
 def test_contract_smoke_read_only_passes_explicit_space_to_api_reads(monkeypatch):
     fake = FakeClient()
-    monkeypatch.setattr(qa, "get_client", lambda: fake)
+    monkeypatch.setattr(qa, "get_authoring_client", lambda: fake)
     monkeypatch.setattr(qa, "resolve_space_id", lambda client, explicit=None: explicit or "space-1")
 
     result = runner.invoke(app, ["qa", "contracts", "--json"])
@@ -165,7 +165,7 @@ def test_contract_smoke_env_requires_space_when_named_login_is_ambiguous(monkeyp
 
 def test_contract_smoke_write_roundtrip_sets_gets_and_deletes_context(monkeypatch):
     fake = FakeClient()
-    monkeypatch.setattr(qa, "get_client", lambda: fake)
+    monkeypatch.setattr(qa, "get_authoring_client", lambda: fake)
     monkeypatch.setattr(qa, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(app, ["qa", "contracts", "--write", "--json"])
@@ -183,7 +183,7 @@ def test_contract_smoke_upload_can_emit_context_backed_message(monkeypatch, tmp_
     sample = tmp_path / "probe.md"
     sample.write_text("# Probe\n")
     fake = FakeClient()
-    monkeypatch.setattr(qa, "get_client", lambda: fake)
+    monkeypatch.setattr(qa, "get_authoring_client", lambda: fake)
     monkeypatch.setattr(qa, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -257,7 +257,7 @@ def test_preflight_writes_ci_artifact(monkeypatch, tmp_path):
 
 def test_widgets_generates_current_signal_fixture_contract(monkeypatch):
     fake = FakeClient()
-    monkeypatch.setattr(qa, "get_client", lambda: fake)
+    monkeypatch.setattr(qa, "get_authoring_client", lambda: fake)
     monkeypatch.setattr(qa, "resolve_space_id", lambda client, explicit=None: explicit or "space-1")
 
     result = runner.invoke(
@@ -327,7 +327,7 @@ def test_widgets_generates_current_signal_fixture_contract(monkeypatch):
 
 def test_widgets_can_send_media_sidecar_probe(monkeypatch):
     fake = FakeClient()
-    monkeypatch.setattr(qa, "get_client", lambda: fake)
+    monkeypatch.setattr(qa, "get_authoring_client", lambda: fake)
     monkeypatch.setattr(qa, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -355,7 +355,7 @@ def test_widgets_can_attach_uploaded_evidence_to_alert_fixture(monkeypatch, tmp_
     evidence = tmp_path / "evidence.md"
     evidence.write_text("# Evidence\n")
     fake = FakeClient()
-    monkeypatch.setattr(qa, "get_client", lambda: fake)
+    monkeypatch.setattr(qa, "get_authoring_client", lambda: fake)
     monkeypatch.setattr(qa, "resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(

--- a/tests/test_reminders_commands.py
+++ b/tests/test_reminders_commands.py
@@ -42,7 +42,7 @@ class _FakeClient:
 
 
 def _install_fake_runtime(monkeypatch, client: _FakeClient) -> None:
-    monkeypatch.setattr("ax_cli.commands.reminders.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.reminders.get_authoring_client", lambda: client)
     monkeypatch.setattr(
         "ax_cli.commands.reminders.resolve_space_id",
         lambda _client, *, explicit=None: explicit or "space-abc",

--- a/tests/test_spaces_commands.py
+++ b/tests/test_spaces_commands.py
@@ -31,7 +31,7 @@ def test_spaces_use_accepts_slug_and_warns_when_bound_agent_not_attached(monkeyp
         saved["space_id"] = space_id
         saved["local"] = local
 
-    monkeypatch.setattr("ax_cli.commands.spaces.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.spaces.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.spaces.save_space_id", fake_save_space_id)
 
     result = runner.invoke(app, ["spaces", "use", "ax-cli-dev", "--json"])
@@ -60,7 +60,7 @@ def test_spaces_use_global_saves_global_config(monkeypatch):
         saved["space_id"] = space_id
         saved["local"] = local
 
-    monkeypatch.setattr("ax_cli.commands.spaces.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.spaces.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.spaces.save_space_id", fake_save_space_id)
 
     result = runner.invoke(app, ["spaces", "use", "ax-cli-dev", "--global", "--json"])

--- a/tests/test_task_loop_modes.py
+++ b/tests/test_task_loop_modes.py
@@ -42,7 +42,7 @@ class _FakeClient:
 
 
 def _install_fake_runtime(monkeypatch, client: _FakeClient) -> None:
-    monkeypatch.setattr("ax_cli.commands.reminders.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.reminders.get_authoring_client", lambda: client)
     monkeypatch.setattr(
         "ax_cli.commands.reminders.resolve_space_id",
         lambda _client, *, explicit=None: explicit or "space-abc",

--- a/tests/test_task_loop_offline.py
+++ b/tests/test_task_loop_offline.py
@@ -30,7 +30,7 @@ def test_add_works_fully_offline_with_explicit_space_id(monkeypatch, tmp_path):
     def _explode(*_a, **_kw):
         raise RuntimeError("get_client should not be called when --space-id is provided")
 
-    monkeypatch.setattr("ax_cli.commands.reminders.get_client", _explode)
+    monkeypatch.setattr("ax_cli.commands.reminders.get_authoring_client", _explode)
     monkeypatch.setattr("ax_cli.commands.reminders.resolve_space_id", _explode)
 
     result = runner.invoke(
@@ -62,7 +62,7 @@ class _ConnectErrorClient:
 
 
 def _install_offline_runtime(monkeypatch, client):
-    monkeypatch.setattr("ax_cli.commands.reminders.get_client", lambda: client)
+    monkeypatch.setattr("ax_cli.commands.reminders.get_authoring_client", lambda: client)
     monkeypatch.setattr(
         "ax_cli.commands.reminders.resolve_space_id",
         lambda _client, *, explicit=None: explicit or "space-abc",

--- a/tests/test_tasks_commands.py
+++ b/tests/test_tasks_commands.py
@@ -30,7 +30,7 @@ def test_tasks_create_assign_accepts_agent_handle(monkeypatch):
             }
             return {"task": {"id": "task-1", "title": title, "assignee_id": assignee_id, "priority": priority}}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -59,7 +59,7 @@ def test_tasks_create_accepts_space_slug(monkeypatch):
             calls["create_task"] = {"space_id": space_id, "title": title}
             return {"task": {"id": "task-1", "title": title, "priority": priority}}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
 
     result = runner.invoke(
         app,
@@ -144,7 +144,7 @@ def test_tasks_create_human_output_includes_resolved_space(monkeypatch):
         def create_task(self, space_id, title, *, description=None, priority="medium", assignee_id=None):
             return {"task": {"id": "task-1", "title": title, "priority": priority}}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
 
     result = runner.invoke(
         app,
@@ -168,7 +168,7 @@ def test_tasks_create_assign_to_accepts_uuid_without_agent_lookup(monkeypatch):
             calls["create_task"] = {"assignee_id": assignee_id}
             return {"task": {"id": "task-1", "title": title, "assignee_id": assignee_id}}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -186,7 +186,7 @@ def test_tasks_create_assign_unknown_handle_fails(monkeypatch):
         def list_agents(self, *, space_id=None, limit=None):
             return {"agents": [{"id": "agent-456", "name": "cipher"}]}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -214,7 +214,7 @@ def test_tasks_create_mention_prefixes_notification(monkeypatch):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -253,7 +253,7 @@ def test_tasks_create_assign_handle_mentions_assignee_by_default(monkeypatch):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_space_id", lambda client, explicit=None: "space-1")
 
     result = runner.invoke(
@@ -287,7 +287,7 @@ def test_tasks_update_assign_to_accepts_uuid_without_lookup(monkeypatch):
             calls["update_task"] = {"task_id": task_id, "fields": fields}
             return {"id": task_id, **fields}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_gateway_config", lambda: {})
 
     result = runner.invoke(
@@ -318,7 +318,7 @@ def test_tasks_update_assign_to_resolves_handle_via_task_space(monkeypatch):
             calls["update_task"] = {"task_id": task_id, "fields": fields}
             return {"id": task_id, **fields}
 
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_gateway_config", lambda: {})
 
     result = runner.invoke(
@@ -357,7 +357,7 @@ def test_tasks_update_assign_to_rejected_on_gateway_path(monkeypatch):
 
 def test_tasks_update_requires_at_least_one_field(monkeypatch):
     monkeypatch.setattr("ax_cli.commands.tasks.resolve_gateway_config", lambda: {})
-    monkeypatch.setattr("ax_cli.commands.tasks.get_client", lambda: object())
+    monkeypatch.setattr("ax_cli.commands.tasks.get_authoring_client", lambda: object())
 
     result = runner.invoke(app, ["tasks", "update", "task-42"])
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -53,7 +53,7 @@ def test_upload_file_passes_resolved_space_to_upload_api(monkeypatch, tmp_path):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.upload.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.upload.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.upload.resolve_space_id", lambda client: "space-1")
 
     result = runner.invoke(
@@ -102,7 +102,7 @@ def test_upload_file_no_message_still_stores_context(monkeypatch, tmp_path):
             calls["message"] = {"space_id": space_id, "content": content, "attachments": attachments}
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.upload.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.upload.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.upload.resolve_space_id", lambda client: "space-1")
 
     result = runner.invoke(
@@ -146,7 +146,7 @@ def test_upload_file_quiet_still_stores_context_without_message(monkeypatch, tmp
             calls["message"] = {"space_id": space_id, "content": content, "attachments": attachments}
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.upload.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.upload.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.upload.resolve_space_id", lambda client: "space-1")
 
     result = runner.invoke(app, ["upload", "file", str(sample), "--quiet"])
@@ -193,7 +193,7 @@ def test_upload_file_vault_stores_context_before_promote(monkeypatch, tmp_path):
             }
             return {"id": "msg-1"}
 
-    monkeypatch.setattr("ax_cli.commands.upload.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.upload.get_authoring_client", lambda: FakeClient())
     monkeypatch.setattr("ax_cli.commands.upload.resolve_space_id", lambda client: "space-1")
 
     result = runner.invoke(


### PR DESCRIPTION
## Summary

Implements Phase 3 of #142: introduces `get_authoring_client()` as the single entry point for resolving a credential-bearing `AxClient`, and migrates the 67 `get_client()` call sites across 19 command modules to use it.

The factory resolves the invoking principal in two paths:

1. **Gateway-brokered workspace** (`[gateway]` + `[agent]` blocks in `.ax/config.toml`, registry has the agent): returns the managed-agent client via the registry's token file. No local PAT required.
2. **Non-brokered workspace**: falls through to the existing `get_client()` resolver, which reads a local PAT from config / env. `get_client` is preserved as a public function for backwards compatibility, per the issue.

**User-visible unblock**: commands that lacked a Gateway-aware branch (notably `ax keys list / create / delete`) previously failed in Gateway-brokered shells because `get_client()` requires a local PAT. They now resolve the managed-agent client via the registry and succeed without one.

Modules migrated (19): `agents, alerts, apps, auth, channel, context, credentials, events, handoff, heartbeat, keys, listen, messages, qa, reminders, spaces, tasks, upload, watch`.

## What this PR does NOT do

To keep the diff focused, several patterns from the issue's smoke-test bullet are intentionally left for follow-up. The exemptions are documented in `tests/test_authoring_client_migration.py` so reviewers can tell deferred work from oversight at a glance:

- **`commands/gateway.py` is not migrated.** It defines and legitimately uses `_load_gateway_user_client` and `_load_managed_agent_client(entry)` for explicit-identity operations (`gateway login`, `gateway agents add`, `gateway agents send <name>`). These resolve identities other than the invoking principal and are out of scope for the factory.
- **`commands/auth.py` retains four `AxClient(...)` constructions** plus one `_gateway_local_call(method="whoami")` for credential probing (`whoami` against explicit token candidates). Different operation from "give me a client for the invoking principal."
- **`commands/qa.py` retains one `AxClient(...)`** for the QA test-environment auth flow.
- **`messages.py / tasks.py / agents.py / context.py / spaces.py`** still dispatch through `_gateway_local_call` inside their `if gateway_cfg:` branches. Collapsing those branches is restructural (it removes the daemon-proxy intermediate hop and changes wire-level behavior in brokered shells) and is worth a separate review.

## Commits

1. `feat(config): introduce get_authoring_client() factory` — adds the factory in `ax_cli/config.py` plus 4 behavioral tests in `tests/test_authoring_client.py` (brokered, non-brokered, no-credential error path, `get_client` backwards-compat).
2. `refactor(commands): migrate call sites to get_authoring_client` — swaps all 67 call sites across the 19 modules and updates 23 test files that monkey-patch `<module>.get_client`.
3. `test(config): lock get_authoring_client migration with smoke regression` — adds `tests/test_authoring_client_migration.py` with 41 parametrized structural assertions: factory exists, `get_client` preserved, no migrated module calls `get_client()` directly, every migrated module uses `get_authoring_client()`, and `commands/gateway.py` continues to expose the two helpers the factory lazy-imports.

## Validation

- `pytest tests/test_authoring_client.py` — 4/4 green
- `pytest tests/test_authoring_client_migration.py` — 41/41 green
- `pytest tests/test_tasks_commands.py tests/test_agents_commands.py
  tests/test_messages.py tests/test_context_commands.py
  tests/test_spaces_commands.py tests/test_auth_commands.py
  tests/test_alerts_commands.py tests/test_credentials_commands.py
  tests/test_reminders_commands.py tests/test_heartbeat_commands.py
  tests/test_apps_commands.py tests/test_handoff.py tests/test_upload.py
  tests/test_qa_contracts.py tests/test_avatar_day.py` — 244/244 green
- `ruff check ax_cli/ tests/` clean
- `ruff format --check` clean for all touched files
- 22 pre-existing failures on clean `main` remain (Windows-specific TOML escape / file-mode / path separator issues unrelated to this PR); please run on review env.

## Release Notes

- [x] This should appear in the changelog (`refactor:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [ ] No token, profile, PAT, JWT, or agent identity behavior changed
- [x] Auth behavior changed and the docs/tests were updated

Part of #142.