### PR TITLE
fix(tasks): support --assign-to on ax tasks update through Gateway

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -792,7 +792,7 @@ _LOCAL_PROXY_METHODS: dict[str, dict] = {
     "search_messages": {"args": ["query"], "kwargs": ["limit", "agent_id"]},
     "list_tasks": {"kwargs": ["limit", "space_id"]},
     "get_task": {"args": ["task_id"]},
-    "update_task": {"args": ["task_id"], "kwargs": ["status", "priority"]},
+    "update_task": {"args": ["task_id"], "kwargs": ["status", "priority", "assignee_id"]},
     # File upload proxy: agents on the Gateway-native path can attach files
     # to messages without holding the user PAT. Daemon reads the path on
     # behalf of the agent and uploads via the agent's managed AxClient, so

--- a/ax_cli/commands/tasks.py
+++ b/ax_cli/commands/tasks.py
@@ -467,9 +467,7 @@ def update(
     gateway_cfg = resolve_gateway_config()
     if gateway_cfg:
         if assign_to is not None:
-            fields["assignee_id"] = _resolve_update_assignee_id_via_gateway(
-                gateway_cfg, task_id, assign_to
-            )
+            fields["assignee_id"] = _resolve_update_assignee_id_via_gateway(gateway_cfg, task_id, assign_to)
         data = _gateway_local_call(
             gateway_cfg=gateway_cfg,
             method="update_task",
@@ -518,9 +516,7 @@ def _resolve_update_assignee_id(client, task_id: str, assignee: str) -> str:
     return _resolve_assignee_id(client, candidate, space_id=task_space_id)
 
 
-def _resolve_update_assignee_id_via_gateway(
-    gateway_cfg: dict, task_id: str, assignee: str
-) -> str:
+def _resolve_update_assignee_id_via_gateway(gateway_cfg: dict, task_id: str, assignee: str) -> str:
     """Resolve --assign-to for ``ax tasks update`` when running through Gateway.
 
     Mirrors ``_resolve_update_assignee_id`` but performs the lookups via the

--- a/ax_cli/commands/tasks.py
+++ b/ax_cli/commands/tasks.py
@@ -467,11 +467,9 @@ def update(
     gateway_cfg = resolve_gateway_config()
     if gateway_cfg:
         if assign_to is not None:
-            typer.echo(
-                "Error: --assign-to is not supported with Gateway-native task updates yet.",
-                err=True,
+            fields["assignee_id"] = _resolve_update_assignee_id_via_gateway(
+                gateway_cfg, task_id, assign_to
             )
-            raise typer.Exit(1)
         data = _gateway_local_call(
             gateway_cfg=gateway_cfg,
             method="update_task",
@@ -518,3 +516,55 @@ def _resolve_update_assignee_id(client, task_id: str, assignee: str) -> str:
         )
         raise typer.Exit(1)
     return _resolve_assignee_id(client, candidate, space_id=task_space_id)
+
+
+def _resolve_update_assignee_id_via_gateway(
+    gateway_cfg: dict, task_id: str, assignee: str
+) -> str:
+    """Resolve --assign-to for ``ax tasks update`` when running through Gateway.
+
+    Mirrors ``_resolve_update_assignee_id`` but performs the lookups via the
+    Gateway local proxy (``get_task`` then ``list_agents``), so the managed
+    agent does not need a direct PAT to translate a handle into an agent UUID.
+    """
+    candidate = assignee.strip()
+    try:
+        return str(UUID(candidate))
+    except ValueError:
+        pass
+    current = _gateway_local_call(
+        gateway_cfg=gateway_cfg,
+        method="get_task",
+        args={"task_id": task_id},
+    )
+    if isinstance(current, dict) and isinstance(current.get("task"), dict):
+        current = current["task"]
+    task_space_id = str(current.get("space_id") or "") if isinstance(current, dict) else ""
+    if not task_space_id:
+        typer.echo(
+            f"Error: Could not determine space for task {task_id} to resolve assignee handle "
+            f"'{assignee}'. Pass an agent UUID instead.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    agents_result = _gateway_local_call(
+        gateway_cfg=gateway_cfg,
+        method="list_agents",
+        args={"space_id": task_space_id, "limit": 500},
+    )
+    handle = candidate.removeprefix("@").lower()
+    matches = [agent for agent in _agent_items(agents_result) if handle in _agent_names(agent)]
+    if not matches:
+        typer.echo(f"Error: No visible agent found for assignment target '{assignee}'.", err=True)
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        typer.echo(
+            f"Error: Assignment target '{assignee}' matched multiple agents. Use an agent UUID.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    agent_id = matches[0].get("id")
+    if not agent_id:
+        typer.echo(f"Error: Agent '{assignee}' did not include an id in the API response.", err=True)
+        raise typer.Exit(1)
+    return str(agent_id)

--- a/tests/test_tasks_commands.py
+++ b/tests/test_tasks_commands.py
@@ -335,24 +335,97 @@ def test_tasks_update_assign_to_resolves_handle_via_task_space(monkeypatch):
     }
 
 
-def test_tasks_update_assign_to_rejected_on_gateway_path(monkeypatch):
+def test_tasks_update_assign_to_uuid_through_gateway(monkeypatch):
+    """UUID assignee_id forwards through the Gateway proxy without a handle lookup."""
+    calls = []
+    agent_id = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+
     monkeypatch.setattr(
         "ax_cli.commands.tasks.resolve_gateway_config",
         lambda: {"url": "http://127.0.0.1:8765", "agent_name": "wishy", "workdir": "/repo"},
     )
 
-    def _should_not_call(**kwargs):
-        raise AssertionError(f"Gateway path should not run when --assign-to is rejected: {kwargs}")
+    def fake_gateway_local_call(*, gateway_cfg, method, args=None, **_):
+        calls.append({"method": method, "args": dict(args or {})})
+        if method == "update_task":
+            return {"id": args["task_id"], **{k: v for k, v in args.items() if k != "task_id"}}
+        raise AssertionError(f"unexpected proxy method: {method}")
 
-    monkeypatch.setattr("ax_cli.commands.tasks._gateway_local_call", _should_not_call)
+    monkeypatch.setattr("ax_cli.commands.tasks._gateway_local_call", fake_gateway_local_call)
 
     result = runner.invoke(
         app,
-        ["tasks", "update", "task-42", "--assign-to", "demo-agent"],
+        ["tasks", "update", "task-42", "--assign-to", agent_id, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    # UUID short-circuits — no get_task / list_agents needed.
+    assert [c["method"] for c in calls] == ["update_task"]
+    assert calls[0]["args"] == {"task_id": "task-42", "assignee_id": agent_id}
+
+
+def test_tasks_update_assign_to_handle_through_gateway(monkeypatch):
+    """Handle assign-to resolves via Gateway-proxied get_task + list_agents, then forwards UUID."""
+    calls = []
+
+    monkeypatch.setattr(
+        "ax_cli.commands.tasks.resolve_gateway_config",
+        lambda: {"url": "http://127.0.0.1:8765", "agent_name": "wishy", "workdir": "/repo"},
+    )
+
+    def fake_gateway_local_call(*, gateway_cfg, method, args=None, **_):
+        calls.append({"method": method, "args": dict(args or {})})
+        if method == "get_task":
+            return {"task": {"id": args["task_id"], "space_id": "space-9"}}
+        if method == "list_agents":
+            return {"agents": [{"id": "agent-789", "name": "demo-agent"}]}
+        if method == "update_task":
+            return {"id": args["task_id"], **{k: v for k, v in args.items() if k != "task_id"}}
+        raise AssertionError(f"unexpected proxy method: {method}")
+
+    monkeypatch.setattr("ax_cli.commands.tasks._gateway_local_call", fake_gateway_local_call)
+
+    result = runner.invoke(
+        app,
+        ["tasks", "update", "task-42", "--assign", "@demo-agent", "--status", "in_progress", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [c["method"] for c in calls] == ["get_task", "list_agents", "update_task"]
+    assert calls[0]["args"] == {"task_id": "task-42"}
+    assert calls[1]["args"] == {"space_id": "space-9", "limit": 500}
+    assert calls[2]["args"] == {
+        "task_id": "task-42",
+        "status": "in_progress",
+        "assignee_id": "agent-789",
+    }
+
+
+def test_tasks_update_assign_to_handle_through_gateway_no_match(monkeypatch):
+    """A handle that doesn't match any agent in the task's space exits cleanly with a clear error."""
+    monkeypatch.setattr(
+        "ax_cli.commands.tasks.resolve_gateway_config",
+        lambda: {"url": "http://127.0.0.1:8765", "agent_name": "wishy", "workdir": "/repo"},
+    )
+
+    def fake_gateway_local_call(*, gateway_cfg, method, args=None, **_):
+        if method == "get_task":
+            return {"task": {"id": args["task_id"], "space_id": "space-9"}}
+        if method == "list_agents":
+            return {"agents": [{"id": "other", "name": "someone-else"}]}
+        if method == "update_task":
+            raise AssertionError("update_task must not run when handle resolution fails")
+        raise AssertionError(f"unexpected proxy method: {method}")
+
+    monkeypatch.setattr("ax_cli.commands.tasks._gateway_local_call", fake_gateway_local_call)
+
+    result = runner.invoke(
+        app,
+        ["tasks", "update", "task-42", "--assign-to", "ghost-agent"],
     )
 
     assert result.exit_code == 1
-    assert "--assign-to is not supported with Gateway-native task updates" in result.output
+    assert "No visible agent found for assignment target 'ghost-agent'" in result.output
 
 
 def test_tasks_update_requires_at_least_one_field(monkeypatch):


### PR DESCRIPTION
## Summary

Lets `ax tasks update --assign-to` work when the CLI is running under a Gateway-managed identity (no local PAT). Closes #161 and the residual scope of aX task `1602e004` (note: list/get/update are already routed through Gateway via `_LOCAL_PROXY_METHODS` — the only remaining gap was assignee handling on `update_task`).

## Problem

`ax tasks update --assign-to` was a hard-fail under Gateway:

```python
# Before — ax_cli/commands/tasks.py
if assign_to is not None:
    typer.echo(
        "Error: --assign-to is not supported with Gateway-native task updates yet.",
        err=True,
    )
    raise typer.Exit(1)
```

Two reasons:

1. The Gateway proxy allowlist for `update_task` did not include `assignee_id`, so even a UUID couldn't be forwarded.
2. There was no handle-resolution path that worked without a local PAT — `_resolve_update_assignee_id` calls `client.get_task` / `client.list_agents` against the direct API.

## Changes

* `ax_cli/commands/gateway.py` — Add `"assignee_id"` to `_LOCAL_PROXY_METHODS["update_task"]` kwargs. UUIDs forwarded to the proxy now reach `AxClient.update_task(task_id, assignee_id=...)` unchanged.
* `ax_cli/commands/tasks.py` — Drop the early-rejection guard on the Gateway path. Add `_resolve_update_assignee_id_via_gateway()` that mirrors the existing client-side resolver but performs the `get_task` and `list_agents` lookups through `_gateway_local_call`, so a managed agent without a local PAT can still translate `@handle` → agent UUID before the update.
* `tests/test_tasks_commands.py` — Replace `test_tasks_update_assign_to_rejected_on_gateway_path` with three tests covering the new behavior:
  * UUID through Gateway: forwards `assignee_id` directly without `get_task` / `list_agents` lookups.
  * Handle through Gateway: resolves via Gateway-proxied `get_task` (for the task's space) + `list_agents` (in that space), then forwards the resolved UUID.
  * Handle-no-match: exits 1 with the same actionable error as the direct path (`No visible agent found for assignment target ...`).

## Direction check

Keeps Gateway as the trust boundary for runtime-authored actions. The managed agent never needs a direct PAT; handle resolution stays inside the proxy session and uses the agent's already-approved binding. Behavior is symmetric with the direct path: same UUID short-circuit, same handle resolver shape, same error messages.

The duplication between `_resolve_update_assignee_id` and `_resolve_update_assignee_id_via_gateway` is deliberate — the underlying call shapes differ (client method vs `_gateway_local_call`) and forcing them through a single adapter would obscure both. If a third path appears, that's the time to factor it.

## Test plan

- [x] `uv run --with pytest pytest tests/test_tasks_commands.py` — 14/14 pass
- [x] `uv run --with pytest pytest` — net **−1 failure / +3 passes** vs `main` (all remaining failures are pre-existing Windows-environment issues: TOML path escapes, chmod stubs, profile env shell-quoting)
- [x] `uv run --with ruff ruff check .` — clean
- [ ] Manual smoke: `ax tasks update <id> --assign-to <agent-uuid>` from a Gateway-bound workdir
- [ ] Manual smoke: `ax tasks update <id> --assign-to @handle` from a Gateway-bound workdir
- [ ] Manual smoke: `ax tasks update <id> --assign-to ghost-agent` returns the no-match error cleanly

## Related

* Closes #161
* Resolves the residual scope of aX task `1602e004`. The original "list/get/update don't route through Gateway" framing is stale — Gateway-local routing for those three landed earlier; only `assignee_id` on `update_task` was the residual gap.
