### PR TITLE
feat(gateway): active-space single source of truth + slug cache

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -78,6 +78,7 @@ from ..gateway import (
     load_gateway_registry,
     load_gateway_session,
     load_recent_gateway_activity,
+    load_space_cache,
     looks_like_space_uuid,
     ollama_setup_status,
     record_gateway_activity,
@@ -85,9 +86,12 @@ from ..gateway import (
     save_agent_pending_messages,
     save_gateway_registry,
     save_gateway_session,
+    save_space_cache,
+    space_name_from_cache,
     ui_log_path,
     ui_status,
     upsert_agent_entry,
+    upsert_space_cache_entry,
     verify_local_session_token,
     write_gateway_ui_state,
 )
@@ -822,13 +826,34 @@ def _space_list_from_response(raw: object) -> list[dict]:
 
 
 def _space_name_for_id(client: AxClient, space_id: str) -> str | None:
+    """Friendly-name lookup with persistent-cache short-circuit.
+
+    Hits the local space cache first so we don't pay an upstream `list_spaces`
+    call (and risk a 429) for a name we already know. Only falls through to
+    upstream when the cache has no entry for this id, and refreshes the cache
+    on a successful fetch so future calls stay in-process.
+    """
+    cached = space_name_from_cache(space_id)
+    if cached:
+        return cached
     try:
-        for item in _space_list_from_response(client.list_spaces()):
-            if auth_cmd._candidate_space_id(item) == space_id:
-                return str(item.get("name") or item.get("slug") or space_id)
+        rows = _space_list_from_response(client.list_spaces())
     except Exception:
         return None
-    return None
+    refreshed: list[dict] = []
+    match: str | None = None
+    for item in rows:
+        sid = auth_cmd._candidate_space_id(item)
+        if not sid:
+            continue
+        name = str(item.get("name") or item.get("slug") or sid)
+        slug = str(item.get("slug") or "").strip() or None
+        refreshed.append({"id": sid, "name": name, "slug": slug})
+        if sid == space_id:
+            match = name
+    if refreshed:
+        save_space_cache(refreshed)
+    return match
 
 
 def _resolve_gateway_agent_home_space(
@@ -3409,28 +3434,14 @@ def _render_gateway_dashboard(payload: dict) -> Group:
     )
 
 
-def _spaces_cache_path() -> Path:
-    return gateway_dir() / "spaces.cache.json"
-
-
-def _load_spaces_cache() -> list[dict]:
-    try:
-        raw = json.loads(_spaces_cache_path().read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return []
-    items = raw.get("spaces") if isinstance(raw, dict) else raw
-    return [item for item in (items or []) if isinstance(item, dict)]
-
-
-def _save_spaces_cache(spaces: list[dict]) -> None:
-    payload = {"spaces": spaces, "saved_at": datetime.now(timezone.utc).isoformat()}
-    try:
-        _spaces_cache_path().write_text(json.dumps(payload), encoding="utf-8")
-    except OSError:
-        pass
-
-
 def _normalize_spaces_response(items: list) -> list[dict]:
+    """Normalize an upstream `list_spaces` response into [{id, name, slug}].
+
+    If a row arrives with an empty/missing name (we've seen this happen for
+    brand-new spaces), fall back to the local cache before defaulting to the
+    UUID — avoids the "raw UUID rendered in picker" symptom for any space the
+    operator has seen at least once.
+    """
     spaces: list[dict] = []
     for item in items or []:
         if not isinstance(item, dict):
@@ -3438,10 +3449,12 @@ def _normalize_spaces_response(items: list) -> list[dict]:
         space_id = str(item.get("id") or item.get("space_id") or "").strip()
         if not space_id:
             continue
+        upstream_name = str(item.get("name") or item.get("space_name") or "").strip()
+        cached_name = space_name_from_cache(space_id) if not upstream_name else None
         spaces.append(
             {
                 "id": space_id,
-                "name": str(item.get("name") or item.get("space_name") or space_id),
+                "name": upstream_name or cached_name or space_id,
                 "slug": str(item.get("slug") or "").strip() or None,
             }
         )
@@ -3468,10 +3481,10 @@ def _spaces_payload() -> dict:
         items = raw.get("spaces", raw) if isinstance(raw, dict) else raw
         spaces = _normalize_spaces_response(items or [])
         if spaces:
-            _save_spaces_cache(spaces)
+            save_space_cache(spaces)
     except Exception as exc:  # noqa: BLE001 — upstream errors are routine here
         error = str(exc)
-        spaces = _load_spaces_cache()
+        spaces = load_space_cache()
         cached = bool(spaces)
 
     if active_space_id and not any(s["id"] == active_space_id for s in spaces):
@@ -5914,11 +5927,9 @@ def use_gateway_space(
     session["space_id"] = sid
     session["space_name"] = space_name
     path = save_gateway_session(session)
-    registry = load_gateway_registry()
-    registry.setdefault("gateway", {})
-    registry["gateway"]["space_id"] = sid
-    registry["gateway"]["space_name"] = space_name
-    save_gateway_registry(registry)
+    # Persist the resolved id/name into the spaces cache so subsequent slug
+    # switches stay cache-served and stop hammering list_spaces.
+    upsert_space_cache_entry(sid, name=space_name, slug=None)
     record_gateway_activity("gateway_space_use", space_id=sid, space_name=space_name)
     result = {
         "session_path": str(path),

--- a/ax_cli/config.py
+++ b/ax_cli/config.py
@@ -1240,6 +1240,20 @@ def _resolve_space_ref(client: AxClient, ref: str, *, source: str) -> str:
     if _is_uuid_like(value):
         return value
 
+    # Cache short-circuit: any slug/name we've ever resolved before stays
+    # resolvable from disk without going upstream. This is the difference
+    # between a clean slug switch and a 429 from paxai.app.
+    try:
+        from .gateway import lookup_space_in_cache  # local import — avoid cycle
+
+        cached = lookup_space_in_cache(value)
+        if cached:
+            sid = str(cached.get("id") or cached.get("space_id") or "").strip()
+            if sid and _is_uuid_like(sid):
+                return sid
+    except Exception:
+        pass
+
     spaces = _space_items(client.list_spaces())
     needle = _space_lookup_key(value)
     matches = []
@@ -1274,6 +1288,28 @@ def _resolve_space_ref(client: AxClient, ref: str, *, source: str) -> str:
     if not space_id:
         typer.echo(f"Error: Matched space '{ref}' did not include an id.", err=True)
         raise typer.Exit(1)
+
+    # Persist the freshly-fetched list so future slug switches stay cached.
+    # Suppress any error: cache is a best-effort optimization, not load-bearing.
+    try:
+        from .gateway import save_space_cache  # local import — avoid cycle
+
+        normalized = []
+        for s in spaces:
+            sid_raw = str(s.get("id") or s.get("space_id") or "").strip()
+            if not sid_raw:
+                continue
+            normalized.append(
+                {
+                    "id": sid_raw,
+                    "name": str(s.get("name") or s.get("space_name") or sid_raw),
+                    "slug": str(s.get("slug") or "").strip() or None,
+                }
+            )
+        if normalized:
+            save_space_cache(normalized)
+    except Exception:
+        pass
     return str(space_id)
 
 

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -2821,6 +2821,115 @@ def activity_log_path() -> Path:
     return gateway_dir() / "activity.jsonl"
 
 
+def space_cache_path() -> Path:
+    """Disk cache of {id, name, slug} triples for the user's visible spaces.
+
+    Single source for slug→UUID resolution and friendly-name hydration.
+    Populated by any successful upstream `list_spaces()` call. Consulted by
+    space-ref resolvers and the UI before falling back to upstream — that
+    keeps slug/name lookups out of the 429 path and lets the UI render
+    friendly names even when paxai.app rate-limits us.
+    """
+    return gateway_dir() / "spaces.cache.json"
+
+
+def load_space_cache() -> list[dict[str, Any]]:
+    path = space_cache_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    items = raw.get("spaces") if isinstance(raw, dict) else raw
+    return [item for item in (items or []) if isinstance(item, dict)]
+
+
+def save_space_cache(spaces: list[dict[str, Any]]) -> None:
+    """Atomically replace the spaces cache.
+
+    Caller passes already-normalized rows ({id, name, slug}); we mirror them
+    verbatim. Empty input is a no-op so callers don't have to null-guard.
+    """
+    if not spaces:
+        return
+    path = space_cache_path()
+    payload = {"spaces": spaces, "saved_at": datetime.now(timezone.utc).isoformat()}
+    tmp = path.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        _chmod_quiet(tmp, 0o600)
+        tmp.replace(path)
+    except OSError:
+        pass
+
+
+def upsert_space_cache_entry(space_id: str, *, name: str | None = None, slug: str | None = None) -> None:
+    """Update a single entry in the spaces cache without touching the rest.
+
+    Used after a slug-resolve so a non-cached space gets persisted for future
+    slug switches without forcing a full list_spaces refresh.
+    """
+    sid = str(space_id or "").strip()
+    if not sid or not looks_like_space_uuid(sid):
+        return
+    rows = load_space_cache()
+    found = False
+    for row in rows:
+        if str(row.get("id") or row.get("space_id") or "").strip() == sid:
+            if name:
+                row["name"] = str(name)
+            if slug:
+                row["slug"] = str(slug)
+            found = True
+            break
+    if not found:
+        rows.append(
+            {
+                "id": sid,
+                "name": str(name or sid),
+                "slug": str(slug) if slug else None,
+            }
+        )
+    save_space_cache(rows)
+
+
+def lookup_space_in_cache(ref: str) -> dict[str, Any] | None:
+    """Resolve a space ref (UUID, slug, name) against the local cache.
+
+    Returns the cached row or None. Keeps slug switches out of the 429 path:
+    a slug we have ever resolved before stays resolvable from cache without
+    hitting upstream.
+    """
+    needle = str(ref or "").strip()
+    if not needle:
+        return None
+    norm = needle.lower()
+    for row in load_space_cache():
+        sid = str(row.get("id") or row.get("space_id") or "").strip()
+        if not sid:
+            continue
+        if sid == needle:
+            return row
+        slug = str(row.get("slug") or "").strip().lower()
+        name = str(row.get("name") or "").strip().lower()
+        if slug and slug == norm:
+            return row
+        if name and name == norm:
+            return row
+    return None
+
+
+def space_name_from_cache(space_id: str) -> str | None:
+    sid = str(space_id or "").strip()
+    if not sid:
+        return None
+    for row in load_space_cache():
+        if str(row.get("id") or row.get("space_id") or "").strip() == sid:
+            n = str(row.get("name") or "").strip()
+            if n:
+                return n
+    return None
+
+
 def agent_dir(name: str) -> Path:
     path = gateway_agents_dir() / name
     path.mkdir(parents=True, exist_ok=True)
@@ -3046,6 +3155,12 @@ def load_gateway_registry() -> dict[str, Any]:
     gateway.setdefault("pid", None)
     gateway.setdefault("last_started_at", None)
     gateway.setdefault("last_reconcile_at", None)
+    # Active-space lives in session.json — strip any stale duplicate from the
+    # gateway record so callers can't accidentally read a stale value. Older
+    # registries (pre-simplification) carry these keys; this is the
+    # auto-migration path so we don't need a separate migration step.
+    gateway.pop("space_id", None)
+    gateway.pop("space_name", None)
     reconcile_corrupt_space_ids(registry)
     # Stamp a load-time snapshot so save_gateway_registry can distinguish:
     #   - "caller removed this row" vs "another writer added this row"
@@ -5843,6 +5958,18 @@ class GatewayDaemon:
                     for field in restart_fields
                     if str(runtime.entry.get(field) or "") != str(entry.get(field) or "")
                 ]
+                # If the only difference on space_id is that the runtime's
+                # cached entry held a non-UUID (legacy corruption that
+                # `reconcile_corrupt_space_ids` just repaired on load), the
+                # space hasn't actually changed — it's a clean-up. Drop
+                # `space_id` from the change set so we don't emit a phantom
+                # `runtime_rebinding` event on every registry load.
+                if "space_id" in changed_fields:
+                    prev_sid = str(runtime.entry.get("space_id") or "").strip()
+                    new_sid = str(entry.get("space_id") or "").strip()
+                    if prev_sid and not looks_like_space_uuid(prev_sid) and looks_like_space_uuid(new_sid):
+                        changed_fields = [f for f in changed_fields if f != "space_id"]
+                        runtime.entry["space_id"] = new_sid
                 if changed_fields:
                     record_gateway_activity(
                         "runtime_rebinding",

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -4916,11 +4916,13 @@ def test_gateway_status_payload_surfaces_alerts(monkeypatch, tmp_path):
 
 def test_gateway_spaces_use_resolves_slug_and_updates_session(monkeypatch, tmp_path):
     monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path / "config"))
+    private_uuid = "11111111-2222-3333-4444-555555555555"
+    team_uuid = "66666666-7777-8888-9999-aaaaaaaaaaaa"
     gateway_core.save_gateway_session(
         {
             "token": "axp_u_test.token",
             "base_url": "https://paxai.app",
-            "space_id": "private-space",
+            "space_id": private_uuid,
             "space_name": "madtank-workspace",
             "username": "codex",
         }
@@ -4930,8 +4932,8 @@ def test_gateway_spaces_use_resolves_slug_and_updates_session(monkeypatch, tmp_p
         def list_spaces(self):
             return {
                 "spaces": [
-                    {"id": "private-space", "slug": "madtank-workspace", "name": "madtank's Workspace"},
-                    {"id": "team-space", "slug": "ax-cli-dev", "name": "aX CLI Dev"},
+                    {"id": private_uuid, "slug": "madtank-workspace", "name": "madtank's Workspace"},
+                    {"id": team_uuid, "slug": "ax-cli-dev", "name": "aX CLI Dev"},
                 ]
             }
 
@@ -4941,14 +4943,21 @@ def test_gateway_spaces_use_resolves_slug_and_updates_session(monkeypatch, tmp_p
 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert payload["space_id"] == "team-space"
+    assert payload["space_id"] == team_uuid
     assert payload["space_name"] == "aX CLI Dev"
     session = gateway_core.load_gateway_session()
-    assert session["space_id"] == "team-space"
+    assert session["space_id"] == team_uuid
     assert session["space_name"] == "aX CLI Dev"
+    # Active space lives only in session.json — registry.gateway must NOT
+    # carry a duplicate copy (post-simplification: single source of truth).
     registry = gateway_core.load_gateway_registry()
-    assert registry["gateway"]["space_id"] == "team-space"
-    assert registry["gateway"]["space_name"] == "aX CLI Dev"
+    assert "space_id" not in registry["gateway"]
+    assert "space_name" not in registry["gateway"]
+    # Resolved id/name should be persisted to the spaces cache so a subsequent
+    # slug switch can short-circuit list_spaces.
+    cached = gateway_core.load_space_cache()
+    cached_ids = {row.get("id") for row in cached}
+    assert team_uuid in cached_ids
 
 
 def test_gateway_spaces_current_shows_session_space(monkeypatch, tmp_path):
@@ -6787,3 +6796,174 @@ def test_gateway_spaces_list_command_renders_table(monkeypatch, tmp_path):
     payload = json.loads(result.output)
     assert payload["active_space_id"] == _GOOD_SPACE_UUID
     assert payload["spaces"][0]["id"] == _GOOD_SPACE_UUID
+
+
+# -- Active-space simplification (single source of truth) ---------------------
+
+
+def test_load_gateway_registry_strips_legacy_gateway_space_keys(monkeypatch, tmp_path):
+    """Legacy registries with space_id/space_name in the gateway block must be
+    auto-migrated on load: session.json owns active space, registry.gateway
+    never carries a duplicate."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    legacy = {
+        "version": 1,
+        "gateway": {
+            "gateway_id": "gw-test",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+            "session_connected": True,
+        },
+        "agents": [],
+        "bindings": [],
+        "identity_bindings": [],
+        "approvals": [],
+    }
+    gateway_core.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    gateway_core.registry_path().write_text(json.dumps(legacy), encoding="utf-8")
+
+    loaded = gateway_core.load_gateway_registry()
+    assert "space_id" not in loaded["gateway"]
+    assert "space_name" not in loaded["gateway"]
+    # Gateway-specific metadata must be preserved.
+    assert loaded["gateway"]["gateway_id"] == "gw-test"
+    assert loaded["gateway"]["session_connected"] is True
+
+
+def test_status_payload_active_space_sourced_from_session_only(monkeypatch, tmp_path):
+    """Top-level status.space_id/space_name must come from session.json. The
+    nested gateway block must not carry duplicate space_id/space_name even if
+    callers pass the registry through it (the load-time strip enforces this)."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": _GOOD_SPACE_UUID,
+            "space_name": "madtank's Workspace",
+            "username": "madtank",
+        }
+    )
+    legacy = {
+        "version": 1,
+        "gateway": {
+            "gateway_id": "gw-test",
+            "space_id": "some-other-space",
+            "space_name": "Wrong Workspace",
+            "session_connected": True,
+            "desired_state": "running",
+            "effective_state": "running",
+        },
+        "agents": [],
+        "bindings": [],
+        "identity_bindings": [],
+        "approvals": [],
+    }
+    gateway_core.registry_path().write_text(json.dumps(legacy), encoding="utf-8")
+
+    payload = gateway_cmd._status_payload(activity_limit=1)
+
+    assert payload["space_id"] == _GOOD_SPACE_UUID
+    assert payload["space_name"] == "madtank's Workspace"
+    assert "space_id" not in payload["gateway"]
+    assert "space_name" not in payload["gateway"]
+
+
+def test_resolve_space_ref_uses_cache_when_upstream_429(monkeypatch, tmp_path):
+    """A slug we have ever resolved before must be re-resolvable from the
+    spaces cache without going upstream — so transient 429s on list_spaces
+    don't break `gateway spaces use <slug>`."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    team_uuid = "78950af5-4d27-441b-9296-ec46de8ba35d"
+    gateway_core.save_space_cache([
+        {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank-workspace"},
+        {"id": team_uuid, "name": "aX CLI Dev", "slug": "ax-cli-dev"},
+    ])
+
+    class Boom:
+        def list_spaces(self):
+            raise AssertionError("upstream must NOT be called when the cache has the slug")
+
+    from ax_cli.config import _resolve_space_ref
+    resolved = _resolve_space_ref(Boom(), "ax-cli-dev", source="explicit")
+    assert resolved == team_uuid
+
+
+def test_normalize_spaces_response_hydrates_name_from_cache(monkeypatch, tmp_path):
+    """If upstream returns a row with a missing/empty name, the UI must
+    surface the cached friendly name for previously-seen spaces instead of
+    falling back to the raw UUID."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_space_cache([
+        {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
+    ])
+
+    upstream_partial = [
+        {"id": _GOOD_SPACE_UUID, "name": "", "slug": "madtank"},
+    ]
+    rows = gateway_cmd._normalize_spaces_response(upstream_partial)
+    assert rows[0]["name"] == "madtank's Workspace"
+
+
+def test_runtime_reconcile_skips_phantom_rebinding_after_corruption_repair(monkeypatch, tmp_path):
+    """The reconcile_corrupt_space_ids band-aid repairs entry.space_id from a
+    leaked name to a UUID. The daemon's reconcile() must NOT emit a fake
+    runtime_rebinding event for that purely-cosmetic change."""
+    captured: list[dict] = []
+
+    def fake_record(event, **kwargs):
+        captured.append({"event": event, **kwargs})
+
+    monkeypatch.setattr(gateway_core, "record_gateway_activity", fake_record)
+
+    class FakeRuntime:
+        def __init__(self, entry):
+            self.entry = dict(entry)
+            self._stopped = False
+
+        def stop(self):
+            self._stopped = True
+
+        def start(self):
+            pass
+
+    daemon = gateway_core.GatewayDaemon.__new__(gateway_core.GatewayDaemon)
+    daemon._runtimes = {}
+    daemon.client_factory = lambda: object()
+    daemon.logger = None
+    runtime = FakeRuntime({
+        "name": "agent-x",
+        "agent_id": "00000000-1111-2222-3333-444444444444",
+        "space_id": "madtank's Workspace",  # legacy non-UUID corruption
+        "base_url": "https://paxai.app",
+        "token_file": "/tmp/agent-token",
+        "runtime_type": "inbox",
+    })
+    daemon._runtimes["agent-x"] = runtime
+    repaired_entry = {
+        "name": "agent-x",
+        "agent_id": "00000000-1111-2222-3333-444444444444",
+        "space_id": _GOOD_SPACE_UUID,  # repaired by reconcile_corrupt_space_ids
+        "base_url": "https://paxai.app",
+        "token_file": "/tmp/agent-token",
+        "runtime_type": "inbox",
+        "desired_state": "running",
+        "approval_state": "approved",
+        "attestation_state": "verified",
+        "identity_status": "verified",
+        "environment_status": "environment_allowed",
+        "space_status": "active_in_space",
+    }
+
+    daemon._reconcile_runtime(repaired_entry)
+
+    rebindings = [c for c in captured if c["event"] == "runtime_rebinding"]
+    assert rebindings == [], (
+        "reconcile() emitted a phantom runtime_rebinding when the only change "
+        "was a non-UUID -> UUID space_id repair"
+    )
+    assert runtime.entry["space_id"] == _GOOD_SPACE_UUID


### PR DESCRIPTION
## Summary

Resolves a Gateway split-brain on active-space and the 429-on-slug-switch failure mode. Both were called out by codex_supervisor with concrete repro evidence (top-level `ax gateway status --json` reporting one `space_id` while the nested `gateway.*` record reported a different one; slug switch hitting 429 on `list_spaces` while direct UUID switch worked).

The fix is two complementary changes:

1. **Single source of truth for active operator space.** `session.json` owns `space_id` / `space_name`. `registry.gateway` no longer carries a duplicate. `load_gateway_registry` auto-migrates legacy registries by stripping the keys on read; the next `save_gateway_registry` writes them out. `use_gateway_space` no longer writes them.

2. **Persistent space metadata cache.** New helpers (`load_space_cache`, `save_space_cache`, `upsert_space_cache_entry`, `lookup_space_in_cache`, `space_name_from_cache`) maintain `{id, name, slug}` rows under `~/.ax/gateway/spaces.cache.json`. `_resolve_space_ref` (config.py) and `_space_name_for_id` (commands/gateway.py) now consult the cache first. Slug switches for any space we've ever resolved before stay cache-served — no upstream call, no 429 path.

Bonus: `_reconcile_runtime` now suppresses phantom `runtime_rebinding` events when the only `space_id` change is a `reconcile_corrupt_space_ids` repair (non-UUID → UUID). Activity log evidence at 2026-05-03/04 (e.g. `taskforge_backend` `new_space_id: "madtank's Workspace"`) was the symptom.

## Files

- `ax_cli/gateway.py`: cache helpers; load_gateway_registry strip; _reconcile_runtime suppression.
- `ax_cli/commands/gateway.py`: cache imports; _space_name_for_id cache-first; _normalize_spaces_response cache-fallback name; _spaces_payload via public cache; use_gateway_space drops registry.gateway writes + persists to cache.
- `ax_cli/config.py`: _resolve_space_ref cache short-circuit + cache-after-fetch.
- `tests/test_gateway_commands.py`: 5 new tests + 1 updated for the new contract.

## Verification packet

- `uv run pytest tests/` → **735 passed** (full suite, no skips on touched code).
- `uv run ruff check ax_cli/` → clean.
- New tests cover: legacy registry strip, status payload sourced from session, slug switch served from cache under upstream 429, name hydration from cache when upstream row has missing name, no phantom rebinding after corruption repair, and updated `spaces use` test that asserts no `space_id`/`space_name` in `registry.gateway` and that the resolved id is persisted to the spaces cache.

## Out of scope

- Inbox UI (separate PR; both Jacob and I have concurrent WIP for that).
- Removing `reconcile_corrupt_space_ids`. The writer was already fixed in 968f76a; the band-aid stays as defense-in-depth on stale registries. The phantom-rebinding suppression in this PR is the user-visible fix.

## Test plan

- [ ] Reviewer runs `uv run pytest tests/` — 735 pass.
- [ ] Reviewer runs `ax gateway spaces use <slug>` from a clean Gateway → confirms it works on first call (populates cache) and on subsequent calls under simulated 429.
- [ ] Reviewer inspects `~/.ax/gateway/registry.json` after `gateway spaces use` → confirms no `space_id`/`space_name` in the `gateway` block.
- [ ] Reviewer runs `ax gateway status --json` → top-level `space_id`/`space_name` come from session; nested `gateway.*` block has no duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)