### PR TITLE
fix(cli): detect and warn when --bio/--specialization are silently dropped

### DIFF
--- a/ax_cli/commands/agents.py
+++ b/ax_cli/commands/agents.py
@@ -26,6 +26,30 @@ from .handoff import _wait_for_handoff_reply
 # rejected as a 500, so the CLI fails fast with a helpful message instead.
 AVATAR_URL_MAX_LENGTH = 512
 
+_ISSUE_76_URL = "https://github.com/ax-platform/ax-gateway/issues/76"
+
+_VERIFIABLE_FIELDS: dict[str, str] = {
+    "bio": "--bio",
+    "specialization": "--specialization",
+}
+
+
+def _warn_if_fields_dropped(sent: dict[str, Any], response: dict[str, Any]) -> list[str]:
+    """Compare sent fields against the server response and warn on silent drops.
+
+    Returns the list of flag names that were sent but not confirmed.
+    """
+    dropped = [flag for key, flag in _VERIFIABLE_FIELDS.items() if key in sent and response.get(key) != sent[key]]
+    if dropped:
+        flags = ", ".join(dropped)
+        err_console.print(
+            f"[yellow]Warning:[/yellow] {flags} accepted (HTTP 200) but not "
+            f"confirmed in server response.\n"
+            f"  These fields may not be supported by your current backend version.\n"
+            f"  See: {_ISSUE_76_URL}",
+        )
+    return dropped
+
 
 def _effective_config_line() -> str:
     """One-liner describing the resolved environment, for mutating commands.
@@ -737,6 +761,7 @@ def update_agent(
         data = client.update_agent(identifier, **fields)
     except httpx.HTTPStatusError as e:
         handle_error(e)
+    _warn_if_fields_dropped(fields, data)
     if as_json:
         print_json(data)
     else:

--- a/ax_cli/commands/bootstrap.py
+++ b/ax_cli/commands/bootstrap.py
@@ -179,6 +179,8 @@ def _polish_metadata(
 
     Skipped silently when nothing to update — this path isn't mandatory.
     """
+    from .agents import _warn_if_fields_dropped
+
     fields: dict = {}
     if bio is not None:
         fields["bio"] = bio
