### PR TITLE
feat(gateway): reliability + cleanup UI stack

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1412,6 +1412,62 @@ def _hide_managed_agents(names: list[str], *, reason: str = "operator_cleanup") 
     }
 
 
+def _restore_hidden_managed_agents(names: list[str]) -> dict:
+    """Symmetric inverse of _hide_managed_agents.
+
+    Clears lifecycle_phase=hidden + hide bookkeeping, restores desired_state
+    to whatever the operator-driven hide had captured (desired_state_before_hide).
+    Refuses to restore agents that are not in the hidden phase — the
+    archived phase has its own restore path (PR #147), and "active" agents
+    don't need restoration.
+    """
+    normalized_names: list[str] = []
+    seen: set[str] = set()
+    for raw_name in names:
+        name = str(raw_name or "").strip()
+        key = name.lower()
+        if not name or key in seen:
+            continue
+        normalized_names.append(name)
+        seen.add(key)
+    if not normalized_names:
+        raise ValueError("Choose at least one managed agent to restore.")
+
+    registry = load_gateway_registry()
+    restored: list[dict] = []
+    missing: list[str] = []
+    not_hidden: list[str] = []
+    for name in normalized_names:
+        entry = find_agent_entry(registry, name)
+        if not entry:
+            missing.append(name)
+            continue
+        if str(entry.get("lifecycle_phase") or "") != "hidden":
+            not_hidden.append(name)
+            continue
+        prior = str(entry.get("desired_state_before_hide") or "").strip() or "running"
+        entry["lifecycle_phase"] = "active"
+        entry["desired_state"] = prior
+        entry.pop("desired_state_before_hide", None)
+        entry.pop("hidden_at", None)
+        entry.pop("hidden_reason", None)
+        restored.append(entry)
+
+    save_gateway_registry(registry)
+    for entry in restored:
+        record_gateway_activity(
+            "managed_agent_unhidden",
+            entry=entry,
+            operator_action=True,
+        )
+    return {
+        "count": len(restored),
+        "missing": missing,
+        "not_hidden": not_hidden,
+        "restored": [annotate_runtime_health(entry, registry=registry) for entry in restored],
+    }
+
+
 def _build_session_client_silent() -> AxClient | None:
     """Build a user-PAT session client without raising. Returns None when
     the gateway is not logged in or the session token is missing/invalid.
@@ -5001,6 +5057,18 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         [str(name or "").strip() for name in raw_names],
                         reason=str(body.get("reason") or "operator_cleanup"),
                     )
+                    _write_json_response(self, payload)
+                    return
+                if parsed.path == "/api/agents/cleanup-restore":
+                    raw_names = body.get("names")
+                    if not isinstance(raw_names, list):
+                        _write_json_response(
+                            self,
+                            {"error": "names must be a list of managed agent names"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    payload = _restore_hidden_managed_agents([str(name or "").strip() for name in raw_names])
                     _write_json_response(self, payload)
                     return
                 if parsed.path == "/local/connect":

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1473,6 +1473,127 @@ def _restore_hidden_managed_agents(names: list[str]) -> dict:
     }
 
 
+def _read_recovery_evidence(name: str) -> dict | None:
+    """Reconstruct a minimal registry row for an agent from local evidence.
+
+    Used when a managed_agent_added activity event was recorded but the
+    registry row was lost (pre-race-fix damage). Reads from three sources,
+    all verifiable:
+
+    - Activity log: most recent managed_agent_added for ``name`` →
+      agent_id, asset_id, install_id, gateway_id, runtime_type,
+      transport, space_id, token_file, credential_source, ts.
+    - Token directory: ``~/.ax/gateway/agents/<name>/token`` must exist
+      (we don't fabricate credentials).
+    - Workdir ``.ax/AGENT_CONTEXT.md`` if present, for the workdir hint.
+
+    Returns None if no managed_agent_added event is recorded or the
+    token file is missing — both required for a safe recovery.
+    """
+    target_event: dict | None = None
+    activity_path = activity_log_path()
+    try:
+        with activity_path.open(encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    ev = json.loads(line)
+                except (ValueError, json.JSONDecodeError):
+                    continue
+                if ev.get("agent_name") != name or ev.get("event") != "managed_agent_added":
+                    continue
+                target_event = ev  # later writes win — pick the most recent
+    except OSError:
+        return None
+    if not isinstance(target_event, dict):
+        return None
+    token_file = str(target_event.get("token_file") or "").strip()
+    if not token_file or not Path(token_file).is_file():
+        return None
+    return target_event
+
+
+def _recover_managed_agents_from_evidence(names: list[str]) -> dict:
+    """Recover registry rows for agents present locally (token + activity)
+    but absent from registry.json (pre-race-fix row loss).
+
+    Refuses to recover agents that are already in the registry — use
+    archive/restore or hide/unhide for state changes on existing rows.
+    The reconstructed row is minimal: enough fields for the daemon to
+    pick it up on next reconcile and hydrate the rest from upstream.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in names:
+        n = str(raw or "").strip()
+        if not n or n.lower() in seen:
+            continue
+        normalized.append(n)
+        seen.add(n.lower())
+    if not normalized:
+        raise ValueError("Choose at least one agent to recover.")
+
+    registry = load_gateway_registry()
+    recovered: list[dict] = []
+    already_present: list[str] = []
+    no_evidence: list[str] = []
+
+    for name in normalized:
+        if find_agent_entry(registry, name) is not None:
+            already_present.append(name)
+            continue
+        evidence = _read_recovery_evidence(name)
+        if evidence is None:
+            no_evidence.append(name)
+            continue
+        # Build minimal row — sourced fields only.
+        entry: dict = {
+            "name": name,
+            "agent_id": str(evidence.get("agent_id") or "").strip(),
+            "asset_id": str(evidence.get("asset_id") or evidence.get("agent_id") or "").strip(),
+            "install_id": str(evidence.get("install_id") or "").strip(),
+            "gateway_id": str(evidence.get("gateway_id") or "").strip(),
+            "runtime_type": str(evidence.get("runtime_type") or "").strip(),
+            "transport": str(evidence.get("transport") or "gateway").strip(),
+            "credential_source": str(evidence.get("credential_source") or "gateway").strip(),
+            "token_file": str(evidence.get("token_file") or "").strip(),
+            "space_id": str(evidence.get("space_id") or "").strip(),
+            "added_at": str(evidence.get("ts") or "").strip(),
+            "lifecycle_phase": "active",
+            "desired_state": "stopped",  # safe default — operator restarts deliberately
+            "drift_reason": "registry_row_recovered_from_evidence",
+        }
+        # Pick a sensible template_id from runtime_type; daemon hydrates from
+        # upstream on reconcile.
+        rt = entry["runtime_type"]
+        if rt == "claude_code_channel":
+            entry["template_id"] = "claude_code_channel"
+            entry["template_label"] = "Claude Code Channel"
+        elif rt == "hermes_sentinel":
+            entry["template_id"] = "hermes"
+            entry["template_label"] = "Hermes"
+        elif rt == "inbox":
+            entry["template_id"] = "pass_through"
+            entry["template_label"] = "Pass-through"
+        registry.setdefault("agents", []).append(entry)
+        recovered.append(entry)
+
+    save_gateway_registry(registry)
+    for entry in recovered:
+        record_gateway_activity(
+            "managed_agent_recovered",
+            entry=entry,
+            operator_action=True,
+            recovery_source="local_evidence",
+        )
+
+    return {
+        "count": len(recovered),
+        "already_present": already_present,
+        "no_evidence": no_evidence,
+        "recovered": [annotate_runtime_health(entry, registry=registry) for entry in recovered],
+    }
+
+
 def _build_session_client_silent() -> AxClient | None:
     """Build a user-PAT session client without raising. Returns None when
     the gateway is not logged in or the session token is missing/invalid.
@@ -5126,6 +5247,22 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                     payload = _restore_hidden_managed_agents([str(name or "").strip() for name in raw_names])
                     _write_json_response(self, payload)
                     return
+                if parsed.path == "/api/agents/recover":
+                    raw_names = body.get("names")
+                    if not isinstance(raw_names, list):
+                        _write_json_response(
+                            self,
+                            {"error": "names must be a list of managed agent names"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    try:
+                        payload = _recover_managed_agents_from_evidence([str(name or "").strip() for name in raw_names])
+                    except ValueError as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                        return
+                    _write_json_response(self, payload)
+                    return
                 if parsed.path == "/local/connect":
                     agent_name = str(body.get("agent_name") or body.get("name") or "").strip()
                     registry_ref = str(
@@ -7582,6 +7719,46 @@ def restore_agent(
     for name in not_found:
         err_console.print(f"[red]Managed agent not found:[/red] {name}")
     if not restored and not_found:
+        raise typer.Exit(1)
+
+
+@agents_app.command("recover")
+def recover_agents(
+    names: list[str] = typer.Argument(..., help="One or more agent names whose registry rows were lost"),
+    as_json: bool = JSON_OPTION,
+):
+    """Recover registry rows from local evidence (token + activity log).
+
+    Use when a managed_agent_added event was recorded but the registry
+    row is missing — typically pre-race-fix damage. Reads the most
+    recent managed_agent_added event for each name from the activity
+    log, confirms the token file exists, and inserts a minimal row
+    with the verified fields. The daemon hydrates the rest from
+    upstream on the next reconcile pass.
+
+    Refuses to recover agents already present in the registry. Refuses
+    to recover agents lacking either the activity event or the token
+    file (we don't fabricate credentials).
+    """
+    try:
+        result = _recover_managed_agents_from_evidence(list(names))
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(2) from exc
+    if as_json:
+        print_json(result)
+        if result["count"] == 0:
+            raise typer.Exit(1)
+        return
+    for entry in result.get("recovered", []):
+        err_console.print(f"[green]Recovered:[/green] @{entry.get('name')} (agent_id={entry.get('agent_id')})")
+    for name in result.get("already_present", []):
+        err_console.print(f"[yellow]Already present:[/yellow] @{name} (no recovery needed)")
+    for name in result.get("no_evidence", []):
+        err_console.print(
+            f"[red]No recovery evidence:[/red] @{name} (need both managed_agent_added activity + token file)"
+        )
+    if result["count"] == 0 and (result.get("no_evidence") or not result.get("already_present")):
         raise typer.Exit(1)
 
 

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1270,6 +1270,83 @@ def _build_session_client_silent() -> AxClient | None:
         return None
 
 
+def _archive_managed_agent(name: str, *, reason: str | None = None, client_factory=None) -> dict:
+    """Archive a managed agent. Sticky — sweep won't auto-restore.
+
+    Sets `lifecycle_phase=archived` and `desired_state=stopped` so the daemon
+    reconciler stops the runtime. Captures `desired_state_before_archive` so
+    `restore` can put it back. Best-effort upstream signal `archived`. The
+    local registry is authoritative; upstream failure is logged, never fatal.
+    """
+    registry = load_gateway_registry()
+    entry = find_agent_entry(registry, name)
+    if not entry:
+        raise LookupError(f"Managed agent not found: {name}")
+    if str(entry.get("lifecycle_phase") or "active") == "archived":
+        return annotate_runtime_health(entry, registry=registry)
+    prior_desired_state = str(entry.get("desired_state") or "running")
+    entry["lifecycle_phase"] = "archived"
+    entry["archived_at"] = _utc_now_iso()
+    if reason and str(reason).strip():
+        entry["archived_reason"] = str(reason).strip()[:240]
+    else:
+        entry.pop("archived_reason", None)
+    entry["desired_state_before_archive"] = prior_desired_state
+    entry["desired_state"] = "stopped"
+    save_gateway_registry(registry, merge_archive=False)
+    record_gateway_activity(
+        "managed_agent_archived",
+        entry=entry,
+        reason=str(reason).strip() if reason else None,
+    )
+    user_client = client_factory() if client_factory is not None else _build_session_client_silent()
+    if user_client is not None:
+        from ..gateway import _post_lifecycle_signal as _signal
+
+        try:
+            _signal(user_client, entry, phase="archived", note=str(reason or "")[:240] or None)
+        except Exception:  # noqa: BLE001
+            pass
+    return annotate_runtime_health(entry, registry=registry)
+
+
+def _restore_managed_agent(name: str, *, client_factory=None) -> dict:
+    """Restore an archived agent to active. Honors prior desired_state.
+
+    If `desired_state_before_archive` was captured at archive time, the
+    runtime restores to that state. Otherwise defaults to `stopped` (safer
+    than auto-resuming a runtime the operator may have intentionally
+    disabled). Best-effort upstream signal `connected`.
+    """
+    registry = load_gateway_registry()
+    entry = find_agent_entry(registry, name)
+    if not entry:
+        raise LookupError(f"Managed agent not found: {name}")
+    if str(entry.get("lifecycle_phase") or "active") != "archived":
+        return annotate_runtime_health(entry, registry=registry)
+    prior = str(entry.get("desired_state_before_archive") or "stopped")
+    entry["lifecycle_phase"] = "active"
+    entry.pop("archived_at", None)
+    entry.pop("archived_reason", None)
+    entry.pop("desired_state_before_archive", None)
+    entry["desired_state"] = prior if prior in {"running", "stopped"} else "stopped"
+    save_gateway_registry(registry, merge_archive=False)
+    record_gateway_activity("managed_agent_restored", entry=entry)
+    user_client = client_factory() if client_factory is not None else _build_session_client_silent()
+    if user_client is not None:
+        from ..gateway import _post_lifecycle_signal as _signal
+
+        try:
+            _signal(user_client, entry, phase="connected")
+        except Exception:  # noqa: BLE001
+            pass
+    return annotate_runtime_health(entry, registry=registry)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
 def _remove_managed_agent(name: str, *, client_factory=None) -> dict:
     registry = load_gateway_registry()
     peek = find_agent_entry(registry, name)
@@ -1610,12 +1687,18 @@ def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -
         _with_registry_refs(registry, annotate_runtime_health(agent, registry=registry))
         for agent in registry.get("agents", [])
     ]
-    # Partition out hidden + system agents so default surfaces stay tidy.
-    # System agents (switchboards, service accounts) are infrastructure
-    # plumbing; hidden agents are stale ones the daemon swept away.
+    # Partition out archived + hidden + system agents so default surfaces
+    # stay tidy. System agents (switchboards, service accounts) are
+    # infrastructure plumbing; hidden agents are stale ones the daemon swept
+    # away; archived agents are user-disabled entries that are sticky.
+    archived_agents_list = [a for a in all_agents if str(a.get("lifecycle_phase") or "active") == "archived"]
     hidden_agents_list = [a for a in all_agents if str(a.get("lifecycle_phase") or "active") == "hidden"]
     system_agents_list = [a for a in all_agents if _is_system_agent(a)]
-    visible_agents = [a for a in all_agents if a not in hidden_agents_list and a not in system_agents_list]
+    visible_agents = [
+        a
+        for a in all_agents
+        if a not in archived_agents_list and a not in hidden_agents_list and a not in system_agents_list
+    ]
     agents = all_agents if include_hidden else visible_agents
     approvals = list_gateway_approvals()
     pending_approvals = [item for item in approvals if str(item.get("status") or "") == "pending"]
@@ -1685,6 +1768,7 @@ def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -
             "blocked_agents": len(blocked_agents),
             "hidden_agents": len(hidden_agents_list),
             "system_agents": len(system_agents_list),
+            "archived_agents": len(archived_agents_list),
             "pending_approvals": len(pending_approvals),
         },
     }
@@ -6680,17 +6764,25 @@ def list_agents(
         False,
         "--all",
         "-a",
-        help="Include hidden (auto-swept stale) and system (switchboard / service-account) agents.",
+        help="Include archived, hidden (auto-swept stale), and system (switchboard / service-account) agents.",
+    ),
+    archived_only: bool = typer.Option(
+        False,
+        "--archived",
+        help="Show only archived (user-disabled) agents — the inactive section.",
     ),
 ):
     """List Gateway-managed agents."""
-    payload = _status_payload(include_hidden=show_all)
+    payload = _status_payload(include_hidden=show_all or archived_only)
     agents = payload["agents"]
+    if archived_only:
+        agents = [a for a in agents if str(a.get("lifecycle_phase") or "active") == "archived"]
     if as_json:
         print_json(
             {
                 "agents": agents,
                 "count": len(agents),
+                "archived": payload["summary"].get("archived_agents", 0),
                 "hidden": payload["summary"].get("hidden_agents", 0),
                 "system": payload["summary"].get("system_agents", 0),
             }
@@ -6701,10 +6793,14 @@ def list_agents(
         [{**agent, "type": _agent_type_label(agent), "output": _agent_output_label(agent)} for agent in agents],
         keys=["registry_ref", "name", "type", "mode", "presence", "output", "confidence", "space_id"],
     )
+    archived_n = payload["summary"].get("archived_agents", 0)
     hidden_n = payload["summary"].get("hidden_agents", 0)
     system_n = payload["summary"].get("system_agents", 0)
-    if not show_all and (hidden_n or system_n):
-        err_console.print(f"[dim]({hidden_n} hidden, {system_n} system — pass --all to include)[/dim]")
+    if not show_all and not archived_only and (archived_n or hidden_n or system_n):
+        err_console.print(
+            f"[dim]({archived_n} archived, {hidden_n} hidden, {system_n} system — "
+            "pass --all to include, --archived to show only archived)[/dim]"
+        )
 
 
 @agents_app.command("show")
@@ -7061,6 +7157,70 @@ def stop_agent(name: str = typer.Argument(..., help="Managed agent name")):
         err_console.print(f"[red]Managed agent not found:[/red] {name}")
         raise typer.Exit(1)
     err_console.print(f"[green]Desired state set to stopped:[/green] @{name}")
+
+
+@agents_app.command("archive")
+def archive_agent(
+    names: list[str] = typer.Argument(..., help="One or more managed agent names to archive"),
+    reason: str = typer.Option(None, "--reason", "-r", help="Optional note describing why this is archived"),
+    as_json: bool = JSON_OPTION,
+):
+    """Archive (disable) one or more managed agents.
+
+    Archived agents are sticky-hidden — they don't appear in default views
+    and the daemon will not auto-restore them on reconnect. Use
+    `agents restore` to bring them back.
+    """
+    archived: list[dict] = []
+    not_found: list[str] = []
+    for name in names:
+        try:
+            archived.append(_archive_managed_agent(name, reason=reason))
+        except LookupError:
+            not_found.append(name)
+    if as_json:
+        print_json({"archived": archived, "not_found": not_found, "count": len(archived)})
+        if not_found and not archived:
+            raise typer.Exit(1)
+        return
+    for entry in archived:
+        err_console.print(f"[green]Archived:[/green] @{entry.get('name')}")
+    for name in not_found:
+        err_console.print(f"[red]Managed agent not found:[/red] {name}")
+    if not archived and not_found:
+        raise typer.Exit(1)
+
+
+@agents_app.command("restore")
+def restore_agent(
+    names: list[str] = typer.Argument(..., help="One or more archived agent names to restore"),
+    as_json: bool = JSON_OPTION,
+):
+    """Restore (re-enable) one or more archived agents.
+
+    Restores `lifecycle_phase=active`. The runtime returns to the desired
+    state captured at archive time; if none was captured, defaults to
+    stopped. Start the runtime explicitly with `agents start <name>`.
+    """
+    restored: list[dict] = []
+    not_found: list[str] = []
+    for name in names:
+        try:
+            restored.append(_restore_managed_agent(name))
+        except LookupError:
+            not_found.append(name)
+    if as_json:
+        print_json({"restored": restored, "not_found": not_found, "count": len(restored)})
+        if not_found and not restored:
+            raise typer.Exit(1)
+        return
+    for entry in restored:
+        ds = str(entry.get("desired_state") or "stopped")
+        err_console.print(f"[green]Restored:[/green] @{entry.get('name')} (desired_state={ds})")
+    for name in not_found:
+        err_console.print(f"[red]Managed agent not found:[/red] {name}")
+    if not restored and not_found:
+        raise typer.Exit(1)
 
 
 @agents_app.command("remove")

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -183,6 +183,95 @@ def _load_gateway_session_or_exit() -> dict:
     return session
 
 
+# ---------------------------------------------------------------------------
+# Upstream rate-limit handling: retry with exponential backoff + structured
+# error so operator-visible flows (Connect agent modal, CLI commands) degrade
+# cleanly when paxai.app rate-limits us. Two retry budgets:
+#   - Interactive (Connect agent modal, CLI invocations): 2 retries × 1s/2s
+#     base_wait → ~3s ceiling so the operator's UI doesn't hang.
+#   - Background (reconcile loop, cache refresh): 5 retries × exponential.
+# ---------------------------------------------------------------------------
+
+INTERACTIVE_429_MAX_RETRIES = 2
+INTERACTIVE_429_BASE_WAIT = 1.0
+BACKGROUND_429_MAX_RETRIES = 5
+BACKGROUND_429_BASE_WAIT = 1.0
+
+
+class UpstreamRateLimitedError(RuntimeError):
+    """Raised when an upstream call returned 429 even after retries.
+
+    Carries the original ``httpx.HTTPStatusError`` plus a parsed
+    ``retry_after_seconds`` (from the Retry-After header, when present)
+    so callers can surface operator-actionable guidance without having
+    to re-parse the upstream response.
+    """
+
+    def __init__(self, last_exc: httpx.HTTPStatusError, retries_attempted: int) -> None:
+        self.last_exc = last_exc
+        self.retries_attempted = retries_attempted
+        retry_after: int | None = None
+        try:
+            response = last_exc.response
+            header_value = response.headers.get("retry-after") if response is not None else None
+            if header_value:
+                retry_after = int(float(header_value))
+        except (ValueError, AttributeError, TypeError):
+            retry_after = None
+        self.retry_after_seconds = retry_after
+        super().__init__(f"Upstream rate-limited after {retries_attempted} retries")
+
+
+def _with_upstream_429_retry(call, *, max_retries: int, base_wait: float = 1.0):
+    """Run ``call`` and retry on httpx 429 with exponential backoff.
+
+    Waits ``base_wait * 2**attempt`` between attempts. Other httpx
+    exceptions (4xx/5xx that aren't 429, network errors) propagate
+    immediately. After the configured retry budget is exhausted on a
+    persistent 429, raises ``UpstreamRateLimitedError`` carrying the
+    final exception and any Retry-After hint.
+    """
+    attempts = 0
+    while True:
+        try:
+            return call()
+        except httpx.HTTPStatusError as exc:
+            if exc.response is None or exc.response.status_code != 429:
+                raise
+            if attempts >= max_retries:
+                raise UpstreamRateLimitedError(exc, attempts) from exc
+            wait = base_wait * (2**attempts)
+            time.sleep(wait)
+            attempts += 1
+
+
+# Agents-list cache: serves last-good upstream response when paxai.app
+# rate-limits us, mirroring the spaces cache pattern in PR #148. The cache
+# is best-effort — write/read failures are swallowed; we never fail a
+# request because we couldn't update cache.
+
+
+def _agents_cache_path() -> Path:
+    return gateway_dir() / "agents.cache.json"
+
+
+def _load_agents_cache() -> list[dict]:
+    try:
+        raw = json.loads(_agents_cache_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    items = raw.get("agents") if isinstance(raw, dict) else raw
+    return [item for item in (items or []) if isinstance(item, dict)]
+
+
+def _save_agents_cache(agents: list[dict]) -> None:
+    payload = {"agents": agents, "saved_at": datetime.now(timezone.utc).isoformat()}
+    try:
+        _agents_cache_path().write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _save_agent_token(name: str, token: str) -> Path:
     token_path = agent_token_path(name)
     token_path.write_text(token.strip() + "\n")
@@ -813,11 +902,22 @@ def _agent_space_name_from_backend_record(agent: dict, space_id: str | None) -> 
 
 
 def _backend_agent_record(client: AxClient, name: str) -> dict | None:
+    """Look up an agent by name on the upstream backend.
+
+    Falls back to the local agents cache when upstream is unavailable
+    (e.g. paxai.app rate-limits us). Successful upstream responses
+    seed/refresh the cache so the next failure has stale-but-usable
+    data to serve.
+    """
+    agents: list[dict] = []
     try:
         agents_data = client.list_agents()
+        agents = agents_data if isinstance(agents_data, list) else (agents_data or {}).get("agents", []) or []
+        if agents:
+            _save_agents_cache([a for a in agents if isinstance(a, dict)])
     except Exception:
-        return None
-    agents = agents_data if isinstance(agents_data, list) else agents_data.get("agents", [])
+        # Upstream unavailable — fall back to last-good cache.
+        agents = _load_agents_cache()
     for agent in agents:
         if not isinstance(agent, dict):
             continue
@@ -916,30 +1016,48 @@ def _register_managed_agent(
         registry=registry,
         explicit_space_id=space_id or existing_home_space,
     )
-    existing = _find_agent_in_space(client, name, selected_space)
+    existing = _with_upstream_429_retry(
+        lambda: _find_agent_in_space(client, name, selected_space),
+        max_retries=INTERACTIVE_429_MAX_RETRIES,
+        base_wait=INTERACTIVE_429_BASE_WAIT,
+    )
     if existing:
         agent = existing
         if description or model:
-            client.update_agent(name, **{k: v for k, v in {"description": description, "model": model}.items() if v})
+            _with_upstream_429_retry(
+                lambda: client.update_agent(
+                    name, **{k: v for k, v in {"description": description, "model": model}.items() if v}
+                ),
+                max_retries=INTERACTIVE_429_MAX_RETRIES,
+                base_wait=INTERACTIVE_429_BASE_WAIT,
+            )
     else:
-        agent = _create_agent_in_space(
-            client,
-            name=name,
-            space_id=selected_space,
-            description=description,
-            model=model,
+        agent = _with_upstream_429_retry(
+            lambda: _create_agent_in_space(
+                client,
+                name=name,
+                space_id=selected_space,
+                description=description,
+                model=model,
+            ),
+            max_retries=INTERACTIVE_429_MAX_RETRIES,
+            base_wait=INTERACTIVE_429_BASE_WAIT,
         )
     _polish_metadata(client, name=name, bio=None, specialization=None, system_prompt=None)
 
     agent_id = str(agent.get("id") or agent.get("agent_id") or "")
-    token, pat_source = _mint_agent_pat(
-        client,
-        agent_id=agent_id,
-        agent_name=name,
-        audience=audience,
-        expires_in_days=90,
-        pat_name=f"gateway-{name}",
-        space_id=selected_space,
+    token, pat_source = _with_upstream_429_retry(
+        lambda: _mint_agent_pat(
+            client,
+            agent_id=agent_id,
+            agent_name=name,
+            audience=audience,
+            expires_in_days=90,
+            pat_name=f"gateway-{name}",
+            space_id=selected_space,
+        ),
+        max_retries=INTERACTIVE_429_MAX_RETRIES,
+        base_wait=INTERACTIVE_429_BASE_WAIT,
     )
     token_file = _save_agent_token(name, token)
 
@@ -4771,20 +4889,38 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                     _write_json_response(self, payload, status=status_code)
                     return
                 if parsed.path == "/api/agents":
-                    payload = _register_managed_agent(
-                        name=str(body.get("name") or "").strip(),
-                        template_id=str(body.get("template_id") or "").strip() or None,
-                        runtime_type=str(body.get("runtime_type") or "").strip() or None,
-                        exec_cmd=str(body.get("exec_command") or "").strip() or None,
-                        workdir=str(body.get("workdir") or "").strip() or None,
-                        ollama_model=str(body.get("ollama_model") or "").strip() or None,
-                        space_id=str(body.get("space_id") or "").strip() or None,
-                        audience=str(body.get("audience") or "both"),
-                        description=str(body.get("description") or "").strip() or None,
-                        model=str(body.get("model") or "").strip() or None,
-                        timeout_seconds=body.get("timeout_seconds", body.get("timeout")),
-                        start=bool(body.get("start", True)),
-                    )
+                    try:
+                        payload = _register_managed_agent(
+                            name=str(body.get("name") or "").strip(),
+                            template_id=str(body.get("template_id") or "").strip() or None,
+                            runtime_type=str(body.get("runtime_type") or "").strip() or None,
+                            exec_cmd=str(body.get("exec_command") or "").strip() or None,
+                            workdir=str(body.get("workdir") or "").strip() or None,
+                            ollama_model=str(body.get("ollama_model") or "").strip() or None,
+                            space_id=str(body.get("space_id") or "").strip() or None,
+                            audience=str(body.get("audience") or "both"),
+                            description=str(body.get("description") or "").strip() or None,
+                            model=str(body.get("model") or "").strip() or None,
+                            timeout_seconds=body.get("timeout_seconds", body.get("timeout")),
+                            start=bool(body.get("start", True)),
+                        )
+                    except UpstreamRateLimitedError as exc:
+                        retry_after = exc.retry_after_seconds or 30
+                        _write_json_response(
+                            self,
+                            {
+                                "error": "Upstream rate-limited (paxai.app returned 429).",
+                                "error_class": "rate_limited",
+                                "retry_after_seconds": retry_after,
+                                "operator_action": (
+                                    f"Wait {retry_after} seconds and try again. "
+                                    "Other agent runtimes may be holding the rate-limit budget; "
+                                    "stopping or archiving idle agents can reduce pressure."
+                                ),
+                            },
+                            status=HTTPStatus.TOO_MANY_REQUESTS,
+                        )
+                        return
                     profile = gateway_core.infer_operator_profile(payload)
                     if (
                         profile["placement"] == "attached"

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -78,6 +78,7 @@ from ..gateway import (
     load_gateway_registry,
     load_gateway_session,
     load_recent_gateway_activity,
+    looks_like_space_uuid,
     ollama_setup_status,
     record_gateway_activity,
     remove_agent_entry,
@@ -839,7 +840,11 @@ def _resolve_gateway_agent_home_space(
 ) -> str:
     explicit = str(explicit_space_id or "").strip()
     if explicit:
-        return explicit
+        if looks_like_space_uuid(explicit):
+            return explicit
+        # Caller passed a name/slug — resolve through the backend so we never
+        # store a non-UUID in the registry's space_id field.
+        return resolve_space_id(client, explicit=explicit)
     session_space = str(session.get("space_id") or "").strip()
     if session_space:
         return session_space
@@ -3108,10 +3113,28 @@ def _render_gateway_dashboard(payload: dict) -> Group:
     )
 
 
-def _spaces_payload() -> dict:
-    client = _load_gateway_user_client()
-    raw = client.list_spaces()
-    items = raw.get("spaces", raw) if isinstance(raw, dict) else raw
+def _spaces_cache_path() -> Path:
+    return gateway_dir() / "spaces.cache.json"
+
+
+def _load_spaces_cache() -> list[dict]:
+    try:
+        raw = json.loads(_spaces_cache_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    items = raw.get("spaces") if isinstance(raw, dict) else raw
+    return [item for item in (items or []) if isinstance(item, dict)]
+
+
+def _save_spaces_cache(spaces: list[dict]) -> None:
+    payload = {"spaces": spaces, "saved_at": datetime.now(timezone.utc).isoformat()}
+    try:
+        _spaces_cache_path().write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _normalize_spaces_response(items: list) -> list[dict]:
     spaces: list[dict] = []
     for item in items or []:
         if not isinstance(item, dict):
@@ -3126,12 +3149,50 @@ def _spaces_payload() -> dict:
                 "slug": str(item.get("slug") or "").strip() or None,
             }
         )
+    return spaces
+
+
+def _spaces_payload() -> dict:
+    """Return the spaces visible to the Gateway bootstrap session.
+
+    Always surfaces ``active_space_id`` / ``active_space_name`` from session
+    state, even when the upstream ``list_spaces`` call fails (e.g. paxai.app
+    rate-limits). Successful upstream responses are cached on disk so the UI
+    keeps a usable picker through transient outages.
+    """
     session = load_gateway_session() or {}
-    return {
+    active_space_id = str(session.get("space_id") or "").strip() or None
+    active_space_name = str(session.get("space_name") or "").strip() or None
+
+    error: str | None = None
+    cached = False
+    try:
+        client = _load_gateway_user_client()
+        raw = client.list_spaces()
+        items = raw.get("spaces", raw) if isinstance(raw, dict) else raw
+        spaces = _normalize_spaces_response(items or [])
+        if spaces:
+            _save_spaces_cache(spaces)
+    except Exception as exc:  # noqa: BLE001 — upstream errors are routine here
+        error = str(exc)
+        spaces = _load_spaces_cache()
+        cached = bool(spaces)
+
+    if active_space_id and not any(s["id"] == active_space_id for s in spaces):
+        spaces = [
+            {"id": active_space_id, "name": active_space_name or active_space_id, "slug": None},
+            *spaces,
+        ]
+
+    payload: dict = {
         "spaces": spaces,
-        "active_space_id": str(session.get("space_id") or "").strip() or None,
-        "active_space_name": str(session.get("space_name") or "").strip() or None,
+        "active_space_id": active_space_id,
+        "active_space_name": active_space_name,
     }
+    if error:
+        payload["error"] = error
+        payload["cached"] = cached
+    return payload
 
 
 def _move_managed_agent_space(name: str, new_space_id: str) -> dict:
@@ -4894,20 +4955,14 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                     _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.NOT_FOUND)
                 return
             if parsed.path == "/api/spaces":
-                try:
-                    _write_json_response(self, _spaces_payload())
-                except typer.Exit:
-                    _write_json_response(
-                        self,
-                        {"error": "Gateway is not logged in.", "spaces": [], "active_space_id": None},
-                        status=HTTPStatus.SERVICE_UNAVAILABLE,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    _write_json_response(
-                        self,
-                        {"error": str(exc), "spaces": [], "active_space_id": None},
-                        status=HTTPStatus.BAD_GATEWAY,
-                    )
+                payload = _spaces_payload()
+                # _spaces_payload never raises: upstream failures fall back to
+                # cached spaces + session-known active space. Return 200 as
+                # long as we have something usable; 503 only when there is
+                # neither cache nor session.
+                has_data = bool(payload.get("spaces") or payload.get("active_space_id"))
+                status = HTTPStatus.OK if has_data else HTTPStatus.SERVICE_UNAVAILABLE
+                _write_json_response(self, payload, status=status)
                 return
             if parsed.path.startswith("/api/agents/") and parsed.path.endswith("/inbox"):
                 name = unquote(parsed.path.removeprefix("/api/agents/").removesuffix("/inbox")).strip()
@@ -5557,6 +5612,48 @@ def current_gateway_space(as_json: bool = JSON_OPTION):
         return
     err_console.print(f"Gateway current space: {result.get('space_name') or result.get('space_id') or '-'}")
     err_console.print(f"  space_id = {result.get('space_id') or '-'}")
+
+
+@spaces_app.command("list")
+def list_gateway_spaces(as_json: bool = JSON_OPTION):
+    """List the spaces visible to the Gateway bootstrap session.
+
+    Falls back to the locally cached list when the upstream API is
+    unavailable (e.g. rate-limited), so the operator always sees something
+    actionable.
+    """
+    payload = _spaces_payload()
+    if as_json:
+        print_json(payload)
+        return
+
+    spaces = payload.get("spaces") or []
+    active_id = payload.get("active_space_id")
+    if not spaces:
+        err_console.print("[yellow]No spaces available.[/yellow]")
+        if payload.get("error"):
+            err_console.print(f"  error = {payload['error']}")
+        return
+
+    rows = []
+    for space in spaces:
+        sid = str(space.get("id") or "")
+        rows.append(
+            {
+                "current": "*" if sid and sid == active_id else "",
+                "name": str(space.get("name") or sid),
+                "space_id": sid,
+                "slug": str(space.get("slug") or "") or "-",
+            }
+        )
+    print_table(
+        ["", "Name", "Space ID", "Slug"],
+        rows,
+        keys=["current", "name", "space_id", "slug"],
+    )
+    if payload.get("error"):
+        marker = "cached" if payload.get("cached") else "session-only"
+        err_console.print(f"[dim]Upstream unavailable ({marker}): {payload['error']}[/dim]")
 
 
 @app.command("activity")

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1366,6 +1366,52 @@ def _set_managed_agent_desired_state(name: str, desired_state: str) -> dict:
     return annotate_runtime_health(entry, registry=registry)
 
 
+def _hide_managed_agents(names: list[str], *, reason: str = "operator_cleanup") -> dict:
+    normalized_names = []
+    seen = set()
+    for raw_name in names:
+        name = str(raw_name or "").strip()
+        key = name.lower()
+        if not name or key in seen:
+            continue
+        normalized_names.append(name)
+        seen.add(key)
+    if not normalized_names:
+        raise ValueError("Choose at least one managed agent to hide.")
+
+    registry = load_gateway_registry()
+    hidden: list[dict] = []
+    missing: list[str] = []
+    hidden_reason = str(reason or "").strip() or "operator_cleanup"
+    hidden_at = gateway_core._now_iso()
+    for name in normalized_names:
+        entry = find_agent_entry(registry, name)
+        if not entry:
+            missing.append(name)
+            continue
+        if str(entry.get("desired_state") or "").strip().lower() != "stopped":
+            entry["desired_state_before_hide"] = entry.get("desired_state") or "running"
+        entry["desired_state"] = "stopped"
+        entry["lifecycle_phase"] = "hidden"
+        entry["hidden_at"] = hidden_at
+        entry["hidden_reason"] = hidden_reason
+        hidden.append(entry)
+
+    save_gateway_registry(registry)
+    for entry in hidden:
+        record_gateway_activity(
+            "managed_agent_hidden",
+            entry=entry,
+            hidden_reason=hidden_reason,
+            operator_action=True,
+        )
+    return {
+        "count": len(hidden),
+        "missing": missing,
+        "hidden": [annotate_runtime_health(entry, registry=registry) for entry in hidden],
+    }
+
+
 def _build_session_client_silent() -> AxClient | None:
     """Build a user-PAT session client without raising. Returns None when
     the gateway is not logged in or the session token is missing/invalid.
@@ -4941,6 +4987,21 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         if stored:
                             payload = _with_registry_refs(registry, annotate_runtime_health(stored, registry=registry))
                     _write_json_response(self, payload, status=HTTPStatus.CREATED)
+                    return
+                if parsed.path == "/api/agents/cleanup-hide":
+                    raw_names = body.get("names")
+                    if not isinstance(raw_names, list):
+                        _write_json_response(
+                            self,
+                            {"error": "names must be a list of managed agent names"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    payload = _hide_managed_agents(
+                        [str(name or "").strip() for name in raw_names],
+                        reason=str(body.get("reason") or "operator_cleanup"),
+                    )
+                    _write_json_response(self, payload)
                     return
                 if parsed.path == "/local/connect":
                     agent_name = str(body.get("agent_name") or body.get("name") or "").strip()

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2999,9 +2999,7 @@ def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = Tru
             on_disk = None
         if isinstance(on_disk, dict):
             disk_agents = on_disk.get("agents") or []
-            disk_by_name = {
-                str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")
-            }
+            disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
             for entry in registry.get("agents") or []:
                 if not isinstance(entry, dict):
                     continue

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2963,6 +2963,9 @@ def save_gateway_session(data: dict[str, Any]) -> Path:
     return session_path()
 
 
+_LOAD_SNAPSHOT_KEY = "_load_snapshot_agent_names"
+
+
 def load_gateway_registry() -> dict[str, Any]:
     registry = _read_json(registry_path(), default=_default_registry())
     registry.setdefault("version", 1)
@@ -2979,26 +2982,65 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
+    # Stamp the names present at load time so save_gateway_registry can
+    # tell "caller removed this row" apart from "another writer added this
+    # row after we loaded" when reconciling against disk at save time.
+    registry[_LOAD_SNAPSHOT_KEY] = sorted(
+        str(a.get("name") or "") for a in registry["agents"] if isinstance(a, dict) and a.get("name")
+    )
     return registry
 
 
 def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = True) -> Path:
     """Persist the registry to disk.
 
-    By default, performs a race-safety merge: re-reads disk and pulls
-    archive-related fields forward, so a CLI archive that landed between
-    the caller's load and this save is not clobbered. The daemon's
-    reconcile loop relies on this. Atomic CLI ops (archive/restore) that
-    are *the* authoritative writer for archive fields opt out via
-    `merge_archive=False` so they don't see-saw with their own writes.
+    Performs two race-safety merges before writing:
+
+    1. **Row preservation** (always on): re-reads disk and appends any
+       agent rows that exist on disk but not in memory *and* were not in
+       the caller's load-time snapshot. This recovers writes from a
+       second writer (e.g. the UI server's POST /api/agents add) that
+       landed between this caller's load and save. The load-time
+       snapshot — stamped by load_gateway_registry — distinguishes
+       "caller removed this row" (in snapshot, not in memory; do not
+       resurrect) from "another writer added this row" (not in snapshot,
+       on disk; preserve).
+
+    2. **Archive-field merge** (gated on merge_archive=True, the default):
+       pulls archive lifecycle fields forward from disk so a CLI archive
+       that landed mid-tick is not clobbered. Atomic CLI ops that are
+       *the* authoritative writer for archive fields opt out via
+       merge_archive=False so they don't see-saw with their own writes.
     """
-    if merge_archive:
-        try:
-            on_disk = _read_json(registry_path(), default=None)
-        except Exception:  # noqa: BLE001
-            on_disk = None
-        if isinstance(on_disk, dict):
-            disk_agents = on_disk.get("agents") or []
+    # Pop the load snapshot so it never leaks to disk.
+    loaded_names = set(registry.pop(_LOAD_SNAPSHOT_KEY, []))
+
+    try:
+        on_disk = _read_json(registry_path(), default=None)
+    except Exception:  # noqa: BLE001
+        on_disk = None
+
+    if isinstance(on_disk, dict):
+        disk_agents = on_disk.get("agents") or []
+        in_memory_names = {
+            str(a.get("name") or "") for a in registry.get("agents") or [] if isinstance(a, dict) and a.get("name")
+        }
+
+        # (1) Preserve rows added by another writer after this caller loaded.
+        for disk_entry in disk_agents:
+            if not isinstance(disk_entry, dict):
+                continue
+            name = str(disk_entry.get("name") or "")
+            if not name:
+                continue
+            if name in in_memory_names:
+                continue  # already in memory; either updating or untouched
+            if name in loaded_names:
+                continue  # caller removed it (was in our snapshot, not in memory)
+            registry.setdefault("agents", []).append(disk_entry)
+
+        # (2) Existing archive-field merge.
+        if merge_archive:
             disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
             for entry in registry.get("agents") or []:
                 if not isinstance(entry, dict):

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2964,7 +2964,22 @@ def save_gateway_session(data: dict[str, Any]) -> Path:
     return session_path()
 
 
-_LOAD_SNAPSHOT_KEY = "_load_snapshot_agent_names"
+_LOAD_SNAPSHOT_KEY = "_load_snapshot"
+
+# Fields the operator (CLI / UI server) writes authoritatively. The daemon's
+# reconcile loop should NEVER clobber these mid-flight: if a field's value
+# on disk differs from what was present at this caller's load, another
+# writer changed it and we must take disk's value, not memory's stale view.
+_OPERATOR_AUTHORITATIVE_FIELDS = (
+    "desired_state",
+    "lifecycle_phase",
+    "archived_at",
+    "archived_reason",
+    "desired_state_before_archive",
+    "hidden_at",
+    "hidden_reason",
+    "desired_state_before_hide",
+)
 
 
 def load_gateway_registry() -> dict[str, Any]:
@@ -2983,38 +2998,62 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
-    # Stamp the names present at load time so save_gateway_registry can
-    # tell "caller removed this row" apart from "another writer added this
-    # row after we loaded" when reconciling against disk at save time.
-    registry[_LOAD_SNAPSHOT_KEY] = sorted(
-        str(a.get("name") or "") for a in registry["agents"] if isinstance(a, dict) and a.get("name")
-    )
+    # Stamp a load-time snapshot so save_gateway_registry can distinguish:
+    #   - "caller removed this row" vs "another writer added this row"
+    #     (row existence diff)
+    #   - "caller updated this field" vs "another writer updated this
+    #     field" (field-level diff for operator-authoritative fields like
+    #     desired_state — if our load-time value matches memory but disk
+    #     differs, another writer changed it; respect disk's view)
+    snapshot: dict[str, dict[str, Any]] = {}
+    for entry in registry["agents"]:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "")
+        if not name:
+            continue
+        snapshot[name] = {field: entry.get(field) for field in _OPERATOR_AUTHORITATIVE_FIELDS}
+    registry[_LOAD_SNAPSHOT_KEY] = snapshot
     return registry
 
 
 def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = True) -> Path:
     """Persist the registry to disk.
 
-    Performs two race-safety merges before writing:
+    Performs three race-safety merges before writing:
 
     1. **Row preservation** (always on): re-reads disk and appends any
        agent rows that exist on disk but not in memory *and* were not in
-       the caller's load-time snapshot. This recovers writes from a
-       second writer (e.g. the UI server's POST /api/agents add) that
-       landed between this caller's load and save. The load-time
-       snapshot — stamped by load_gateway_registry — distinguishes
-       "caller removed this row" (in snapshot, not in memory; do not
-       resurrect) from "another writer added this row" (not in snapshot,
-       on disk; preserve).
+       the caller's load-time snapshot. Recovers writes from a second
+       writer (e.g. the UI server's POST /api/agents add) that landed
+       between this caller's load and save.
 
-    2. **Archive-field merge** (gated on merge_archive=True, the default):
-       pulls archive lifecycle fields forward from disk so a CLI archive
-       that landed mid-tick is not clobbered. Atomic CLI ops that are
-       *the* authoritative writer for archive fields opt out via
-       merge_archive=False so they don't see-saw with their own writes.
+    2. **Operator-authoritative field preservation** (always on): for
+       each field in _OPERATOR_AUTHORITATIVE_FIELDS (desired_state,
+       lifecycle_phase, archive/hide flags), if the value on disk
+       differs from this caller's load-time snapshot, another writer
+       changed it; take disk's value. This is what makes
+       `ax gateway agents stop` actually stick: the daemon's stale
+       `desired_state=running` view does not clobber the CLI's freshly
+       written `desired_state=stopped`.
+
+    3. **Archive-field merge** (gated on merge_archive=True, the
+       default): legacy bidirectional archive merge from PR #147.
+       Subsumed by (2) for normal flows; preserved for the explicit
+       archived↔active transition path so atomic CLI ops can opt out
+       via merge_archive=False to avoid seesawing with their own writes.
     """
     # Pop the load snapshot so it never leaks to disk.
-    loaded_names = set(registry.pop(_LOAD_SNAPSHOT_KEY, []))
+    snapshot_raw = registry.pop(_LOAD_SNAPSHOT_KEY, None)
+    snapshot: dict[str, dict[str, Any]]
+    if isinstance(snapshot_raw, dict):
+        snapshot = snapshot_raw
+    elif isinstance(snapshot_raw, list):
+        # Backwards-compat with names-only snapshot from earlier load.
+        snapshot = {name: {} for name in snapshot_raw}
+    else:
+        snapshot = {}
+    loaded_names = set(snapshot.keys())
 
     try:
         on_disk = _read_json(registry_path(), default=None)
@@ -3040,7 +3079,31 @@ def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = Tru
                 continue  # caller removed it (was in our snapshot, not in memory)
             registry.setdefault("agents", []).append(disk_entry)
 
-        # (2) Existing archive-field merge.
+        # (2) Operator-authoritative field preservation.
+        # If a field's disk value differs from our load-time snapshot,
+        # another writer changed it; take disk's value over ours.
+        disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
+        for entry in registry.get("agents") or []:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "")
+            disk_entry = disk_by_name.get(name)
+            if not isinstance(disk_entry, dict):
+                continue
+            loaded_fields = snapshot.get(name, {})
+            for field in _OPERATOR_AUTHORITATIVE_FIELDS:
+                disk_value = disk_entry.get(field)
+                loaded_value = loaded_fields.get(field)
+                if disk_value != loaded_value:
+                    # Another writer changed this field after our load.
+                    # Preserve their write — overwrite our memory's view.
+                    if field in disk_entry:
+                        entry[field] = disk_value
+                    else:
+                        entry.pop(field, None)
+
+        # (3) Existing archive-field merge (kept for the merge_archive=False
+        # opt-out semantics; (2) covers the common case).
         if merge_archive:
             disk_by_name = {str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")}
             for entry in registry.get("agents") or []:

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -54,6 +54,7 @@ MIN_HANDLER_TIMEOUT_SECONDS = 1
 SSE_IDLE_TIMEOUT_SECONDS = 45.0
 RUNTIME_STALE_AFTER_SECONDS = 75.0
 RUNTIME_HIDDEN_AFTER_SECONDS = 15 * 60.0  # default: hide stale agents after 15 min
+SETUP_ERROR_BACKOFF_SECONDS = 30.0  # silence retry storm after a runtime setup error
 # active = visible, normal operation
 # hidden = system auto-hid because of staleness; auto-restores on reconnect
 # archived = user explicitly disabled; sticky (no auto-restore); requires explicit `agents restore`
@@ -4267,6 +4268,18 @@ class ManagedAgentRuntime:
             return
         if self._listener_thread and self._listener_thread.is_alive():
             return
+        # Setup-error backoff: if this runtime hit a setup error within the
+        # backoff window (missing token file, missing script, etc.), do not
+        # retry every reconcile tick. Retrying every 1s does not help — the
+        # operator must fix the precondition first — and each attempt fires
+        # a runtime_error activity event and can pressure upstream rate
+        # limits. Operator-driven `agents start <name>` clears the field
+        # via the explicit desired_state transition.
+        last_runtime_error_at = self.entry.get("last_runtime_error_at")
+        if last_runtime_error_at:
+            age = _age_seconds(last_runtime_error_at)
+            if age is not None and age < SETUP_ERROR_BACKOFF_SECONDS:
+                return
         self.stop_event.clear()
         self._queue = queue.Queue(maxsize=int(self.entry.get("queue_size") or DEFAULT_QUEUE_SIZE))
         self._reply_anchor_ids = set()
@@ -4362,8 +4375,13 @@ class ManagedAgentRuntime:
         if not script.exists():
             error = f"Hermes sentinel script not found: {script}"
             self._update_state(
-                effective_state="error", current_status="error", current_activity=error, last_error=error
+                effective_state="error",
+                current_status="error",
+                current_activity=error,
+                last_error=error,
+                last_runtime_error_at=_now_iso(),
             )
+            self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
             record_gateway_activity("runtime_error", entry=self.entry, error=error)
             return
         try:
@@ -4371,8 +4389,13 @@ class ManagedAgentRuntime:
         except ValueError as exc:
             error = str(exc)
             self._update_state(
-                effective_state="error", current_status="error", current_activity=error, last_error=error
+                effective_state="error",
+                current_status="error",
+                current_activity=error,
+                last_error=error,
+                last_runtime_error_at=_now_iso(),
             )
+            self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
             record_gateway_activity("runtime_error", entry=self.entry, error=error)
             return
 
@@ -4411,8 +4434,13 @@ class ManagedAgentRuntime:
         except Exception as exc:
             error = f"Failed to start Hermes sentinel: {str(exc)[:360]}"
             self._update_state(
-                effective_state="error", current_status="error", current_activity=error, last_error=error
+                effective_state="error",
+                current_status="error",
+                current_activity=error,
+                last_error=error,
+                last_runtime_error_at=_now_iso(),
             )
+            self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
             record_gateway_activity("runtime_error", entry=self.entry, error=error)
             return
 
@@ -4424,10 +4452,12 @@ class ManagedAgentRuntime:
             current_tool=None,
             current_tool_call_id=None,
             last_error=None,
+            last_runtime_error_at=None,
             last_connected_at=_now_iso(),
             last_seen_at=_now_iso(),
             reconnect_backoff_seconds=0,
         )
+        self.entry["last_runtime_error_at"] = None
         record_gateway_activity(
             "runtime_started",
             entry=self.entry,

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -54,7 +54,10 @@ MIN_HANDLER_TIMEOUT_SECONDS = 1
 SSE_IDLE_TIMEOUT_SECONDS = 45.0
 RUNTIME_STALE_AFTER_SECONDS = 75.0
 RUNTIME_HIDDEN_AFTER_SECONDS = 15 * 60.0  # default: hide stale agents after 15 min
-_LIFECYCLE_PHASES = {"active", "hidden"}
+# active = visible, normal operation
+# hidden = system auto-hid because of staleness; auto-restores on reconnect
+# archived = user explicitly disabled; sticky (no auto-restore); requires explicit `agents restore`
+_LIFECYCLE_PHASES = {"active", "hidden", "archived"}
 LOCAL_SESSION_TTL_SECONDS = 24 * 60 * 60
 GATEWAY_EVENT_PREFIX = "AX_GATEWAY_EVENT "
 DEFAULT_OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434").rstrip("/")
@@ -2979,7 +2982,51 @@ def load_gateway_registry() -> dict[str, Any]:
     return registry
 
 
-def save_gateway_registry(registry: dict[str, Any]) -> Path:
+def save_gateway_registry(registry: dict[str, Any], *, merge_archive: bool = True) -> Path:
+    """Persist the registry to disk.
+
+    By default, performs a race-safety merge: re-reads disk and pulls
+    archive-related fields forward, so a CLI archive that landed between
+    the caller's load and this save is not clobbered. The daemon's
+    reconcile loop relies on this. Atomic CLI ops (archive/restore) that
+    are *the* authoritative writer for archive fields opt out via
+    `merge_archive=False` so they don't see-saw with their own writes.
+    """
+    if merge_archive:
+        try:
+            on_disk = _read_json(registry_path(), default=None)
+        except Exception:  # noqa: BLE001
+            on_disk = None
+        if isinstance(on_disk, dict):
+            disk_agents = on_disk.get("agents") or []
+            disk_by_name = {
+                str(a.get("name") or ""): a for a in disk_agents if isinstance(a, dict) and a.get("name")
+            }
+            for entry in registry.get("agents") or []:
+                if not isinstance(entry, dict):
+                    continue
+                disk_entry = disk_by_name.get(str(entry.get("name") or ""))
+                if not isinstance(disk_entry, dict):
+                    continue
+                # CLI is authoritative for the archived ↔ active transition.
+                # Take disk's archive fields whenever the disk OR the in-memory
+                # copy has archive state — covers both directions of the race
+                # (CLI archive into the daemon's active view, *and* CLI restore
+                # into the daemon's still-archived view).
+                disk_phase = str(disk_entry.get("lifecycle_phase") or "")
+                mem_phase = str(entry.get("lifecycle_phase") or "")
+                if disk_phase == "archived" or (mem_phase == "archived" and disk_phase != "archived"):
+                    for field in (
+                        "lifecycle_phase",
+                        "archived_at",
+                        "archived_reason",
+                        "desired_state_before_archive",
+                        "desired_state",
+                    ):
+                        if field in disk_entry:
+                            entry[field] = disk_entry[field]
+                        else:
+                            entry.pop(field, None)
     _write_json(registry_path(), registry)
     return registry_path()
 
@@ -5737,6 +5784,14 @@ class GatewayDaemon:
             phase = str(entry.get("lifecycle_phase") or "active").strip().lower()
             if phase not in _LIFECYCLE_PHASES:
                 phase = "active"
+
+            # Archived is sticky — sweep never transitions in or out of it. The
+            # only path in is `agents archive`; the only path out is
+            # `agents restore`. Skip both auto-hide and auto-restore for these
+            # entries, and skip upstream lifecycle signaling (the explicit
+            # archive call already signaled `archived` upstream).
+            if phase == "archived":
+                continue
 
             # Hide transition: active → hidden once stale past threshold.
             if (

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2982,6 +2982,50 @@ _OPERATOR_AUTHORITATIVE_FIELDS = (
 )
 
 
+_SPACE_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_space_uuid(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SPACE_UUID_RE.match(value.strip()))
+
+
+def reconcile_corrupt_space_ids(registry: dict[str, Any]) -> int:
+    """Heal agent rows where ``space_id`` holds a name/slug instead of a UUID.
+
+    Recovers the correct UUID from sibling fields (``active_space_id``,
+    ``default_space_id``, ``allowed_spaces[].space_id``). Idempotent — rows
+    whose ``space_id`` is already UUID-shaped or empty are left alone.
+    Returns the count of repaired rows.
+    """
+    repaired = 0
+    for entry in registry.get("agents", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("space_id")
+        if not isinstance(sid, str) or not sid.strip() or looks_like_space_uuid(sid):
+            continue
+        candidate = ""
+        for key in ("active_space_id", "default_space_id"):
+            v = entry.get(key)
+            if looks_like_space_uuid(v):
+                candidate = str(v).strip()
+                break
+        if not candidate:
+            allowed = entry.get("allowed_spaces") or []
+            if isinstance(allowed, list):
+                for row in allowed:
+                    if isinstance(row, dict) and looks_like_space_uuid(row.get("space_id")):
+                        candidate = str(row["space_id"]).strip()
+                        break
+        if candidate:
+            entry["space_id"] = candidate
+            repaired += 1
+    return repaired
+
+
 def load_gateway_registry() -> dict[str, Any]:
     registry = _read_json(registry_path(), default=_default_registry())
     registry.setdefault("version", 1)
@@ -2998,6 +3042,7 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
+    reconcile_corrupt_space_ids(registry)
     # Stamp a load-time snapshot so save_gateway_registry can distinguish:
     #   - "caller removed this row" vs "another writer added this row"
     #     (row existence diff)

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -5935,18 +5935,22 @@ class GatewayDaemon:
         *,
         session: dict[str, Any] | None,
     ) -> None:
-        """Per-tick sweep: hide stale agents, signal liveness transitions upstream.
+        """Per-tick sweep: signal liveness transitions upstream.
+
+        Hide and restore are operator-driven only. The sweep observes liveness
+        and signals deltas upstream; it never mutates ``lifecycle_phase``. Use
+        ``ax gateway agents hide`` / ``unhide`` (or the Cleanup UI) to change
+        lifecycle phase.
 
         - Skips system agents (switchboards, service accounts).
-        - Promotes active+stale entries past the hide threshold to lifecycle_phase=hidden.
-        - Auto-restores hidden entries that have come back online.
+        - Skips archived entries entirely (no upstream signaling either —
+          archive already signaled).
         - On any liveness delta vs last_lifecycle_signal.phase, calls
           send_heartbeat upstream best-effort. 404 counts as success.
         """
         agents = registry.get("agents") or []
         if not agents:
             return
-        threshold = _hide_after_stale_seconds(registry)
         client = self._sweep_client(session)
         for entry in agents:
             if not isinstance(entry, dict):
@@ -5954,43 +5958,15 @@ class GatewayDaemon:
             if _is_system_agent(entry):
                 continue
             liveness = str(entry.get("liveness") or "").strip().lower()
-            age_raw = entry.get("last_seen_age_seconds")
-            try:
-                age = float(age_raw) if age_raw is not None else None
-            except (TypeError, ValueError):
-                age = None
             phase = str(entry.get("lifecycle_phase") or "active").strip().lower()
             if phase not in _LIFECYCLE_PHASES:
                 phase = "active"
 
-            # Archived is sticky — sweep never transitions in or out of it. The
-            # only path in is `agents archive`; the only path out is
-            # `agents restore`. Skip both auto-hide and auto-restore for these
-            # entries, and skip upstream lifecycle signaling (the explicit
-            # archive call already signaled `archived` upstream).
+            # Archived is sticky — explicit archive already signaled upstream,
+            # don't double-signal. Hide/unhide are operator-only and the sweep
+            # never touches lifecycle_phase, so no transition logic here.
             if phase == "archived":
                 continue
-
-            # Hide transition: active → hidden once stale past threshold.
-            if (
-                phase == "active"
-                and liveness in {"stale", "offline", "setup_error"}
-                and age is not None
-                and age >= threshold
-            ):
-                entry["lifecycle_phase"] = "hidden"
-                entry["hidden_at"] = _now_iso()
-                entry["hidden_reason"] = liveness
-                record_gateway_activity("managed_agent_hidden", entry=entry, reason=liveness)
-                phase = "hidden"
-
-            # Auto-restore: hidden → active when reconnected and fresh.
-            elif phase == "hidden" and liveness == "connected" and (age is None or age <= RUNTIME_STALE_AFTER_SECONDS):
-                entry["lifecycle_phase"] = "active"
-                entry.pop("hidden_at", None)
-                entry.pop("hidden_reason", None)
-                record_gateway_activity("managed_agent_unhidden", entry=entry)
-                phase = "active"
 
             # Upstream signal on liveness delta. Sticky liveness rate-limits.
             if liveness in {"connected", "stale", "offline", "setup_error"}:

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -73,6 +73,7 @@
     .system-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); font-family: var(--mono); font-size: 11px; color: var(--muted); cursor: pointer; transition: border-color 120ms ease, color 120ms ease; }
     .system-toggle:hover { border-color: var(--line-strong); color: var(--text); }
     .system-toggle.on { border-color: rgba(94,234,212,0.4); color: var(--accent); background: rgba(94,234,212,0.08); }
+    .system-toggle[hidden] { display: none; }
     .chip.system { color: var(--muted); border-color: var(--line); background: rgba(255,255,255,0.04); }
 
     .hero { display: grid; grid-template-columns: 1fr; gap: 18px; margin-bottom: 30px; }
@@ -1486,14 +1487,16 @@
 
     function updateRow(row, agent) {
       const status = friendlyStatus(agent);
-      const dot = row.children[0];
-      const agentEl = row.children[1];
+      // Row children: [0] cleanup-cell (always present, hidden in default mode),
+      // [1] dot, [2] row-agent, [3] row-space, [4] row-last-seen, [5] row-action.
+      const dot = row.children[1];
+      const agentEl = row.children[2];
       const typeMarkEl = agentEl.children[0];
       const nameEl = agentEl.querySelector(".row-name");
       const typeLabelEl = agentEl.querySelector(".row-type-label");
-      const spaceEl = row.children[2];
-      const lastSeenEl = row.children[3];
-      const actionEl = row.children[4];
+      const spaceEl = row.children[3];
+      const lastSeenEl = row.children[4];
+      const actionEl = row.children[5];
 
       if (isMailboxRuntime(agent)) {
         renderMailboxIndicator(dot, agent, status);

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -74,6 +74,12 @@
     .system-toggle:hover { border-color: var(--line-strong); color: var(--text); }
     .system-toggle.on { border-color: rgba(94,234,212,0.4); color: var(--accent); background: rgba(94,234,212,0.08); }
     .system-toggle[hidden] { display: none; }
+    /* Hidden-agent rows: visually distinct so operators can tell them apart from active. */
+    .agent-row.row-hidden { background: rgba(255, 255, 255, 0.015); }
+    .agent-row.row-hidden .row-name { color: var(--muted); }
+    .agent-row.row-hidden .row-type-label::after { content: " · Hidden"; color: var(--muted-2); font-style: italic; }
+    .row-unhide { padding: 4px 10px; border-radius: 999px; border: 1px solid var(--line); background: transparent; color: var(--muted); font-family: var(--mono); font-size: 11px; cursor: pointer; }
+    .row-unhide:hover { border-color: var(--accent); color: var(--accent); }
     .chip.system { color: var(--muted); border-color: var(--line); background: rgba(255,255,255,0.04); }
 
     .hero { display: grid; grid-template-columns: 1fr; gap: 18px; margin-bottom: 30px; }
@@ -398,6 +404,7 @@
           <button type="button" class="system-toggle" id="cleanup-hide-btn" hidden title="Hide selected agents from the list and stop their runtimes">Hide selected</button>
           <span class="count" id="cleanup-selection" hidden></span>
           <button type="button" class="system-toggle" id="cleanup-toggle" title="Bulk-clean stale agents from this list">Clean up</button>
+          <button type="button" class="system-toggle" id="hidden-toggle" title="Show hidden/inactive agents — restore individually with their Unhide button">Show hidden</button>
           <button type="button" class="system-toggle" id="system-toggle" title="Show gateway-internal agents like switchboards">Show system agents</button>
           <span class="count" id="agent-count" hidden></span>
         </div>
@@ -514,6 +521,7 @@
       rowsByName: new Map(),
       lastRenderMode: null, // "disconnected" | "connect" | "list"
       showSystemAgents: false,
+      showHidden: false,
       cleanupMode: false,
       selectedNames: new Set(),
     };
@@ -521,6 +529,7 @@
     // Restore system-agent toggle state from localStorage so the choice persists across reloads.
     try {
       state.showSystemAgents = window.localStorage.getItem("ax-demo-show-system") === "1";
+      state.showHidden = window.localStorage.getItem("ax-demo-show-hidden") === "1";
     } catch (_) { /* ignore */ }
     function isSystemAgent(agent) {
       const name = String(agent.name || "");
@@ -828,8 +837,12 @@
 
     async function loadStatus() {
       let status;
+      // When the operator wants to see hidden/inactive agents we have to ask
+      // the backend for the unfiltered list — default /api/status filters
+      // hidden+system out of the agents array (counts stay in summary).
+      const path = state.showHidden ? "/api/status?all=1" : "/api/status";
       try {
-        status = await api("GET", "/api/status");
+        status = await api("GET", path);
       } catch (err) {
         renderDisconnectedState(err.message || "Gateway daemon is not responding.");
         return;
@@ -838,9 +851,11 @@
       state.baseUrl = status.base_url || null;
       state.user = status.user || null;
       state.agents = Array.isArray(status.agents) ? status.agents : [];
+      state.summary = status.summary || {};
       state.sessionSpaceId = status.space_id || null;
       // activeSpaceId stays "" (= All spaces) unless user explicitly picks one.
       renderConnectionPill();
+      refreshHiddenToggleUI();
       if (!state.connected) {
         renderConnectPrompt();
         return;
@@ -1528,6 +1543,7 @@
       if (spaceEl.textContent !== newSpace) spaceEl.textContent = newSpace;
       spaceEl.title = spaceIsMuted ? "" : newSpace;
       const needsApproval = String(agent.approval_state || "").toLowerCase() === "pending" && agent.approval_id;
+      const isHidden = String(agent.lifecycle_phase || "") === "hidden";
       clearChildren(actionEl);
       if (needsApproval) {
         actionEl.appendChild(makeEl("button", {
@@ -1539,9 +1555,20 @@
             openDrawer(newName);
           },
         }, ["Review"]));
+      } else if (isHidden) {
+        actionEl.appendChild(makeEl("button", {
+          type: "button",
+          class: "row-unhide",
+          title: "Restore this agent — clears hidden state and returns it to default view",
+          onclick: (event) => {
+            event.stopPropagation();
+            void unhideAgent(newName);
+          },
+        }, ["Unhide"]));
       } else {
         actionEl.appendChild(makeEl("span", { class: "row-chev" }, ["›"]));
       }
+      row.classList.toggle("row-hidden", isHidden);
       row.classList.toggle("active-row", state.drawerAgentName === agent.name);
     }
 
@@ -2391,6 +2418,46 @@
 
     $("cleanup-hide-btn").addEventListener("click", () => {
       void hideSelectedAgents();
+    });
+
+    function refreshHiddenToggleUI() {
+      const btn = $("hidden-toggle");
+      if (!btn) return;
+      const hiddenCount = (state.summary && state.summary.hidden_agents) || 0;
+      btn.classList.toggle("on", state.showHidden);
+      btn.textContent = state.showHidden
+        ? "Hide hidden" + (hiddenCount ? " (" + hiddenCount + ")" : "")
+        : "Show hidden" + (hiddenCount ? " (" + hiddenCount + ")" : "");
+      // Stay visible when there *are* hidden agents OR when we're already showing them
+      // (so the operator can toggle back). If neither, fade it out.
+      btn.style.display = hiddenCount === 0 && !state.showHidden ? "none" : "";
+    }
+
+    async function unhideAgent(name) {
+      try {
+        const result = await api("POST", "/api/agents/cleanup-restore", { names: [name] });
+        if (result && result.count > 0) {
+          showToast("Restored @" + name, "ok");
+        } else if (result && result.not_hidden && result.not_hidden.length) {
+          showToast("@" + name + " was not hidden", "warn");
+        } else {
+          showToast("Restore failed for @" + name, "err");
+        }
+        await loadStatus();
+      } catch (err) {
+        showToast(err.message || "Restore failed", "err");
+      }
+    }
+
+    $("hidden-toggle").addEventListener("click", () => {
+      state.showHidden = !state.showHidden;
+      try { window.localStorage.setItem("ax-demo-show-hidden", state.showHidden ? "1" : "0"); } catch (_) {}
+      refreshHiddenToggleUI();
+      // Re-render fully so hidden rows add/remove cleanly.
+      state.rowsByName.clear();
+      clearChildren($("agent-region"));
+      state.lastRenderMode = null;
+      void loadStatus();
     });
 
     wizardSubmit.addEventListener("click", async () => {

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -804,6 +804,7 @@
         const message = (payload && payload.error) || ("Request failed (" + res.status + ")");
         const err = new Error(message);
         err.status = res.status;
+        err.payload = payload;
         throw err;
       }
       return payload;
@@ -2310,7 +2311,16 @@
         state.submitting = false;
         wizardSubmit.disabled = false;
         formStatus.style.display = "none";
-        formError.textContent = err.message || "Connection failed.";
+        // Operator-actionable surface for upstream rate limits — show the
+        // retry-after window + operator_action hint from the structured
+        // 429 payload instead of the bare httpx error string.
+        if (err.status === 429 && err.payload && err.payload.error_class === "rate_limited") {
+          const retryAfter = err.payload.retry_after_seconds || 30;
+          const action = err.payload.operator_action || `Wait ${retryAfter} seconds and try again.`;
+          formError.textContent = `Rate-limited by paxai.app — retry in ${retryAfter}s. ${action}`;
+        } else {
+          formError.textContent = err.message || "Connection failed.";
+        }
         formError.style.display = "block";
       }
     });

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -511,6 +511,7 @@
       spaces: [],
       activeSpaceId: null,
       sessionSpaceId: null,
+      sessionSpaceName: null,
       templates: [],
       selectedTemplateId: "hermes",
       submitting: false,
@@ -666,16 +667,71 @@
       return { icon: "custom", label: templateLabel(agent), className: "type-custom" };
     }
 
+    function looksLikeSpaceId(value) {
+      return /^[0-9a-f]{8}-[0-9a-f-]{13,}$/i.test(String(value || ""));
+    }
+
+    function addSpaceCandidate(map, id, name, { authoritative = false } = {}) {
+      const sid = String(id || "").trim();
+      if (!sid) return;
+      if (!looksLikeSpaceId(sid) && /[\s'"]/.test(sid)) return;
+      const label = String(name || "").trim();
+      const cleanName = label && !looksLikeSpaceId(label) ? label : sid;
+      const existing = map.get(sid);
+      const isSpecificNonSessionName =
+        cleanName !== sid && (!state.sessionSpaceName || cleanName !== state.sessionSpaceName || sid === state.sessionSpaceId);
+      const existingIsWeak =
+        !existing ||
+        existing.name === existing.id ||
+        (state.sessionSpaceName && existing.id !== state.sessionSpaceId && existing.name === state.sessionSpaceName);
+      if (!existing || (authoritative && !existing.authoritative) || (!existing.authoritative && existingIsWeak && isSpecificNonSessionName)) {
+        map.set(sid, { id: sid, name: cleanName, authoritative });
+      }
+    }
+
+    function knownSpaces() {
+      const map = new Map();
+      if (state.sessionSpaceId) {
+        addSpaceCandidate(map, state.sessionSpaceId, state.sessionSpaceName, { authoritative: true });
+      }
+      for (const space of state.spaces || []) {
+        addSpaceCandidate(map, space.id, space.name, { authoritative: true });
+      }
+      for (const agent of state.agents || []) {
+        const agentSpaceId = String(agent.space_id || agent.default_space_id || agent.active_space_id || "").trim();
+        if (agentSpaceId === state.sessionSpaceId) {
+          addSpaceCandidate(map, agentSpaceId, state.sessionSpaceName, { authoritative: true });
+        } else {
+          addSpaceCandidate(map, agentSpaceId, agent.space_name || agent.default_space_name || agent.active_space_name);
+        }
+        for (const space of agent.allowed_spaces || []) {
+          if (typeof space === "string") {
+            addSpaceCandidate(map, space, space);
+          } else if (space) {
+            addSpaceCandidate(map, space.space_id || space.id, space.name || space.space_name);
+          }
+        }
+      }
+      return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    function spaceNameForId(id) {
+      const sid = String(id || "").trim();
+      if (!sid) return "";
+      if (sid === state.sessionSpaceId && state.sessionSpaceName) return state.sessionSpaceName;
+      const match = knownSpaces().find((space) => space.id === sid);
+      return match ? match.name : "";
+    }
+
     function spaceLabel(agent) {
       // Prefer the agent's home space (space_id) over the gateway's runtime
       // operating space (active_space_id). active_space_id reflects what the
       // gateway is *sending as*, not where the agent lives.
       const id = String(agent.space_id || agent.default_space_id || agent.active_space_id || "").trim();
-      const looksLikeId = (s) => /^[0-9a-f]{8}-[0-9a-f-]{13,}$/i.test(String(s || ""));
       const explicit = String(agent.space_name || agent.default_space_name || agent.active_space_name || "").trim();
-      const match = state.spaces.find((space) => space.id === id);
-      if (match) return match.name;
-      if (explicit && !looksLikeId(explicit)) return explicit;
+      const knownName = spaceNameForId(id);
+      if (knownName) return knownName;
+      if (explicit && !looksLikeSpaceId(explicit)) return explicit;
       return id || "—";
     }
 
@@ -853,6 +909,7 @@
       state.agents = Array.isArray(status.agents) ? status.agents : [];
       state.summary = status.summary || {};
       state.sessionSpaceId = status.space_id || null;
+      state.sessionSpaceName = status.space_name || null;
       // activeSpaceId stays "" (= All spaces) unless user explicitly picks one.
       renderConnectionPill();
       refreshHiddenToggleUI();
@@ -1024,13 +1081,15 @@
 
     /* --- Space + template + wizard renders --------------------------- */
 
+    function sessionSpaceLabel() {
+      if (state.sessionSpaceName) return state.sessionSpaceName;
+      if (state.sessionSpaceId) return `Space ${state.sessionSpaceId.slice(0, 8)}`;
+      return "Current space";
+    }
+
     function renderSpaceSelect() {
       const select = $("space-select");
-      const allSpaces = state.spaces.length
-        ? state.spaces
-        : state.sessionSpaceId
-        ? [{ id: state.sessionSpaceId, name: "Current space" }]
-        : [];
+      const allSpaces = knownSpaces();
       clearChildren(select);
       // Always include the "All spaces" option as the default filter.
       const allOpt = makeEl("option", { value: "" }, ["All spaces"]);
@@ -1045,11 +1104,7 @@
 
     function renderAgentSpaceOptions() {
       const select = $("agent-space-input");
-      const spaces = state.spaces.length
-        ? state.spaces
-        : state.sessionSpaceId
-        ? [{ id: state.sessionSpaceId, name: "Current space" }]
-        : [];
+      const spaces = knownSpaces();
       clearChildren(select);
       if (!spaces.length) {
         select.appendChild(makeEl("option", { value: "" }, ["No spaces available"]));

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -101,6 +101,7 @@
     .section-title h2 { margin: 0; font-size: 18px; font-weight: 500; letter-spacing: -0.005em; }
     .section-title .count { color: var(--muted); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 12px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); }
     .section-title .count[hidden] { display: none; }
+    .cleanup-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
 
     /* Connect card (disconnected state) */
     .connect-card { padding: 36px 32px; border-radius: var(--radius); border: 1px solid var(--line-strong); background: var(--panel); backdrop-filter: blur(10px); }
@@ -117,12 +118,17 @@
     /* Agent list (rows) */
     .agent-list { border-radius: var(--radius); border: 1px solid var(--line); background: var(--panel); backdrop-filter: blur(10px); overflow: hidden; }
     .agent-grid-cols { display: grid; grid-template-columns: 38px minmax(220px, 1.15fr) minmax(150px, 0.72fr) minmax(210px, 1fr) minmax(40px, auto); gap: 14px; align-items: center; }
+    .agent-list.cleanup-mode .agent-grid-cols { grid-template-columns: 30px 38px minmax(220px, 1.15fr) minmax(150px, 0.72fr) minmax(210px, 1fr) minmax(40px, auto); }
     .agent-list-head { padding: 12px 20px; border-bottom: 1px solid var(--line); background: rgba(255, 255, 255, 0.02); font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted-2); }
     .agent-row { padding: 16px 20px; border: 0; border-bottom: 1px solid var(--line); background: transparent; color: var(--text); cursor: pointer; transition: background 120ms ease; text-align: left; font: inherit; width: 100%; }
     .agent-row:last-child { border-bottom: 0; }
     .agent-row:hover { background: rgba(255, 255, 255, 0.03); }
     .agent-row:focus-visible { outline: 2px solid rgba(94, 234, 212, 0.5); outline-offset: -2px; }
     .agent-row.active-row { background: rgba(94, 234, 212, 0.06); }
+    .agent-list.cleanup-mode .agent-row { cursor: default; }
+    .cleanup-cell { display: none; justify-self: center; align-items: center; }
+    .agent-list.cleanup-mode .cleanup-cell { display: inline-flex; }
+    .cleanup-check { width: 18px; height: 18px; accent-color: var(--accent); cursor: pointer; }
 
     .dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; justify-self: center; background: var(--muted-2); transition: background 200ms ease, box-shadow 200ms ease; }
     .dot.tone-ok { background: var(--green); box-shadow: 0 0 0 4px var(--green-soft); }
@@ -308,6 +314,7 @@
 
     @media (max-width: 960px) {
       .agent-grid-cols { grid-template-columns: 38px minmax(170px, 1fr) minmax(128px, 0.65fr) minmax(154px, 0.82fr) minmax(30px, auto); gap: 12px; }
+      .agent-list.cleanup-mode .agent-grid-cols { grid-template-columns: 30px 38px minmax(170px, 1fr) minmax(128px, 0.65fr) minmax(154px, 0.82fr) minmax(30px, auto); }
       .row-space { font-size: 12px; }
     }
     @media (max-width: 720px) {
@@ -317,6 +324,7 @@
       .hero-actions { margin-top: 20px; }
       .topbar { margin-bottom: 24px; }
       .agent-grid-cols { grid-template-columns: 34px minmax(0, 1fr) minmax(96px, 0.55fr) minmax(116px, 0.65fr) minmax(22px, auto); gap: 10px; }
+      .agent-list.cleanup-mode .agent-grid-cols { grid-template-columns: 28px 34px minmax(0, 1fr) minmax(96px, 0.55fr) minmax(116px, 0.65fr) minmax(22px, auto); }
       .type-mark { width: 30px; height: 30px; border-radius: 9px; }
       .type-mark svg { width: 18px; height: 18px; }
       .row-agent { gap: 9px; }
@@ -385,7 +393,10 @@
     <section>
       <div class="section-title">
         <h2 id="list-title">Your agents</h2>
-        <div style="display: flex; align-items: center; gap: 10px;">
+        <div class="cleanup-actions">
+          <button type="button" class="system-toggle" id="cleanup-hide-btn" hidden title="Hide selected agents from the list and stop their runtimes">Hide selected</button>
+          <span class="count" id="cleanup-selection" hidden></span>
+          <button type="button" class="system-toggle" id="cleanup-toggle" title="Bulk-clean stale agents from this list">Clean up</button>
           <button type="button" class="system-toggle" id="system-toggle" title="Show gateway-internal agents like switchboards">Show system agents</button>
           <span class="count" id="agent-count" hidden></span>
         </div>
@@ -502,6 +513,8 @@
       rowsByName: new Map(),
       lastRenderMode: null, // "disconnected" | "connect" | "list"
       showSystemAgents: false,
+      cleanupMode: false,
+      selectedNames: new Set(),
     };
 
     // Restore system-agent toggle state from localStorage so the choice persists across reloads.
@@ -1214,6 +1227,7 @@
         list = makeEl("div", { class: "agent-list" });
         // Header row (column labels)
         const head = makeEl("div", { class: "agent-list-head agent-grid-cols" }, [
+          makeEl("span", { class: "cleanup-cell" }),
           makeEl("span"),
           makeEl("span", null, ["Agent"]),
           makeEl("span", null, ["Space"]),
@@ -1255,6 +1269,15 @@
           const row = state.rowsByName.get(name);
           if (row) list.appendChild(row);
         }
+      }
+      // Reapply cleanup-mode class (list may have been recreated above) and
+      // restore checkbox states for any selected agents that survived a reorder.
+      if (state.cleanupMode) {
+        list.classList.add("cleanup-mode");
+        list.querySelectorAll(".cleanup-check").forEach((cb) => {
+          const name = cb.dataset.name;
+          if (name && state.selectedNames.has(name)) cb.checked = true;
+        });
       }
     }
 
@@ -1361,14 +1384,34 @@
         tabindex: "0",
         class: "agent-row agent-grid-cols",
         dataset: { name },
-        onclick: () => openDrawer(name),
+        onclick: (event) => {
+          if (state.cleanupMode) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
+          openDrawer(name);
+        },
         onkeydown: (event) => {
+          if (state.cleanupMode) return;
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
             openDrawer(name);
           }
         },
       });
+      const cleanupCell = makeEl("span", { class: "cleanup-cell" }, [
+        makeEl("input", {
+          type: "checkbox",
+          class: "cleanup-check",
+          dataset: { name },
+          onclick: (event) => {
+            event.stopPropagation();
+            toggleAgentSelection(name, event.target.checked);
+          },
+        }),
+      ]);
+      row.appendChild(cleanupCell);
       row.appendChild(makeEl("span", { class: "dot tone-muted" }));
       row.appendChild(makeEl("span", { class: "row-agent" }, [
         makeEl("span", { class: "type-mark type-custom", title: "Custom", "aria-label": "Custom" }, [typeIcon("custom", "Custom")]),
@@ -2262,6 +2305,89 @@
       state.lastRenderMode = null;
       ensureListMode();
       renderAgentList();
+    });
+
+    function applyCleanupModeClass() {
+      const list = document.querySelector(".agent-list");
+      if (!list) return;
+      list.classList.toggle("cleanup-mode", state.cleanupMode);
+    }
+
+    function refreshCleanupToolbar() {
+      const toggleBtn = $("cleanup-toggle");
+      const hideBtn = $("cleanup-hide-btn");
+      const selCount = $("cleanup-selection");
+      if (state.cleanupMode) {
+        toggleBtn.textContent = "Cancel";
+        toggleBtn.classList.add("on");
+        const n = state.selectedNames.size;
+        hideBtn.hidden = n === 0;
+        hideBtn.textContent = n > 0 ? `Hide ${n} selected` : "Hide selected";
+        selCount.hidden = n === 0;
+        selCount.textContent = n > 0 ? `${n} selected` : "";
+      } else {
+        toggleBtn.textContent = "Clean up";
+        toggleBtn.classList.remove("on");
+        hideBtn.hidden = true;
+        selCount.hidden = true;
+      }
+    }
+
+    function toggleAgentSelection(name, checked) {
+      if (checked) state.selectedNames.add(name);
+      else state.selectedNames.delete(name);
+      refreshCleanupToolbar();
+    }
+
+    function exitCleanupMode() {
+      state.cleanupMode = false;
+      state.selectedNames.clear();
+      // Clear all checkboxes in the DOM.
+      const list = document.querySelector(".agent-list");
+      if (list) {
+        list.querySelectorAll(".cleanup-check").forEach((cb) => { cb.checked = false; });
+      }
+      applyCleanupModeClass();
+      refreshCleanupToolbar();
+    }
+
+    async function hideSelectedAgents() {
+      const names = Array.from(state.selectedNames);
+      if (!names.length) return;
+      const hideBtn = $("cleanup-hide-btn");
+      const original = hideBtn.textContent;
+      hideBtn.disabled = true;
+      hideBtn.textContent = "Hiding…";
+      try {
+        const result = await api("POST", "/api/agents/cleanup-hide", { names, reason: "operator_cleanup" });
+        const hidden = (result && result.count) || 0;
+        const missing = (result && result.missing) || [];
+        if (missing.length) {
+          showToast(`Hid ${hidden}, ${missing.length} not found`, "warn");
+        } else {
+          showToast(`Hid ${hidden} agent${hidden === 1 ? "" : "s"}`, "ok");
+        }
+        exitCleanupMode();
+        await loadStatus();
+      } catch (err) {
+        showToast(err.message || "Hide failed", "err");
+        hideBtn.disabled = false;
+        hideBtn.textContent = original;
+      }
+    }
+
+    $("cleanup-toggle").addEventListener("click", () => {
+      if (state.cleanupMode) {
+        exitCleanupMode();
+        return;
+      }
+      state.cleanupMode = true;
+      applyCleanupModeClass();
+      refreshCleanupToolbar();
+    });
+
+    $("cleanup-hide-btn").addEventListener("click", () => {
+      void hideSelectedAgents();
     });
 
     wizardSubmit.addEventListener("click", async () => {

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5391,6 +5391,65 @@ def test_operator_cleanup_hides_selected_agents(monkeypatch, tmp_path):
     assert [event["event"] for event in recent].count("managed_agent_hidden") == 2
 
 
+def test_operator_cleanup_restore_unhides_selected_agents(monkeypatch, tmp_path):
+    """Symmetric to hide: _restore_hidden_managed_agents clears the hidden
+    bookkeeping, restores desired_state from the captured before-hide value,
+    re-emits the row in default /api/status, and records a
+    managed_agent_unhidden activity event per restored row.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    registry = {
+        "agents": [
+            {
+                "name": "previously-hidden",
+                "agent_id": "agent-prev-hidden",
+                "template_id": "claude_code_channel",
+                "runtime_type": "claude_code_channel",
+                "lifecycle_phase": "hidden",
+                "desired_state": "stopped",
+                "desired_state_before_hide": "running",
+                "hidden_at": gateway_core._now_iso(),
+                "hidden_reason": "operator_cleanup",
+            },
+            {
+                "name": "active-keeper",
+                "agent_id": "agent-keeper",
+                "template_id": "echo",
+                "runtime_type": "echo",
+                "desired_state": "running",
+            },
+        ]
+    }
+    gateway_core.save_gateway_registry(registry)
+
+    # Restore one row plus name a non-existent and a non-hidden row to verify
+    # missing/not_hidden partitions.
+    payload = gateway_cmd._restore_hidden_managed_agents(
+        ["previously-hidden", "ghost", "active-keeper"]
+    )
+
+    assert payload["count"] == 1
+    assert payload["missing"] == ["ghost"]
+    assert payload["not_hidden"] == ["active-keeper"]
+
+    stored = {agent["name"]: agent for agent in gateway_core.load_gateway_registry()["agents"]}
+    restored = stored["previously-hidden"]
+    assert restored["lifecycle_phase"] == "active"
+    assert restored["desired_state"] == "running"  # restored from desired_state_before_hide
+    assert "desired_state_before_hide" not in restored
+    assert "hidden_at" not in restored
+    assert "hidden_reason" not in restored
+
+    # Restored row reappears in default /api/status agents list.
+    visible_payload = gateway_cmd._status_payload(activity_limit=0)
+    visible_names = sorted(agent["name"] for agent in visible_payload["agents"])
+    assert "previously-hidden" in visible_names
+    assert visible_payload["summary"]["hidden_agents"] == 0
+
+    recent = gateway_core.load_recent_gateway_activity()
+    assert [event["event"] for event in recent].count("managed_agent_unhidden") == 1
+
+
 def test_lifecycle_signal_sent_on_connected_to_stale(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
     client = _RecordingHeartbeatClient()

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5391,6 +5391,102 @@ def test_operator_cleanup_hides_selected_agents(monkeypatch, tmp_path):
     assert [event["event"] for event in recent].count("managed_agent_hidden") == 2
 
 
+def test_recover_managed_agents_from_evidence_restores_lost_row(monkeypatch, tmp_path):
+    """Pre-race-fix damage recovery: when a managed_agent_added activity
+    event exists locally but the registry row is missing (silent race
+    clobber), _recover_managed_agents_from_evidence reconstructs a
+    minimal row using only verified evidence — never fabricating
+    credentials.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    # Pre-condition: registry empty, but token file + managed_agent_added
+    # event exist locally — exactly the cc-backend / widget_smith state.
+    gateway_core.save_gateway_registry({"agents": []})
+
+    token_dir = gateway_core.agent_dir("ghost-agent")
+    token_dir.mkdir(parents=True, exist_ok=True)
+    (token_dir / "token").write_text("axp_a_ghost.evidence", encoding="utf-8")
+
+    gateway_core.record_gateway_activity(
+        "managed_agent_added",
+        agent_name="ghost-agent",
+        agent_id="agent-ghost-id",
+        asset_id="agent-ghost-id",
+        install_id="install-ghost",
+        gateway_id="gateway-host",
+        runtime_type="claude_code_channel",
+        transport="gateway",
+        space_id="49afd277-78d2-4a32-9858-3594cda684af",
+        token_file=str(token_dir / "token"),
+        credential_source="gateway",
+    )
+
+    payload = gateway_cmd._recover_managed_agents_from_evidence(["ghost-agent", "missing-no-evidence"])
+
+    assert payload["count"] == 1
+    assert payload["already_present"] == []
+    assert payload["no_evidence"] == ["missing-no-evidence"]
+
+    stored = gateway_core.load_gateway_registry()
+    row = next((a for a in stored["agents"] if a.get("name") == "ghost-agent"), None)
+    assert row is not None, "recovered row missing from registry"
+    assert row["agent_id"] == "agent-ghost-id"
+    assert row["install_id"] == "install-ghost"
+    assert row["runtime_type"] == "claude_code_channel"
+    assert row["template_id"] == "claude_code_channel"
+    assert row["space_id"] == "49afd277-78d2-4a32-9858-3594cda684af"
+    assert row["token_file"] == str(token_dir / "token")
+    assert row["lifecycle_phase"] == "active"
+    assert row["desired_state"] == "stopped"  # safe default — operator restarts deliberately
+    assert row["drift_reason"] == "registry_row_recovered_from_evidence"
+
+    # managed_agent_recovered activity event was recorded.
+    recent = gateway_core.load_recent_gateway_activity()
+    events = [e for e in recent if e.get("event") == "managed_agent_recovered"]
+    assert len(events) == 1
+    assert events[0].get("agent_name") == "ghost-agent"
+
+
+def test_recover_managed_agents_refuses_when_token_missing(monkeypatch, tmp_path):
+    """Recovery requires BOTH the activity event AND the token file.
+    Missing token → no recovery (we don't fabricate credentials).
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    gateway_core.save_gateway_registry({"agents": []})
+
+    # Activity event exists but no token file.
+    gateway_core.record_gateway_activity(
+        "managed_agent_added",
+        agent_name="no-token-agent",
+        agent_id="agent-id",
+        asset_id="agent-id",
+        install_id="install-id",
+        gateway_id="gateway-host",
+        runtime_type="echo",
+        transport="gateway",
+        space_id="space-1",
+        token_file="/tmp/nonexistent-recovery-token-path",
+        credential_source="gateway",
+    )
+
+    payload = gateway_cmd._recover_managed_agents_from_evidence(["no-token-agent"])
+    assert payload["count"] == 0
+    assert payload["no_evidence"] == ["no-token-agent"]
+
+
+def test_recover_managed_agents_skips_already_present_rows(monkeypatch, tmp_path):
+    """Idempotent: if a row already exists, recovery is a no-op for it."""
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    gateway_core.save_gateway_registry(
+        {"agents": [{"name": "already-there", "agent_id": "existing", "template_id": "echo"}]}
+    )
+
+    payload = gateway_cmd._recover_managed_agents_from_evidence(["already-there"])
+    assert payload["count"] == 0
+    assert payload["already_present"] == ["already-there"]
+    assert payload["no_evidence"] == []
+
+
 def test_operator_cleanup_restore_unhides_selected_agents(monkeypatch, tmp_path):
     """Symmetric to hide: _restore_hidden_managed_agents clears the hidden
     bookkeeping, restores desired_state from the captured before-hide value,

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5795,3 +5795,85 @@ def test_status_payload_partitions_archived_separately(monkeypatch, tmp_path):
     all_names = [a["name"] for a in payload_all["agents"]]
     assert "hermes-archived" in all_names
     assert payload_all["summary"]["archived_agents"] == 1
+
+
+def test_runtime_start_skips_when_in_setup_error_backoff(monkeypatch, tmp_path):
+    """Setup-error backoff: runtime.start() must early-return when a
+    runtime_error fired within the last SETUP_ERROR_BACKOFF_SECONDS,
+    so the daemon's per-tick reconcile (every ~1s) doesn't fire a
+    runtime_error storm and pressure upstream rate limits.
+
+    Reproduces the demo-hermes spam: missing token file + desired_state
+    running → 140 runtime_error events in 5 minutes.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    token_file = tmp_path / "token-does-not-exist"  # intentionally missing
+
+    runtime = gateway_core.ManagedAgentRuntime(
+        {
+            "name": "stuck-hermes",
+            "agent_id": "agent-stuck",
+            "space_id": "space-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "hermes_sentinel",
+            "token_file": str(token_file),
+            # Simulates the entry state after a setup error: error 1s ago,
+            # well within the 30s backoff window.
+            "last_runtime_error_at": gateway_core._now_iso(),
+        },
+        client_factory=lambda **kwargs: object(),
+    )
+
+    before = gateway_core.load_recent_gateway_activity()
+    runtime.start()
+    after = gateway_core.load_recent_gateway_activity()
+
+    # Gate must early-return without firing a fresh runtime_error event.
+    assert len(after) == len(before), (
+        "runtime.start() emitted a runtime_error event while in backoff "
+        "window — gate regressed"
+    )
+    # State must be untouched — no transition through "starting".
+    assert runtime._state.get("effective_state") != "starting"
+
+
+def test_runtime_start_proceeds_after_setup_error_backoff_expires(monkeypatch, tmp_path):
+    """Once the backoff window expires, the runtime is allowed to retry.
+    The retry will fire its own runtime_error if the precondition is
+    still broken — that fresh error stamps a new last_runtime_error_at,
+    re-arming the gate.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    token_file = tmp_path / "token-does-not-exist"  # still missing
+
+    # last_runtime_error_at older than the backoff window.
+    long_ago = (
+        datetime.now(timezone.utc) - timedelta(seconds=gateway_core.SETUP_ERROR_BACKOFF_SECONDS + 60)
+    ).isoformat()
+
+    runtime = gateway_core.ManagedAgentRuntime(
+        {
+            "name": "expired-hermes",
+            "agent_id": "agent-expired",
+            "space_id": "space-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "hermes_sentinel",
+            "token_file": str(token_file),
+            "last_runtime_error_at": long_ago,
+        },
+        client_factory=lambda **kwargs: object(),
+    )
+
+    before = gateway_core.load_recent_gateway_activity()
+    runtime.start()
+    after = gateway_core.load_recent_gateway_activity()
+
+    new_events = [e for e in after if e not in before]
+    runtime_errors = [e for e in new_events if e.get("event") == "runtime_error"]
+    assert len(runtime_errors) == 1, (
+        f"expected exactly one runtime_error after backoff expired, got {len(runtime_errors)}"
+    )
+    # Fresh error stamps a new last_runtime_error_at, re-arming the gate
+    # against repeat retries from the next reconcile tick.
+    assert runtime.entry.get("last_runtime_error_at") is not None
+    assert runtime.entry["last_runtime_error_at"] != long_ago

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5479,3 +5479,234 @@ def test_send_local_session_message_extracts_mentions_when_client_omits_them():
     assert metadata["mentions"] == ["night_owl"]
     assert metadata["routing_intent"] == "reply_with_mentions"
     assert metadata["purpose"] == "test"
+
+
+def test_archive_managed_agent_sets_phase_and_stops_runtime(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    entry = {
+        "name": "probe-doomed",
+        "agent_id": "agent-doomed",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "desired_state": "running",
+        "effective_state": "running",
+        "liveness": "connected",
+        "last_seen_age_seconds": 5.0,
+    }
+    gateway_core.save_gateway_registry({"agents": [entry]})
+    client = _RecordingHeartbeatClient()
+    result = gateway_cmd._archive_managed_agent(
+        "probe-doomed", reason="cleanup", client_factory=lambda: client
+    )
+    assert result["lifecycle_phase"] == "archived"
+    registry = gateway_core.load_gateway_registry()
+    stored = next(a for a in registry["agents"] if a["name"] == "probe-doomed")
+    assert stored["lifecycle_phase"] == "archived"
+    assert stored["archived_reason"] == "cleanup"
+    assert stored["desired_state"] == "stopped"
+    assert stored["desired_state_before_archive"] == "running"
+    assert "archived_at" in stored
+    # Upstream signal sent best-effort.
+    assert any(h["status"] == "archived" for h in client.heartbeats)
+    # Audit event recorded.
+    recent = gateway_core.load_recent_gateway_activity()
+    assert any(r.get("event") == "managed_agent_archived" for r in recent)
+
+
+def test_archive_managed_agent_idempotent(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    entry = {
+        "name": "probe-already",
+        "agent_id": "agent-already",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "lifecycle_phase": "archived",
+        "archived_at": gateway_core._now_iso(),
+        "archived_reason": "first call",
+        "desired_state": "stopped",
+        "desired_state_before_archive": "running",
+    }
+    gateway_core.save_gateway_registry({"agents": [entry]})
+    client = _RecordingHeartbeatClient()
+    gateway_cmd._archive_managed_agent(
+        "probe-already", reason="second call", client_factory=lambda: client
+    )
+    stored = next(
+        a for a in gateway_core.load_gateway_registry()["agents"] if a["name"] == "probe-already"
+    )
+    # Reason not overwritten on a no-op archive — first archived_reason preserved.
+    assert stored["archived_reason"] == "first call"
+    assert client.heartbeats == []
+
+
+def test_archive_then_restore_returns_to_prior_desired_state(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    entry = {
+        "name": "probe-roundtrip",
+        "agent_id": "agent-rt",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "desired_state": "running",
+        "effective_state": "running",
+        "liveness": "connected",
+        "last_seen_age_seconds": 5.0,
+    }
+    gateway_core.save_gateway_registry({"agents": [entry]})
+    client = _RecordingHeartbeatClient()
+    gateway_cmd._archive_managed_agent("probe-roundtrip", client_factory=lambda: client)
+    gateway_cmd._restore_managed_agent("probe-roundtrip", client_factory=lambda: client)
+    stored = next(
+        a for a in gateway_core.load_gateway_registry()["agents"] if a["name"] == "probe-roundtrip"
+    )
+    assert stored["lifecycle_phase"] == "active"
+    assert stored["desired_state"] == "running"
+    assert "archived_at" not in stored
+    assert "archived_reason" not in stored
+    assert "desired_state_before_archive" not in stored
+    recent = gateway_core.load_recent_gateway_activity()
+    assert any(r.get("event") == "managed_agent_restored" for r in recent)
+    # Restore signals 'connected' upstream.
+    assert any(h["status"] == "connected" for h in client.heartbeats)
+
+
+def test_restore_unarchived_agent_is_noop(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    entry = {
+        "name": "probe-active",
+        "agent_id": "agent-active",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "lifecycle_phase": "active",
+        "desired_state": "running",
+    }
+    gateway_core.save_gateway_registry({"agents": [entry]})
+    client = _RecordingHeartbeatClient()
+    gateway_cmd._restore_managed_agent("probe-active", client_factory=lambda: client)
+    # No upstream noise on a no-op restore.
+    assert client.heartbeats == []
+
+
+def test_sweep_does_not_unhide_archived_agent(monkeypatch, tmp_path):
+    """Archived is sticky — sweep must not auto-restore even when liveness=connected."""
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    client = _RecordingHeartbeatClient()
+    daemon = _build_daemon(client)
+    entry = _stale_hermes_entry("probe-archived", age_seconds=2.0, liveness="connected")
+    entry["lifecycle_phase"] = "archived"
+    entry["archived_at"] = gateway_core._now_iso()
+    registry = {"agents": [entry]}
+    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
+    # Sticky — sweep must not flip back to active.
+    assert entry["lifecycle_phase"] == "archived"
+    # No upstream signaling for archived entries either.
+    assert client.heartbeats == []
+
+
+def test_save_registry_preserves_restore_written_during_daemon_tick(monkeypatch, tmp_path):
+    """Race regression (other direction): daemon's stale-archived view must
+    not clobber a CLI restore that landed mid-tick.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {
+                "name": "race-restore",
+                "agent_id": "agent-restore",
+                "template_id": "hermes",
+                "runtime_type": "hermes_sentinel",
+                "lifecycle_phase": "archived",
+                "archived_at": gateway_core._now_iso(),
+                "archived_reason": "earlier",
+                "desired_state": "stopped",
+                "desired_state_before_archive": "running",
+            }
+        ]
+    }
+    gateway_core.save_gateway_registry(initial, merge_archive=False)
+
+    # Daemon's stale in-memory copy: still sees the agent as archived.
+    daemon_view = gateway_core.load_gateway_registry()
+
+    # CLI restores between the daemon's load and the daemon's save.
+    gateway_cmd._restore_managed_agent("race-restore")
+
+    # Daemon now saves its (stale, still-archived) copy. Bidirectional merge
+    # should pull the disk's freshly-active state forward.
+    gateway_core.save_gateway_registry(daemon_view)
+
+    final = gateway_core.load_gateway_registry()
+    stored = next(a for a in final["agents"] if a["name"] == "race-restore")
+    assert stored["lifecycle_phase"] == "active"
+    assert "archived_at" not in stored
+    assert "archived_reason" not in stored
+
+
+def test_save_registry_preserves_archive_written_during_daemon_tick(monkeypatch, tmp_path):
+    """Race regression: daemon load → modify → save must not clobber a CLI
+    archive that landed between the daemon's load and the daemon's save.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    # Initial state: probe is active, runtime running.
+    initial = {
+        "agents": [
+            {
+                "name": "race-probe",
+                "agent_id": "agent-race",
+                "template_id": "hermes",
+                "runtime_type": "hermes_sentinel",
+                "lifecycle_phase": "active",
+                "desired_state": "running",
+                "liveness": "connected",
+            }
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Daemon's stale in-memory copy from the start of its tick.
+    daemon_view = gateway_core.load_gateway_registry()
+    daemon_view["agents"][0]["effective_state"] = "running"  # daemon-side update
+
+    # CLI archives between the daemon's load and the daemon's save.
+    gateway_cmd._archive_managed_agent("race-probe")
+
+    # Daemon now saves its (stale) copy. Race-safety merge should preserve
+    # the archive fields the CLI wrote.
+    gateway_core.save_gateway_registry(daemon_view)
+
+    final = gateway_core.load_gateway_registry()
+    stored = next(a for a in final["agents"] if a["name"] == "race-probe")
+    assert stored["lifecycle_phase"] == "archived"
+    assert stored["desired_state"] == "stopped"
+    assert "archived_at" in stored
+
+
+def test_status_payload_partitions_archived_separately(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    archived = _stale_hermes_entry("hermes-archived", age_seconds=5.0, liveness="connected",
+                                   agent_id="agent-archived")
+    archived["lifecycle_phase"] = "archived"
+    archived["archived_at"] = gateway_core._now_iso()
+    active = {
+        "name": "hermes-live",
+        "agent_id": "agent-live",
+        "template_id": "hermes",
+        "runtime_type": "hermes_sentinel",
+        "effective_state": "running",
+        "liveness": "connected",
+        "last_seen_age_seconds": 5.0,
+        "last_seen_at": gateway_core._now_iso(),
+    }
+    gateway_core.save_gateway_registry({"agents": [archived, active]})
+
+    payload = gateway_cmd._status_payload(activity_limit=0)
+    names = [a["name"] for a in payload["agents"]]
+    assert "hermes-archived" not in names
+    assert "hermes-live" in names
+    assert payload["summary"]["archived_agents"] == 1
+    assert payload["summary"]["managed_agents"] == 1
+
+    # include_hidden=True surfaces archived alongside hidden + system.
+    payload_all = gateway_cmd._status_payload(activity_limit=0, include_hidden=True)
+    all_names = [a["name"] for a in payload_all["agents"]]
+    assert "hermes-archived" in all_names
+    assert payload_all["summary"]["archived_agents"] == 1

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5203,36 +5203,21 @@ def _isolate_gateway_paths(monkeypatch, tmp_path):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path / "gw"))
 
 
-def test_sweep_hides_stale_agent_after_threshold(monkeypatch, tmp_path):
+def test_sweep_does_not_auto_hide_stale_agent(monkeypatch, tmp_path):
+    """Sweep must never mutate lifecycle_phase. Hide is operator-driven only."""
     _isolate_gateway_paths(monkeypatch, tmp_path)
-    monkeypatch.delenv("AX_GATEWAY_HIDE_AFTER_STALE_SECONDS", raising=False)
     client = _RecordingHeartbeatClient()
     daemon = _build_daemon(client)
     entry = _stale_hermes_entry("hermes-old", age_seconds=20 * 60)
     registry = {"agents": [entry]}
     daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
-    assert entry["lifecycle_phase"] == "hidden"
-    assert "hidden_at" in entry
-    assert entry["hidden_reason"] == "stale"
+    assert entry.get("lifecycle_phase", "active") == "active"
+    assert "hidden_at" not in entry
+    assert "hidden_reason" not in entry
     recent = gateway_core.load_recent_gateway_activity()
-    assert any(r.get("event") == "managed_agent_hidden" for r in recent)
-
-
-def test_sweep_idempotent_for_already_hidden(monkeypatch, tmp_path):
-    _isolate_gateway_paths(monkeypatch, tmp_path)
-    client = _RecordingHeartbeatClient()
-    daemon = _build_daemon(client)
-    entry = _stale_hermes_entry("hermes-old", age_seconds=20 * 60)
-    registry = {"agents": [entry]}
-    session = {"token": "axp_u_test", "base_url": "http://x"}
-    daemon._sweep_lifecycle(registry, session=session)
-    daemon._sweep_lifecycle(registry, session=session)
-    hidden_events = [
-        r for r in gateway_core.load_recent_gateway_activity()
-        if r.get("event") == "managed_agent_hidden"
-    ]
-    assert len(hidden_events) == 1
-    assert len(client.heartbeats) == 1
+    assert not any(r.get("event") == "managed_agent_hidden" for r in recent)
+    # Upstream liveness signal still goes out — that's the sweep's only job.
+    assert client.heartbeats and client.heartbeats[0]["status"] == "stale"
 
 
 def test_sweep_skips_switchboard(monkeypatch, tmp_path):
@@ -5271,21 +5256,22 @@ def test_sweep_skips_service_account(monkeypatch, tmp_path):
     assert client.heartbeats == []
 
 
-def test_sweep_unhides_on_reconnect(monkeypatch, tmp_path):
+def test_sweep_does_not_auto_unhide_on_reconnect(monkeypatch, tmp_path):
+    """A user-hidden agent that reconnects stays hidden — operator intent
+    sticks across liveness changes. Only ``unhide`` (CLI / UI) restores it."""
     _isolate_gateway_paths(monkeypatch, tmp_path)
     client = _RecordingHeartbeatClient()
     daemon = _build_daemon(client)
     entry = _stale_hermes_entry("hermes-back", age_seconds=2.0, liveness="connected")
     entry["lifecycle_phase"] = "hidden"
     entry["hidden_at"] = gateway_core._now_iso()
-    entry["hidden_reason"] = "stale"
+    entry["hidden_reason"] = "operator_cleanup"
     registry = {"agents": [entry]}
     daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
-    assert entry["lifecycle_phase"] == "active"
-    assert "hidden_at" not in entry
-    assert "hidden_reason" not in entry
+    assert entry["lifecycle_phase"] == "hidden"
+    assert entry["hidden_reason"] == "operator_cleanup"
     recent = gateway_core.load_recent_gateway_activity()
-    assert any(r.get("event") == "managed_agent_unhidden" for r in recent)
+    assert not any(r.get("event") == "managed_agent_unhidden" for r in recent)
 
 
 def test_status_payload_filters_hidden_by_default(monkeypatch, tmp_path):
@@ -5583,9 +5569,10 @@ def test_lifecycle_signal_404_tolerant(monkeypatch, tmp_path):
     entry = _stale_hermes_entry("hermes-ghost", age_seconds=20 * 60)
     registry = {"agents": [entry]}
     daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
-    # Hide still applied locally even though upstream said 404.
-    assert entry["lifecycle_phase"] == "hidden"
-    # Sticky last_lifecycle_signal updated → no infinite retry next tick.
+    # Sweep doesn't mutate lifecycle_phase regardless of upstream response.
+    assert entry.get("lifecycle_phase", "active") == "active"
+    # 404 counts as "platform doesn't know about this agent" — sticky signal
+    # still updated so we don't retry forever.
     assert entry["last_lifecycle_signal"]["phase"] == "stale"
 
 
@@ -5653,8 +5640,9 @@ def test_legacy_entry_without_lifecycle_phase_loads_as_active(monkeypatch, tmp_p
     }
     registry = {"agents": [entry]}
     daemon._sweep_lifecycle(registry, session={"token": "axp_u_test"})
-    # Legacy entry got swept normally (treated as implicit active → hidden).
-    assert entry["lifecycle_phase"] == "hidden"
+    # Legacy entry stays active — sweep no longer auto-hides. The default
+    # ``active`` phase is implied for entries with no lifecycle_phase field.
+    assert entry.get("lifecycle_phase", "active") == "active"
 
 
 def test_send_local_session_message_extracts_mentions_when_client_omits_them():

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5929,3 +5929,114 @@ def test_runtime_start_proceeds_after_setup_error_backoff_expires(monkeypatch, t
     # against repeat retries from the next reconcile tick.
     assert runtime.entry.get("last_runtime_error_at") is not None
     assert runtime.entry["last_runtime_error_at"] != long_ago
+
+
+# ---------------------------------------------------------------------------
+# Upstream 429 backoff + cache (b)
+# ---------------------------------------------------------------------------
+
+
+def _make_429_error() -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://paxai.app/api/v1/agents")
+    response = httpx.Response(429, headers={"retry-after": "12"}, request=request)
+    return httpx.HTTPStatusError("429 Too Many Requests", request=request, response=response)
+
+
+def test_with_upstream_429_retry_succeeds_on_second_attempt(monkeypatch):
+    """Helper retries on 429 and returns the success result of the next call."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(gateway_cmd.time, "sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def call():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _make_429_error()
+        return {"agent": "ok"}
+
+    result = gateway_cmd._with_upstream_429_retry(call, max_retries=2, base_wait=1.0)
+    assert result == {"agent": "ok"}
+    assert calls["n"] == 2
+    assert sleeps == [1.0]  # one backoff before the successful retry
+
+
+def test_with_upstream_429_retry_exhausts_then_raises(monkeypatch):
+    """All attempts 429 → raises UpstreamRateLimitedError carrying the
+    parsed Retry-After hint.
+    """
+    sleeps: list[float] = []
+    monkeypatch.setattr(gateway_cmd.time, "sleep", lambda s: sleeps.append(s))
+
+    def call():
+        raise _make_429_error()
+
+    with pytest.raises(gateway_cmd.UpstreamRateLimitedError) as exc_info:
+        gateway_cmd._with_upstream_429_retry(call, max_retries=2, base_wait=1.0)
+    assert exc_info.value.retries_attempted == 2
+    assert exc_info.value.retry_after_seconds == 12  # parsed from header
+    # 2 retries × exponential = 1s + 2s.
+    assert sleeps == [1.0, 2.0]
+
+
+def test_with_upstream_429_retry_propagates_other_errors(monkeypatch):
+    """Non-429 httpx errors propagate without retry."""
+    monkeypatch.setattr(gateway_cmd.time, "sleep", lambda s: None)
+
+    request = httpx.Request("POST", "https://paxai.app/api/v1/agents")
+    server_error = httpx.HTTPStatusError(
+        "500 Internal Server Error",
+        request=request,
+        response=httpx.Response(500, request=request),
+    )
+
+    def call():
+        raise server_error
+
+    with pytest.raises(httpx.HTTPStatusError):
+        gateway_cmd._with_upstream_429_retry(call, max_retries=3, base_wait=0.1)
+
+
+def test_backend_agent_record_falls_back_to_cache_on_failure(monkeypatch, tmp_path):
+    """When list_agents raises (e.g. 429), _backend_agent_record returns
+    the agent from the local cache instead of None — so dashboard reads
+    survive transient upstream rate limits.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    # Seed the cache as if a previous successful call had populated it.
+    gateway_cmd._save_agents_cache(
+        [
+            {"name": "cached_agent", "agent_id": "agent-cached", "space_id": "space-1"},
+            {"name": "other_agent", "agent_id": "agent-other"},
+        ]
+    )
+
+    class FailingClient:
+        def list_agents(self):
+            raise _make_429_error()
+
+    found = gateway_cmd._backend_agent_record(FailingClient(), "cached_agent")
+    assert found is not None
+    assert found["agent_id"] == "agent-cached"
+
+
+def test_backend_agent_record_seeds_cache_on_successful_upstream(monkeypatch, tmp_path):
+    """Successful upstream list_agents writes to the cache so the next
+    failure has data to serve.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    assert gateway_cmd._load_agents_cache() == []  # empty pre-condition
+
+    class StubClient:
+        def list_agents(self):
+            return {
+                "agents": [
+                    {"name": "fresh_agent", "agent_id": "agent-fresh", "space_id": "space-1"},
+                ]
+            }
+
+    found = gateway_cmd._backend_agent_record(StubClient(), "fresh_agent")
+    assert found is not None
+    assert found["agent_id"] == "agent-fresh"
+
+    cached = gateway_cmd._load_agents_cache()
+    assert any(a.get("name") == "fresh_agent" for a in cached), "upstream success should seed cache"

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5641,6 +5641,91 @@ def test_save_registry_preserves_restore_written_during_daemon_tick(monkeypatch,
     assert "archived_reason" not in stored
 
 
+def test_save_registry_preserves_other_writer_added_row(monkeypatch, tmp_path):
+    """Race regression: daemon's load → modify → save must not clobber an
+    agent row added by another writer (e.g. the UI server's
+    POST /api/agents) between the daemon's load and the daemon's save.
+
+    Reproduces the cc-backend bug from 2026-05-06: managed_agent_added
+    activity recorded, registry write succeeded, then daemon's reconcile
+    tick wrote back without the new row.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {
+                "name": "incumbent",
+                "agent_id": "agent-incumbent",
+                "template_id": "hermes",
+                "runtime_type": "hermes_sentinel",
+                "lifecycle_phase": "active",
+                "desired_state": "running",
+            }
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Daemon's stale in-memory copy from the start of its tick — knows only
+    # about the incumbent.
+    daemon_view = gateway_core.load_gateway_registry()
+    daemon_view["agents"][0]["effective_state"] = "running"  # daemon-side update
+
+    # Another writer (UI server, channel setup, etc.) loads, adds a new
+    # agent, and saves between the daemon's load and the daemon's save.
+    other_writer = gateway_core.load_gateway_registry()
+    other_writer["agents"].append(
+        {
+            "name": "newcomer",
+            "agent_id": "agent-newcomer",
+            "template_id": "claude_code_channel",
+            "runtime_type": "claude_code_channel",
+            "lifecycle_phase": "active",
+            "desired_state": "running",
+        }
+    )
+    gateway_core.save_gateway_registry(other_writer)
+
+    # Daemon now saves its stale copy that never saw newcomer. Row
+    # preservation should keep newcomer.
+    gateway_core.save_gateway_registry(daemon_view)
+
+    final = gateway_core.load_gateway_registry()
+    names = {a["name"] for a in final["agents"]}
+    assert names == {"incumbent", "newcomer"}, (
+        "newcomer was clobbered by daemon save — registry write race regressed"
+    )
+    # Daemon's effective_state update on the incumbent should still apply.
+    incumbent = next(a for a in final["agents"] if a["name"] == "incumbent")
+    assert incumbent["effective_state"] == "running"
+
+
+def test_save_registry_honors_caller_remove(monkeypatch, tmp_path):
+    """Row preservation must distinguish "caller removed this" from
+    "another writer added this." A row that was present at load time and
+    is missing in memory at save time means the caller removed it; we
+    must not resurrect it from disk.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {"name": "to-remove", "agent_id": "a1", "template_id": "echo"},
+            {"name": "to-keep", "agent_id": "a2", "template_id": "echo"},
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Caller loads, removes one row, saves. Disk still had to-remove at
+    # the moment we re-read inside save — the load snapshot tells us we
+    # had it and the caller removed it intentionally.
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [a for a in registry["agents"] if a["name"] != "to-remove"]
+    gateway_core.save_gateway_registry(registry)
+
+    final = gateway_core.load_gateway_registry()
+    names = {a["name"] for a in final["agents"]}
+    assert names == {"to-keep"}, "to-remove was resurrected — remove was lost"
+
+
 def test_save_registry_preserves_archive_written_during_daemon_tick(monkeypatch, tmp_path):
     """Race regression: daemon load → modify → save must not clobber a CLI
     archive that landed between the daemon's load and the daemon's save.

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5699,6 +5699,58 @@ def test_save_registry_preserves_other_writer_added_row(monkeypatch, tmp_path):
     assert incumbent["effective_state"] == "running"
 
 
+def test_save_registry_preserves_other_writer_field_update(monkeypatch, tmp_path):
+    """Race regression (field-level): the daemon's stale `desired_state=running`
+    in-memory view must not clobber the CLI's freshly written
+    `desired_state=stopped` on disk.
+
+    Reproduces the agents-stop bug from 2026-05-06: `ax gateway agents stop`
+    set desired_state=stopped, activity log recorded
+    managed_agent_desired_stopped, but the daemon's next reconcile save
+    flipped it back to running within seconds — making demo-hermes
+    impossible to actually stop.
+    """
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    initial = {
+        "agents": [
+            {
+                "name": "race-stop",
+                "agent_id": "agent-race-stop",
+                "template_id": "hermes",
+                "runtime_type": "hermes_sentinel",
+                "lifecycle_phase": "active",
+                "desired_state": "running",
+                "effective_state": "running",
+            }
+        ]
+    }
+    gateway_core.save_gateway_registry(initial)
+
+    # Daemon's stale in-memory copy from the start of its tick.
+    daemon_view = gateway_core.load_gateway_registry()
+    daemon_view["agents"][0]["effective_state"] = "running"  # daemon-side telemetry update
+
+    # CLI runs `agents stop` between the daemon's load and the daemon's
+    # save: writes desired_state=stopped to disk.
+    cli_view = gateway_core.load_gateway_registry()
+    cli_view["agents"][0]["desired_state"] = "stopped"
+    gateway_core.save_gateway_registry(cli_view)
+
+    # Daemon now saves its (stale) copy. Field-level preservation should
+    # take disk's freshly-written desired_state=stopped, not memory's
+    # stale desired_state=running.
+    gateway_core.save_gateway_registry(daemon_view)
+
+    final = gateway_core.load_gateway_registry()
+    stored = next(a for a in final["agents"] if a["name"] == "race-stop")
+    assert stored["desired_state"] == "stopped", (
+        "daemon clobbered CLI's desired_state=stopped — field-level race "
+        "preservation regressed"
+    )
+    # Daemon's effective_state telemetry update should still apply.
+    assert stored["effective_state"] == "running"
+
+
 def test_save_registry_honors_caller_remove(monkeypatch, tmp_path):
     """Row preservation must distinguish "caller removed this" from
     "another writer added this." A row that was present at load time and

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -5337,6 +5337,60 @@ def test_status_payload_include_hidden_returns_all(monkeypatch, tmp_path):
     assert payload["summary"]["hidden_agents"] == 1
 
 
+def test_operator_cleanup_hides_selected_agents(monkeypatch, tmp_path):
+    _isolate_gateway_paths(monkeypatch, tmp_path)
+    registry = {
+        "agents": [
+            {
+                "name": "stale-one",
+                "agent_id": "agent-stale-one",
+                "template_id": "claude_code_channel",
+                "runtime_type": "claude_code_channel",
+                "desired_state": "running",
+                "effective_state": "error",
+            },
+            {
+                "name": "stale-two",
+                "agent_id": "agent-stale-two",
+                "template_id": "pass_through",
+                "runtime_type": "inbox",
+                "desired_state": "running",
+                "effective_state": "stale",
+            },
+            {
+                "name": "keeper",
+                "agent_id": "agent-keeper",
+                "template_id": "echo",
+                "runtime_type": "echo",
+                "desired_state": "running",
+                "effective_state": "running",
+            },
+        ]
+    }
+    gateway_core.save_gateway_registry(registry)
+
+    payload = gateway_cmd._hide_managed_agents(
+        ["stale-one", "stale-two"],
+        reason="operator_cleanup",
+    )
+
+    assert payload["count"] == 2
+    assert payload["missing"] == []
+    stored = {agent["name"]: agent for agent in gateway_core.load_gateway_registry()["agents"]}
+    assert stored["stale-one"]["lifecycle_phase"] == "hidden"
+    assert stored["stale-one"]["desired_state"] == "stopped"
+    assert stored["stale-one"]["hidden_reason"] == "operator_cleanup"
+    assert stored["stale-two"]["lifecycle_phase"] == "hidden"
+    assert stored["keeper"].get("lifecycle_phase", "active") == "active"
+
+    visible_payload = gateway_cmd._status_payload(activity_limit=0)
+    visible_names = [agent["name"] for agent in visible_payload["agents"]]
+    assert visible_names == ["keeper"]
+    assert visible_payload["summary"]["hidden_agents"] == 2
+    recent = gateway_core.load_recent_gateway_activity()
+    assert [event["event"] for event in recent].count("managed_agent_hidden") == 2
+
+
 def test_lifecycle_signal_sent_on_connected_to_stale(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
     client = _RecordingHeartbeatClient()

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -6153,3 +6153,223 @@ def test_backend_agent_record_seeds_cache_on_successful_upstream(monkeypatch, tm
 
     cached = gateway_cmd._load_agents_cache()
     assert any(a.get("name") == "fresh_agent" for a in cached), "upstream success should seed cache"
+
+
+# ---------------------------------------------------------------------------
+# Spaces hygiene: registry repair, /api/spaces fallback, CLI list
+# ---------------------------------------------------------------------------
+
+
+_GOOD_SPACE_UUID = "49afd277-78d2-4a32-9858-3594cda684af"
+
+
+def test_reconcile_corrupt_space_ids_recovers_uuid_from_active_space():
+    registry = {
+        "agents": [
+            {
+                "name": "taskforge_backend",
+                "space_id": "madtank's Workspace",
+                "active_space_id": _GOOD_SPACE_UUID,
+                "active_space_name": "madtank's Workspace",
+                "default_space_id": _GOOD_SPACE_UUID,
+            }
+        ]
+    }
+    repaired = gateway_core.reconcile_corrupt_space_ids(registry)
+    assert repaired == 1
+    assert registry["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+
+
+def test_reconcile_corrupt_space_ids_falls_back_to_allowed_spaces():
+    registry = {
+        "agents": [
+            {
+                "name": "x",
+                "space_id": "Workspace-Name",
+                "allowed_spaces": [{"space_id": _GOOD_SPACE_UUID, "name": "ws"}],
+            }
+        ]
+    }
+    assert gateway_core.reconcile_corrupt_space_ids(registry) == 1
+    assert registry["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+
+
+def test_reconcile_corrupt_space_ids_idempotent_on_clean_registry():
+    registry = {
+        "agents": [
+            {"name": "a", "space_id": _GOOD_SPACE_UUID},
+            {"name": "b", "space_id": ""},  # empty is left alone
+            {"name": "c"},  # no space_id at all is left alone
+        ]
+    }
+    assert gateway_core.reconcile_corrupt_space_ids(registry) == 0
+    assert registry["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+    assert registry["agents"][1]["space_id"] == ""
+    assert "space_id" not in registry["agents"][2]
+
+
+def test_reconcile_corrupt_space_ids_skips_when_no_uuid_anywhere():
+    registry = {
+        "agents": [
+            {"name": "lost", "space_id": "Some Name", "active_space_id": "Also Not A UUID"},
+        ]
+    }
+    # Nothing recoverable — leave the bad value in place rather than fabricate.
+    assert gateway_core.reconcile_corrupt_space_ids(registry) == 0
+    assert registry["agents"][0]["space_id"] == "Some Name"
+
+
+def test_load_gateway_registry_heals_corrupt_space_id_in_place(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_dir = gateway_core.gateway_dir()
+    gateway_dir.mkdir(parents=True, exist_ok=True)
+    raw = {
+        "version": 1,
+        "agents": [
+            {
+                "name": "taskforge_backend",
+                "space_id": "madtank's Workspace",
+                "active_space_id": _GOOD_SPACE_UUID,
+                "default_space_id": _GOOD_SPACE_UUID,
+            }
+        ],
+    }
+    gateway_core.registry_path().write_text(json.dumps(raw), encoding="utf-8")
+    loaded = gateway_core.load_gateway_registry()
+    assert loaded["agents"][0]["space_id"] == _GOOD_SPACE_UUID
+
+
+def test_resolve_gateway_agent_home_space_resolves_name_to_uuid(monkeypatch):
+    captured = {}
+
+    def fake_resolve(client, *, explicit):
+        captured["explicit"] = explicit
+        return _GOOD_SPACE_UUID
+
+    monkeypatch.setattr(gateway_cmd, "resolve_space_id", fake_resolve)
+
+    resolved = gateway_cmd._resolve_gateway_agent_home_space(
+        client=object(),
+        session={},
+        registry={"agents": []},
+        explicit_space_id="madtank's Workspace",
+    )
+    assert resolved == _GOOD_SPACE_UUID
+    assert captured["explicit"] == "madtank's Workspace"
+
+
+def test_resolve_gateway_agent_home_space_passthrough_for_uuid(monkeypatch):
+    def fake_resolve(*args, **kwargs):
+        raise AssertionError("UUID input should not require a backend round-trip")
+
+    monkeypatch.setattr(gateway_cmd, "resolve_space_id", fake_resolve)
+
+    resolved = gateway_cmd._resolve_gateway_agent_home_space(
+        client=object(),
+        session={},
+        registry={"agents": []},
+        explicit_space_id=_GOOD_SPACE_UUID,
+    )
+    assert resolved == _GOOD_SPACE_UUID
+
+
+def test_spaces_payload_returns_session_active_space_when_upstream_fails(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+            "username": "madtank",
+        }
+    )
+
+    def fake_client_loader():
+        class Boom:
+            def list_spaces(self):
+                raise httpx.HTTPStatusError(
+                    "429 Too Many Requests",
+                    request=httpx.Request("GET", "https://paxai.app/api/v1/spaces"),
+                    response=httpx.Response(429),
+                )
+
+        return Boom()
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", fake_client_loader)
+
+    payload = gateway_cmd._spaces_payload()
+    assert payload["active_space_id"] == _GOOD_SPACE_UUID
+    assert payload["active_space_name"] == "madtank's Workspace"
+    # Active space surfaces in the spaces list even with no cache so the UI
+    # always has something to render.
+    assert any(s["id"] == _GOOD_SPACE_UUID for s in payload["spaces"])
+    assert "error" in payload
+
+
+def test_spaces_payload_uses_cached_spaces_after_upstream_failure(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+        }
+    )
+
+    other_space = "78950af5-4d27-441b-9296-ec46de8ba35d"
+
+    class FirstClient:
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace"},
+                    {"id": other_space, "name": "Other Workspace"},
+                ]
+            }
+
+    class FailingClient:
+        def list_spaces(self):
+            raise RuntimeError("upstream rate limited")
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: FirstClient())
+    first = gateway_cmd._spaces_payload()
+    assert {s["id"] for s in first["spaces"]} == {_GOOD_SPACE_UUID, other_space}
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: FailingClient())
+    second = gateway_cmd._spaces_payload()
+    assert second.get("cached") is True
+    assert {s["id"] for s in second["spaces"]} == {_GOOD_SPACE_UUID, other_space}
+
+
+def test_gateway_spaces_list_command_renders_table(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+        }
+    )
+
+    class StubClient:
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
+                ]
+            }
+
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: StubClient())
+
+    result = runner.invoke(app, ["gateway", "spaces", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["active_space_id"] == _GOOD_SPACE_UUID
+    assert payload["spaces"][0]["id"] == _GOOD_SPACE_UUID


### PR DESCRIPTION
## Summary

Consolidates 12 commits of Gateway reliability and operator-cleanup work that have been carried in `verify/cleanup-ui-on-reliability` and previously open across PRs #147, #148, #153, #157, #158. Rebased onto current `main` (`908b1a65`), all conflicts resolved, full test suite green.

This PR is **orthogonal to #163** — they touch different files. Either can land first.

## What's in the stack

```
9bdae83 fix(gateway): operator-only hide — sweep no longer mutates lifecycle_phase
7334aae feat(gateway): agents recover — restore lost registry rows from local evidence
968f76a fix(gateway): spaces hygiene — repair corrupt space_id, /api/spaces fallback, list command, explicit UI label
69893dd feat(gateway): inactive view + per-row unhide — completes operator cleanup loop
9c2b096 fix(gateway): cleanup UI uat fixes — updateRow indices + hidden CSS override
6b45150 feat(gateway): bulk cleanup UI — checkbox multi-select + Hide selected
a9cc812 fix(gateway): upstream 429 backoff + retry + agents cache
6b63757 fix(gateway): extend race fix to operator-authoritative field updates
02fc8a0 fix(gateway): back off retries after a runtime setup error
94debd1 fix(gateway): preserve agent rows added by other writers during save race
4c7cabe chore(format): ruff format ax_cli/gateway.py
cdda790 feat(gateway): archive/restore lifecycle phase + race-safe registry merge
```

By topic:

- **Operator-only hide** — daemon sweep no longer auto-hides stale agents or auto-unhides on reconnect; both transitions are operator-driven via the Cleanup UI / CLI. Sweep now does one thing: signal liveness deltas upstream.
- **Lifecycle** — archive/restore phase with race-safe registry merge (CLI `_archive_managed_agent`, `_restore_managed_agent`); sweep treats `archived` as sticky; `_status_payload` partitions archived from active and supports `include_hidden=True`.
- **Race fixes** — `save_gateway_registry` does a bidirectional merge so concurrent CLI / daemon writers don't clobber each other's authoritative fields.
- **Setup-error backoff** — runtime start short-circuits inside the `last_runtime_error_at` window so a stuck template doesn't burn restart cycles.
- **Upstream 429 handling** — `_with_upstream_429_retry` helper with interactive (2×, ~3s ceiling) and background (5×, exponential) budgets; `UpstreamRateLimitedError` carries `retry_after_seconds`; agents cache mirrors the spaces cache pattern; wizard error renderer surfaces operator-actionable text.
- **Spaces hygiene** — `_resolve_gateway_agent_home_space` no longer accepts non-UUID values into `space_id`; `reconcile_corrupt_space_ids` heals existing rows from sibling fields on every load; `/api/spaces` no longer strands the UI on upstream 429 (caches + always emits `active_space_id`); new `ax gateway spaces list` CLI; UI uses `state.sessionSpaceName`.
- **Cleanup UI** — bulk checkbox multi-select + Hide-selected; per-row Unhide; Inactive view to recover hidden agents; CSS override to keep hidden rows reliably hidden.
- **Agents recover** — restores registry rows from local evidence (token files, workdir markers) when an agent is missing from the registry, closing the bootstrap-fail loop.

## What this supersedes

The following open PRs reflect commits that are now in this branch. **Not closing them in this PR** — leaving that to a separate maintainer pass:

- #147 archive/restore (head `8d1afad`)
- #148 spaces hygiene (head `9f85b57`, byte-stat identical to `968f76a`)
- #153 race + setup-error backoff (head `32c10e1`)
- #157 429 backoff (head `acf8e0c`, 1-line test delta from `a9cc812`)
- #158 cleanup UI (head was `ff0ecd1`, our verify HEAD pre-rebase)

## Rebase notes

Two conflicts in `tests/test_gateway_commands.py`, both end-of-file pure-additive (no semantic divergence):

1. At `cdda790` (archive/restore): `main`'s `b0528e4` had appended `test_send_local_session_message_extracts_mentions_when_client_omits_them`; our commit appended 8 archive/race tests at the same EOF. Resolution: kept both.
2. At `a9cc812` (429 backoff): empty `=======` to `>>>>>>>` markers — the 429 tests had auto-merged correctly elsewhere (lines 5938+); resolution was just removing the markers.

## Validation

```
uv run ruff check ax_cli/ tests/      # clean
uv run pytest tests/test_gateway_commands.py -q   # 172 passed
uv run pytest -q                       # 702 passed, 0 failed, 0 skipped (macOS)
```

(Note: PR #163's mention of "22 pre-existing Windows failures on clean main" did not reproduce on macOS — those are platform-specific TOML-escape / file-mode / path-separator issues unrelated to this stack.)

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

## Release Notes

- [x] This should appear in the changelog (mixed `feat:` + `fix:` — see commit list)
- [ ] This is internal/docs/test-only and does not need a package release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
