### PR TITLE
feat(auth): add `ax auth refresh` to drop stale JWT after out-of-band claim changes

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -718,6 +718,67 @@ def init(
         console.print("[yellow]Reminder:[/yellow] Add .ax/ to .gitignore")
 
 
+@app.command("refresh")
+def refresh(
+    as_json: bool = JSON_OPTION,
+):
+    """Drop the cached JWT and mint a fresh one from the saved PAT.
+
+    Use this after an out-of-band change to your account that the cached
+    JWT cannot reflect — most commonly joining a new space through the
+    web UI. Without a refresh, the CLI continues to use the cached JWT
+    until it naturally expires, so commands like ``ax spaces list`` may
+    not show the newly-joined space until the next call after expiry.
+
+    The PAT stays put; only the cached short-lived JWT is replaced.
+    """
+    token = resolve_token()
+    if not token:
+        console.print(
+            "[red]No token configured.[/red] For Gateway-managed agents, use "
+            "`ax gateway local ... --workdir <path>` so Gateway can broker the "
+            "agent identity. For user setup, log into Gateway with `ax gateway login`."
+        )
+        raise typer.Exit(1)
+    if not token.startswith("axp_"):
+        console.print("[red]Token is not a PAT (must start with axp_).[/red]")
+        raise typer.Exit(1)
+
+    from ..config import resolve_base_url
+    from ..token_cache import TokenExchanger
+
+    base_url = resolve_base_url()
+    exchanger = TokenExchanger(base_url, token)
+    invalidated = exchanger.invalidate()
+
+    # Determine token class from the saved PAT class (axp_u_ vs axp_a_).
+    token_class = "agent_access" if token.startswith("axp_a_") else "user_access"
+    agent_id = None
+    if token_class == "agent_access":
+        cfg = _load_config(local=True) or _load_config(local=False) or {}
+        agent_id = cfg.get("agent_id")
+
+    try:
+        exchanger.get_token(token_class, agent_id=agent_id, force_refresh=True)
+    except httpx.HTTPStatusError as e:
+        handle_error(e)
+
+    result = {
+        "ok": True,
+        "token_class": token_class,
+        "invalidated_entries": invalidated,
+        "host": base_url,
+    }
+    if as_json:
+        print_json(result)
+        return
+    console.print(f"[green]Refreshed:[/green] {token_class} JWT against {base_url}")
+    if invalidated:
+        console.print(f"[dim]Dropped {invalidated} cached entry/entries before re-exchange.[/dim]")
+    else:
+        console.print("[dim]No cached entries existed; minted a fresh JWT.[/dim]")
+
+
 @app.command("exchange")
 def exchange(
     token_class: str = typer.Option(

--- a/ax_cli/token_cache.py
+++ b/ax_cli/token_cache.py
@@ -135,6 +135,35 @@ class TokenExchanger:
         cache_file.write_text(json.dumps(pruned))
         cache_file.chmod(0o600)
 
+    def invalidate(self) -> int:
+        """Drop every cached JWT minted from this PAT.
+
+        Returns the number of entries removed. Use this when an out-of-band
+        change (joining a new space via the web UI, a bound-agent membership
+        update, role change, etc.) has shifted the user's claims so that any
+        cached JWT no longer reflects current server state. The next
+        ``get_token`` call will re-exchange the PAT for a fresh JWT.
+        """
+        if not self.pat_key_id:
+            return 0
+        # Drop in-memory entries for this PAT.
+        removed = len(self._cache)
+        self._cache = {}
+        # Rewrite disk cache without entries for this PAT (keep other PATs).
+        cache_file = self._cache_dir / "tokens.json"
+        if cache_file.exists():
+            try:
+                existing = json.loads(cache_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+            kept = {k: v for k, v in existing.items() if isinstance(v, dict) and v.get("pat_key_id") != self.pat_key_id}
+            cache_file.write_text(json.dumps(kept))
+            try:
+                cache_file.chmod(0o600)
+            except OSError:
+                pass
+        return removed
+
     def get_token(
         self,
         token_class: str = "user_access",

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -418,3 +418,113 @@ def test_auth_token_show_without_token_points_agents_to_gateway(monkeypatch, con
     assert "ax gateway local" in result.output
     assert "ax gateway login" in result.output
     assert "AX_TOKEN" not in result.output
+
+
+# --- ax auth refresh --------------------------------------------------------
+
+
+class _FakeExchanger:
+    """Stand-in for TokenExchanger that records calls without hitting the API."""
+
+    def __init__(self, base_url, pat):
+        self.base_url = base_url
+        self.pat = pat
+        self.invalidated = False
+        self.last_get_token = None
+        self.invalidated_count = 3
+
+    def invalidate(self):
+        self.invalidated = True
+        return self.invalidated_count
+
+    def get_token(self, token_class, *, agent_id=None, force_refresh=False, **_):
+        self.last_get_token = {
+            "token_class": token_class,
+            "agent_id": agent_id,
+            "force_refresh": force_refresh,
+        }
+        return "jwt.fake.token"
+
+
+def _patch_exchanger_factory(monkeypatch, factory_holder):
+    """Patch the in-function `from ..token_cache import TokenExchanger` import."""
+    import ax_cli.token_cache as token_cache_module
+
+    monkeypatch.setattr(token_cache_module, "TokenExchanger", factory_holder)
+
+
+def test_auth_refresh_invalidates_then_re_exchanges_user_pat(monkeypatch):
+    seen = {}
+
+    def factory(base_url, pat):
+        ex = _FakeExchanger(base_url, pat)
+        seen["exchanger"] = ex
+        return ex
+
+    monkeypatch.setattr("ax_cli.commands.auth.resolve_token", lambda: "axp_u_keyid.secret")
+    monkeypatch.setattr("ax_cli.config.resolve_base_url", lambda: "https://next.paxai.app")
+    _patch_exchanger_factory(monkeypatch, factory)
+
+    result = runner.invoke(app, ["auth", "refresh", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["token_class"] == "user_access"
+    assert payload["invalidated_entries"] == 3
+    assert payload["host"] == "https://next.paxai.app"
+
+    ex = seen["exchanger"]
+    assert ex.invalidated is True
+    assert ex.last_get_token == {
+        "token_class": "user_access",
+        "agent_id": None,
+        "force_refresh": True,
+    }
+
+
+def test_auth_refresh_uses_agent_access_for_agent_pat(monkeypatch):
+    seen = {}
+
+    def factory(base_url, pat):
+        ex = _FakeExchanger(base_url, pat)
+        seen["exchanger"] = ex
+        return ex
+
+    monkeypatch.setattr("ax_cli.commands.auth.resolve_token", lambda: "axp_a_keyid.secret")
+    monkeypatch.setattr("ax_cli.config.resolve_base_url", lambda: "https://next.paxai.app")
+    monkeypatch.setattr("ax_cli.commands.auth._load_config", lambda local=False: {"agent_id": "agent-7"})
+    _patch_exchanger_factory(monkeypatch, factory)
+
+    result = runner.invoke(app, ["auth", "refresh", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["token_class"] == "agent_access"
+
+    ex = seen["exchanger"]
+    assert ex.last_get_token == {
+        "token_class": "agent_access",
+        "agent_id": "agent-7",
+        "force_refresh": True,
+    }
+
+
+def test_auth_refresh_without_token_points_agents_to_gateway(monkeypatch):
+    monkeypatch.setattr("ax_cli.commands.auth.resolve_token", lambda: None)
+
+    result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 1
+    assert "No token configured" in result.output
+    assert "ax gateway login" in result.output
+    assert "AX_TOKEN" not in result.output
+
+
+def test_auth_refresh_rejects_non_pat_token(monkeypatch):
+    monkeypatch.setattr("ax_cli.commands.auth.resolve_token", lambda: "not-a-pat")
+
+    result = runner.invoke(app, ["auth", "refresh"])
+
+    assert result.exit_code == 1
+    assert "must start with axp_" in result.output

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -235,6 +235,67 @@ class TestTokenExchanger:
         mode = cache_file.stat().st_mode & 0o777
         assert mode == 0o600
 
+    def test_invalidate_drops_in_memory_and_disk_entries(
+        self, tmp_path, monkeypatch, sample_pat, mock_exchange
+    ):
+        """invalidate() removes every cached JWT minted from the same PAT."""
+        mock_post = mock_exchange()
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".ax").mkdir()
+        (tmp_path / ".ax" / "config.toml").write_text("")
+
+        exchanger = TokenExchanger("https://example.com", sample_pat)
+        exchanger.get_token("user_access", scope="messages")
+        exchanger.get_token("user_access", scope="agents spaces")
+        cache_file = tmp_path / ".ax" / "cache" / "tokens.json"
+        assert cache_file.exists()
+
+        removed = exchanger.invalidate()
+        assert removed == 2
+        # In-memory cache cleared.
+        assert exchanger._cache == {}
+
+        # Disk entries for this PAT removed (file may still exist with empty
+        # content if it was created, but no entries should remain for this PAT).
+        if cache_file.exists():
+            import json as _json
+
+            on_disk = _json.loads(cache_file.read_text() or "{}")
+            for entry in on_disk.values():
+                assert entry.get("pat_key_id") != exchanger.pat_key_id
+
+        # Next get_token re-exchanges instead of returning a cached value.
+        prior_calls = mock_post.call_count
+        exchanger.get_token("user_access", scope="messages")
+        assert mock_post.call_count == prior_calls + 1
+
+    def test_invalidate_keeps_other_pats_entries(
+        self, tmp_path, monkeypatch, mock_exchange
+    ):
+        """invalidate() must not drop entries belonging to other PATs."""
+        mock_exchange()
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".ax").mkdir()
+        (tmp_path / ".ax" / "config.toml").write_text("")
+
+        pat_a = "axp_u_KeyAlpha.SecretA"
+        pat_b = "axp_u_KeyBeta.SecretB"
+        TokenExchanger("https://example.com", pat_a).get_token("user_access")
+        TokenExchanger("https://example.com", pat_b).get_token("user_access")
+
+        cache_file = tmp_path / ".ax" / "cache" / "tokens.json"
+        import json as _json
+
+        before = _json.loads(cache_file.read_text())
+        assert {entry["pat_key_id"] for entry in before.values()} == {"KeyAlpha", "KeyBeta"}
+
+        TokenExchanger("https://example.com", pat_a).invalidate()
+
+        after = _json.loads(cache_file.read_text())
+        # KeyAlpha entries gone, KeyBeta entries preserved.
+        remaining_pats = {entry["pat_key_id"] for entry in after.values()}
+        assert remaining_pats == {"KeyBeta"}
+
     def test_disk_cache_loads_on_windows_despite_loose_mode(
         self, tmp_path, monkeypatch, sample_pat, mock_exchange
     ):


### PR DESCRIPTION
## Summary

Closes aX task `584bb90e` ("had to sign out and back in again when joining a new space"). Adds `ax auth refresh` so users don't have to re-paste their PAT just to pick up a server-side claim change (most commonly: joining a new space through the web UI while the CLI's cached JWT is still valid).

## Background — why this aX task exists

The CLI exchanges the user's PAT for a short-lived JWT and caches it in `.ax/cache/tokens.json` for the rest of its TTL. The JWT carries the user's claims at exchange time. If the user joins a new space, gets a new bound-agent membership, or has any other out-of-band claim change while the cached JWT is still valid, the CLI keeps using the old JWT — so `ax spaces list` and similar commands miss the new space until expiry.

The existing workaround was to run `axctl login` again, which already does `force_refresh=True` against `TokenExchanger.get_token()` — but it also re-prompts for the PAT, which is a high-friction loop for what is just a JWT refresh.

## What this PR adds

`ax auth refresh` — uses the saved PAT to drop the cached JWT and mint a new one. The PAT stays put; only the short-lived JWT is replaced.

```bash
$ ax auth refresh
Refreshed: user_access JWT against https://paxai.app
Dropped 2 cached entry/entries before re-exchange.

$ ax auth refresh --json
{
  "ok": true,
  "token_class": "user_access",
  "invalidated_entries": 2,
  "host": "https://paxai.app"
}
```

Token class is inferred from the PAT prefix:
* `axp_a_*` → `agent_access` (uses `agent_id` from local config)
* anything else → `user_access`

This matches the existing convention in the `_probe_credential` doctor flow and `ax auth exchange`.

## Implementation

Two narrow changes:

* **`ax_cli/token_cache.py`** — Add `TokenExchanger.invalidate()`. Drops every cached JWT minted from this PAT in both the in-memory cache and on disk, while preserving entries belonging to *other* PATs (so multi-PAT machines aren't disrupted). Returns the count removed.
* **`ax_cli/commands/auth.py`** — New `refresh` subcommand. Reads the saved PAT, calls `invalidate()`, then re-exchanges with `force_refresh=True` so the cache is repopulated immediately. Same "no token configured" guidance and PAT-prefix validation as the sibling `exchange` command.

## Tests

`tests/test_auth_commands.py`:
* `test_auth_refresh_invalidates_then_re_exchanges_user_pat` — happy path with a user PAT
* `test_auth_refresh_uses_agent_access_for_agent_pat` — agent PAT picks the right token class and reads `agent_id` from local config
* `test_auth_refresh_without_token_points_agents_to_gateway` — same Gateway guidance as the rest of `ax auth`
* `test_auth_refresh_rejects_non_pat_token` — actionable error on a non-PAT value

`tests/test_token_cache.py`:
* `test_invalidate_drops_in_memory_and_disk_entries` — verifies both surfaces are cleared and that the next `get_token` actually re-exchanges
* `test_invalidate_keeps_other_pats_entries` — multi-PAT isolation regression guard

## Direction check

* Operator UX: gives a clean, low-friction recovery path that the operator can run themselves the moment they notice stale state. No new abstractions, no behavior change for the common case (the cache continues to amortize PAT exchange).
* Trust boundary: the PAT is read from the same config the rest of `ax auth` uses, doesn't move, doesn't get printed, and doesn't leak into logs. Only the short-lived JWT is replaced.
* No effect on Gateway-managed agents — they continue to be told to use `ax gateway local ...` rather than `ax auth refresh` (the same guidance the rest of `ax auth` already prints).

## Out of scope

The companion gap — implementing `ax spaces join <invite-code>` so the user never has to leave the CLI in the first place — is tracked in issue **#176** and intentionally not addressed here. That command needs the invite-redeem API endpoint, which isn't in this repo. Once the endpoint shape is known, a follow-up PR can wire it up; calling `invalidate()` after a successful join is the right thing to do there too, so the helper added in this PR is reusable.

## Test plan

- [x] `uv run --with pytest pytest tests/test_token_cache.py tests/test_auth_commands.py` — 41 pass, 1 skip
- [x] `uv run --with pytest pytest` — net **+7 passes** vs `main`, no new failures (all remaining failures are pre-existing Windows-environment issues)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke: join a new space via the web UI, confirm `ax spaces list` does not show it, run `ax auth refresh`, confirm `ax spaces list` now shows the new space without re-running `axctl login`.
- [ ] Manual smoke: `ax auth refresh` from a config with no PAT prints the same Gateway-guidance error as `ax auth exchange` / `ax auth token show`.

## Related

* aX task: `584bb90e` (closed by this PR)
* Issue: **#176** (`ax spaces join <invite-code>`) — separate scope, separate PR