@@ -188,7 +190,8 @@ def _polish_metadata(
         fields["system_prompt"] = system_prompt
     if not fields:
         return
-    client.update_agent(name, **fields)
+    data = client.update_agent(name, **fields)
+    _warn_if_fields_dropped(fields, data)
 
 
 def _mint_agent_pat(

--- a/tests/test_agents_update_drop_detection.py
+++ b/tests/test_agents_update_drop_detection.py
@@ -1,0 +1,184 @@
+"""Tests for silent-drop detection on `ax agents update` — see issue #76.
+
+When the server returns HTTP 200 but omits bio/specialization from the
+response, the CLI must warn on stderr so the user doesn't get a false-
+success signal.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+from typer.testing import CliRunner
+
+from ax_cli.commands import agents as agents_cmd
+from ax_cli.commands import bootstrap as bootstrap_cmd
+from ax_cli.commands.agents import _warn_if_fields_dropped
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+class _EchoClient:
+    """Fake client that echoes all sent fields back — simulates a fixed server."""
+
+    def update_agent(self, identifier, **fields):
+        return {"id": "agent-1", "name": identifier, **fields}
+
+
+class _DroppingClient:
+    """Fake client that drops bio/specialization — simulates current server."""
+
+    def update_agent(self, identifier, **fields):
+        kept = {k: v for k, v in fields.items() if k not in ("bio", "specialization")}
+        return {"id": "agent-1", "name": identifier, **kept}
+
+
+# ── unit tests for _warn_if_fields_dropped ──────────────────────────────────
+
+
+def test_no_warning_when_fields_echoed(capsys):
+    sent = {"bio": "scout", "specialization": "recon"}
+    response = {"id": "1", "name": "x", "bio": "scout", "specialization": "recon"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert dropped == []
+    assert "Warning" not in capsys.readouterr().err
+
+
+def test_warning_when_bio_dropped(capsys):
+    sent = {"bio": "scout"}
+    response = {"id": "1", "name": "x"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert dropped == ["--bio"]
+
+
+def test_warning_when_specialization_dropped(capsys):
+    sent = {"specialization": "recon"}
+    response = {"id": "1", "name": "x"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert dropped == ["--specialization"]
+
+
+def test_warning_when_both_dropped(capsys):
+    sent = {"bio": "scout", "specialization": "recon"}
+    response = {"id": "1", "name": "x"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert "--bio" in dropped
+    assert "--specialization" in dropped
+
+
+def test_no_warning_for_description_only():
+    sent = {"description": "updated desc"}
+    response = {"id": "1", "name": "x", "description": "updated desc"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert dropped == []
+
+
+def test_no_warning_when_bio_not_sent():
+    sent = {"description": "hi"}
+    response = {"id": "1", "name": "x", "description": "hi"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert dropped == []
+
+
+def test_warning_detects_value_mismatch():
+    sent = {"bio": "scout"}
+    response = {"id": "1", "name": "x", "bio": "different"}
+    dropped = _warn_if_fields_dropped(sent, response)
+    assert dropped == ["--bio"]
+
+
+# ── integration tests: `ax agents update` command ──────────────────────────
+
+
+def test_update_no_warning_when_server_echoes(monkeypatch):
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: _EchoClient())
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi"])
+    assert result.exit_code == 0, result.stderr
+    assert "Updated agent" in result.stdout
+    assert "Warning" not in result.stderr
+
+
+def test_update_warns_on_stderr_when_server_drops_bio(monkeypatch):
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: _DroppingClient())
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi"])
+    assert result.exit_code == 0
+    assert "Warning" in result.stderr
+    assert "--bio" in result.stderr
+    assert "issues/76" in result.stderr
+
+
+def test_update_warns_on_stderr_when_server_drops_specialization(monkeypatch):
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: _DroppingClient())
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--specialization", "recon"])
+    assert result.exit_code == 0
+    assert "--specialization" in result.stderr
+    assert "issues/76" in result.stderr
+
+
+def test_update_json_stdout_stays_clean_when_warning_fires(monkeypatch):
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: _DroppingClient())
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--bio", "hi", "--json"])
+    assert result.exit_code == 0
+    parsed = _json.loads(result.stdout)
+    assert parsed["name"] == "axolotl"
+    assert "bio" not in parsed
+    assert "Warning" in result.stderr
+    assert "--bio" in result.stderr
+
+
+def test_update_no_warning_when_description_only(monkeypatch):
+    monkeypatch.setattr(agents_cmd, "get_client", lambda: _DroppingClient())
+
+    result = runner.invoke(app, ["agents", "update", "axolotl", "--description", "new desc"])
+    assert result.exit_code == 0
+    assert "Warning" not in result.stderr
+
+
+# ── integration tests: bootstrap _polish_metadata ───────────────────────────
+
+
+def test_polish_metadata_warns_when_server_drops(capsys):
+    bootstrap_cmd._polish_metadata(
+        _DroppingClient(),
+        name="axolotl",
+        bio="scout",
+        specialization="recon",
+        system_prompt=None,
+    )
+    captured = capsys.readouterr()
+    assert "--bio" in captured.err or "--bio" in captured.out
+    assert "--specialization" in captured.err or "--specialization" in captured.out
+
+
+def test_polish_metadata_no_warning_when_echoed(capsys):
+    bootstrap_cmd._polish_metadata(
+        _EchoClient(),
+        name="axolotl",
+        bio="scout",
+        specialization="recon",
+        system_prompt=None,
+    )
+    captured = capsys.readouterr()
+    assert "Warning" not in captured.err
+    assert "Warning" not in captured.out
+
+
+def test_polish_metadata_skips_when_only_system_prompt(capsys):
+    bootstrap_cmd._polish_metadata(
+        _EchoClient(),
+        name="axolotl",
+        bio=None,
+        specialization=None,
+        system_prompt="You are helpful.",
+    )
+    captured = capsys.readouterr()
+    assert "Warning" not in captured.err
+    assert "Warning" not in captured.out


### PR DESCRIPTION
## Summary

Fixes #76 — `ax agents update --bio` / `--specialization` silently dropped by the backend.

- After `client.update_agent()` returns, the CLI now compares each sent field against the response payload
- If `bio` or `specialization` are missing or don't match, a warning is emitted to **stderr** with an actionable message and link to #76
- Covers both `ax agents update` and the bootstrap `_polish_metadata` path
- Warning **self-heals** when the backend is fixed (response echoes fields correctly → no warning)
- No extra HTTP calls — uses the existing update response
- Exit code remains 0 (the server DID accept the request)

### What this does NOT do

- Does **not** remove `--bio`/`--specialization` flags (server may get fixed; CLI should be ready)
- Does **not** change exit codes (update itself succeeded)
- Does **not** add extra HTTP calls

### Example output (stderr, when fields are dropped)

```
Warning: --bio, --specialization accepted (HTTP 200) but not confirmed in server response.
  These fields may not be supported by your current backend version.
  See: https://github.com/ax-platform/ax-gateway/issues/76
```

## Validation

- [x] `pytest tests/ -v --tb=short` — 745 passed (15 new)
- [x] `ruff check ax_cli/` — clean
- [x] `ruff format --check ax_cli/` — clean
- [ ] `axctl auth doctor` — not applicable (no auth/credential changes)
- [ ] Live aX smoke test — warning is best-effort and doesn't change functional behavior

## Release Notes

- [x] This should appear in the changelog (`fix:`)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated

---

**Files changed:**
- `ax_cli/commands/agents.py` — `_warn_if_fields_dropped()` helper + call site in `update_agent`
- `ax_cli/commands/bootstrap.py` — `_polish_metadata()` now checks response
- `tests/test_agents_update_drop_detection.py` — 15 tests (unit + integration)