### PR TITLE
fix(gateway): reject UUID-as-name, sandbox upload_file, ruff format (on top of #173)

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -701,6 +701,15 @@ def _proxy_local_session_call(*, session_token: str, body: dict) -> dict:
         if key in args_in and args_in[key] is not None:
             keyword[key] = args_in[key]
 
+    if method == "upload_file":
+        workdir = str(entry.get("workdir") or "").strip()
+        if not workdir:
+            raise ValueError("upload_file requires the agent to have a workdir configured")
+        file_path = Path(positional[0]).resolve()
+        workdir_path = Path(workdir).resolve()
+        if not str(file_path).startswith(str(workdir_path) + os.sep) and file_path != workdir_path:
+            raise ValueError(f"upload_file path {file_path} is outside the agent workdir {workdir_path}")
+
     client = _load_managed_agent_client(entry)
     method_fn = getattr(client, method, None)
     if not callable(method_fn):
@@ -2193,9 +2202,7 @@ def _inbox_for_managed_agent(
     if unread_only:
         if pending_ids:
             messages = [
-                msg
-                for msg in messages
-                if str(msg.get("id") or msg.get("message_id") or "").strip() in pending_ids
+                msg for msg in messages if str(msg.get("id") or msg.get("message_id") or "").strip() in pending_ids
             ]
         else:
             messages = []

--- a/ax_cli/commands/messages.py
+++ b/ax_cli/commands/messages.py
@@ -872,9 +872,7 @@ def send(
                 raise typer.Exit(1) from exc
             raw_attachment = upload_data.get("attachment", upload_data) if isinstance(upload_data, dict) else {}
             attachment_id = (
-                raw_attachment.get("id")
-                or raw_attachment.get("attachment_id")
-                or raw_attachment.get("file_id")
+                raw_attachment.get("id") or raw_attachment.get("attachment_id") or raw_attachment.get("file_id")
             )
             if not attachment_id:
                 typer.echo(f"Error: upload of {local_path.name} did not return an attachment id.", err=True)
@@ -884,7 +882,9 @@ def send(
                     attachment_id=str(attachment_id),
                     content_type=str(raw_attachment.get("content_type") or "application/octet-stream"),
                     filename=str(raw_attachment.get("filename") or local_path.name),
-                    size=int(raw_attachment.get("size") or raw_attachment.get("size_bytes") or local_path.stat().st_size),
+                    size=int(
+                        raw_attachment.get("size") or raw_attachment.get("size_bytes") or local_path.stat().st_size
+                    ),
                     url=str(raw_attachment.get("url") or ""),
                     context_key=str(raw_attachment.get("context_key") or "") or None,
                 )

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -1560,12 +1560,18 @@ def _space_cache_rows(value: object) -> list[dict[str, Any]]:
     return rows
 
 
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+
+
 def _space_name_from_cache(allowed_spaces: list[dict[str, Any]], space_id: str | None) -> str | None:
     if not space_id:
         return None
     for item in allowed_spaces:
         if str(item.get("space_id") or "") == str(space_id):
-            return str(item.get("name") or space_id)
+            name = str(item.get("name") or "").strip()
+            if name and not _UUID_RE.match(name):
+                return name
+            return None
     return None
 
 
@@ -1910,11 +1916,15 @@ def ensure_gateway_identity_binding(
         ).strip()
         or None
     )
-    default_space_name = _space_name_from_cache(allowed_spaces, default_space_id) or str(
-        entry.get("default_space_name") or entry.get("space_name") or default_space_id or ""
+    default_space_name = (
+        _space_name_from_cache(allowed_spaces, default_space_id)
+        or space_name_from_cache(default_space_id)
+        or str(entry.get("default_space_name") or entry.get("space_name") or default_space_id or "")
     )
-    active_space_name = _space_name_from_cache(allowed_spaces, active_space_id) or str(
-        entry.get("active_space_name") or entry.get("space_name") or active_space_id or ""
+    active_space_name = (
+        _space_name_from_cache(allowed_spaces, active_space_id)
+        or space_name_from_cache(active_space_id)
+        or str(entry.get("active_space_name") or entry.get("space_name") or active_space_id or "")
     )
     binding = {
         "identity_binding_id": str((existing or {}).get("identity_binding_id") or f"idbind_{str(uuid.uuid4())}"),
@@ -2052,6 +2062,7 @@ def evaluate_identity_space_binding(
         str(
             (binding or {}).get("default_space_name")
             or _space_name_from_cache(allowed_spaces, default_space_id)
+            or space_name_from_cache(default_space_id)
             or default_space_id
             or ""
         ).strip()
@@ -2059,6 +2070,7 @@ def evaluate_identity_space_binding(
     )
     active_space_name = (
         _space_name_from_cache(allowed_spaces, active_space_id)
+        or space_name_from_cache(active_space_id)
         or str((binding or {}).get("active_space_name") or active_space_id or "").strip()
         or None
     )

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -7211,3 +7211,238 @@ def test_local_proxy_allowlist_includes_upload_file():
     # file_path is positional, space_id is keyword — matches AxClient.upload_file.
     assert "file_path" in spec.get("args", [])
     assert "space_id" in spec.get("kwargs", [])
+
+
+# -- Promoted from integration tests (docs/integration-tests-gateway.md) --
+# These tests cover bugs found during live operational testing that the
+# existing unit fixtures did not reproduce because they used clean synthetic data.
+
+
+def test_space_name_from_cache_rejects_uuid_stored_as_name():
+    """When the per-agent allowed_spaces cache stores the space UUID as the
+    name field, _space_name_from_cache should treat it as a miss so the
+    caller's or-chain falls through to the global cache.
+
+    Operational finding: after a cold restart the upstream populates
+    allowed_spaces with {"space_id": "<uuid>", "name": "<same-uuid>"},
+    causing active_space_name to show a raw UUID instead of the friendly name.
+    """
+    space_uuid = "0478b063-4100-497d-bbea-2327bea48bc4"
+    allowed_spaces = [{"space_id": space_uuid, "name": space_uuid}]
+
+    result = gateway_core._space_name_from_cache(allowed_spaces, space_uuid)
+
+    # Today this returns the UUID itself (the bug). Once fixed, it should
+    # return None so the or-chain falls through to the global disk cache.
+    # This test documents the expected behavior — it will FAIL until the
+    # fix lands, serving as a regression gate.
+    import re
+    uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+    assert result is None or not uuid_pattern.match(result), (
+        f"_space_name_from_cache returned UUID-as-name '{result}' — "
+        "should return None so the global cache fallback is reached"
+    )
+
+
+def test_annotate_runtime_health_resolves_active_space_name_from_global_cache(monkeypatch, tmp_path):
+    """annotate_runtime_health must resolve active_space_name to a friendly
+    name even when the per-agent allowed_spaces cache stores UUID-as-name.
+
+    Operational finding: /api/status and `ax gateway agents show` both
+    showed the raw UUID for active_space_name because annotate_runtime_health
+    only consulted _space_name_from_cache (per-agent), which returned the
+    UUID, and never fell through to space_name_from_cache (global disk).
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+
+    space_uuid = "0478b063-4100-497d-bbea-2327bea48bc4"
+    friendly_name = "ax-gateway"
+
+    gateway_core.save_space_cache([
+        {"id": space_uuid, "name": friendly_name, "slug": "ax-gateway"},
+    ])
+
+    binding = {
+        "identity_binding_id": "idbind_test",
+        "asset_id": "asset-1",
+        "gateway_id": "gw-1",
+        "install_id": "install-1",
+        "active_space_id": space_uuid,
+        "default_space_id": space_uuid,
+        "allowed_spaces_cache": [
+            {"space_id": space_uuid, "name": space_uuid},
+        ],
+        "environment": {"base_url": "https://paxai.app"},
+        "acting_identity": {"agent_id": "agent-test-1", "agent_name": "test-agent"},
+    }
+    registry = gateway_core.load_gateway_registry()
+    registry.setdefault("identity_bindings", []).append(binding)
+    registry.setdefault("agents", []).append({
+        "name": "test-agent",
+        "agent_id": "agent-test-1",
+        "identity_binding_id": "idbind_test",
+        "install_id": "install-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "hermes",
+        "template_id": "hermes",
+        "desired_state": "running",
+        "effective_state": "running",
+        "space_id": space_uuid,
+        "active_space_id": space_uuid,
+        "credential_source": "gateway",
+        "token_file": "/tmp/fake.token",
+    })
+    gateway_core.save_gateway_registry(registry)
+
+    snapshot = {
+        "name": "test-agent",
+        "agent_id": "agent-test-1",
+        "identity_binding_id": "idbind_test",
+        "install_id": "install-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "hermes",
+        "template_id": "hermes",
+        "desired_state": "running",
+        "effective_state": "running",
+        "space_id": space_uuid,
+        "active_space_id": space_uuid,
+        "credential_source": "gateway",
+        "token_file": "/tmp/fake.token",
+    }
+
+    annotated = gateway_core.annotate_runtime_health(snapshot, registry=registry)
+
+    import re
+    uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+    active_name = annotated.get("active_space_name", "")
+    assert not uuid_pattern.match(active_name), (
+        f"active_space_name is a raw UUID '{active_name}' — "
+        f"should be '{friendly_name}' from the global disk cache"
+    )
+    assert active_name == friendly_name
+
+
+def test_apply_entry_current_space_falls_through_uuid_name_to_global_cache(monkeypatch, tmp_path):
+    """apply_entry_current_space must reach the global disk cache when the
+    per-agent allowed_spaces has UUID-as-name for the target space.
+
+    This is a variant of the existing test at line 7072, but with the
+    critical difference: the agent's allowed_spaces entry has the UUID
+    stored as the name (the real-world failure mode) rather than a clean
+    friendly name (the synthetic fixture that masks the bug).
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+
+    space_uuid = _GOOD_SPACE_UUID
+    friendly_name = "madtank's Workspace"
+
+    gateway_core.save_space_cache([
+        {"id": space_uuid, "name": friendly_name, "slug": "madtank"},
+    ])
+
+    entry = {
+        "name": "agent-x",
+        "space_id": space_uuid,
+        "active_space_id": space_uuid,
+        "active_space_name": space_uuid,
+        "default_space_id": space_uuid,
+        "default_space_name": space_uuid,
+        "space_name": space_uuid,
+        "allowed_spaces": [
+            {"space_id": space_uuid, "name": space_uuid, "is_default": True},
+        ],
+    }
+
+    gateway_core.apply_entry_current_space(entry, space_uuid)
+
+    import re
+    uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+    assert not uuid_pattern.match(entry["active_space_name"]), (
+        f"active_space_name is still UUID '{entry['active_space_name']}' — "
+        f"should be '{friendly_name}' from the global disk cache"
+    )
+    assert entry["active_space_name"] == friendly_name
+
+
+def test_proxy_upload_file_rejects_path_outside_workdir(monkeypatch, tmp_path):
+    """The proxy handler must reject upload_file requests where file_path
+    resolves outside the agent's registered workdir.
+
+    Operational finding: /tmp/gateway-security-test.md (completely outside
+    any agent workdir) was successfully uploaded to paxai.app through the
+    agent's managed PAT. No path restriction was enforced.
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+
+    agent_workdir = tmp_path / "agent-home"
+    agent_workdir.mkdir()
+    outside_file = tmp_path / "sensitive.md"
+    outside_file.write_text("secret content")
+
+    token_file = tmp_path / "agent.token"
+    token_file.write_text("axp_a_test.token")
+
+    gateway_core.save_gateway_session({
+        "token": "axp_u_test.token",
+        "base_url": "https://paxai.app",
+        "space_id": "space-1",
+        "username": "tester",
+    })
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [{
+        "name": "sandboxed-agent",
+        "agent_id": "agent-1",
+        "space_id": "space-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "hermes",
+        "template_id": "hermes",
+        "desired_state": "running",
+        "effective_state": "running",
+        "approval_state": "approved",
+        "token_file": str(token_file),
+        "transport": "gateway",
+        "credential_source": "gateway",
+        "workdir": str(agent_workdir),
+    }]
+    gateway_core.save_gateway_registry(registry)
+
+    entry = registry["agents"][0]
+    session = gateway_core.issue_local_session(registry, entry)
+    gateway_core.save_gateway_registry(registry)
+    session_token = session["session_token"]
+
+    uploaded = False
+
+    class _SpyClient:
+        def __init__(self, **kw):
+            pass
+
+        def upload_file(self, file_path, *, space_id=None):
+            nonlocal uploaded
+            uploaded = True
+            return {"id": "file-1", "filename": "sensitive.md"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(gateway_cmd, "AxClient", _SpyClient)
+
+    # Attempt to upload a file outside the agent's workdir
+    try:
+        gateway_cmd._proxy_local_session_call(
+            session_token=session_token,
+            body={"method": "upload_file", "args": {"file_path": str(outside_file)}},
+        )
+        # If we get here without an error, the path was not validated.
+        # This test documents the expected fix — it will FAIL until
+        # path sandboxing is implemented.
+        assert not uploaded, (
+            f"upload_file accepted path outside workdir: {outside_file} "
+            f"(workdir={agent_workdir}). The proxy must reject this."
+        )
+    except (ValueError, PermissionError) as exc:
+        # Expected after the fix: proxy should raise on path traversal
+        assert "workdir" in str(exc).lower() or "path" in str(exc).lower() or "outside" in str(exc).lower()


### PR DESCRIPTION
> **Depends on / blocked by #173** — this PR targets the `fix/active-space-name-and-inbox-mark-read` branch. Merge #173 first, then rebase this onto `main`.

## Summary

- `_space_name_from_cache` rejects UUID-like strings via `_UUID_RE` regex so callers fall through to global disk cache for friendly names (closes #174)
- `annotate_runtime_health` and `ensure_gateway_identity_binding` gain `space_name_from_cache()` fallback
- `_proxy_local_session_call` validates `upload_file` paths against agent workdir (prevents path-traversal reads)
- `ruff format` applied to `gateway.py` and `messages.py`
- 4 regression tests added

## Test plan

- [x] `python -m pytest tests/test_gateway_commands.py tests/test_gateway_ui_static.py` — 207 passed
- [x] `ruff format --check ax_cli/` — 36 files pass
- [x] Integration tests: 32 PASS, 0 FAIL, 2 WARN, 0 SKIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)