### PR TITLE
feat(gateway): make `local init` fail-closed on a missing --workdir

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -6772,6 +6772,40 @@ def local_connect(
         console.print(f"  expires  = {payload.get('expires_at')}")
 
 
+def _ensure_workdir(path: Path, *, create: bool, raw_input: str | None = None) -> None:
+    """Validate or provision a workdir for a folder-bound Gateway identity.
+
+    The workdir is the durable binding for a Gateway agent — one folder maps
+    to one registry row. Silently creating a directory the operator did not
+    intend is exactly the surprise this guard exists to prevent: a typo in
+    ``--workdir`` should not mint a fresh empty folder somewhere unexpected
+    and then attach an agent identity to it.
+
+    * If the path exists and is a directory, return.
+    * If the path exists but is a file, error.
+    * If the path does not exist and ``create`` is True, create it (with any
+      missing parent directories).
+    * If the path does not exist and ``create`` is False, error with an
+      actionable hint pointing at ``--create-workdir``.
+    """
+    label = raw_input if raw_input and raw_input != str(path) else str(path)
+    if path.exists():
+        if not path.is_dir():
+            raise typer.BadParameter(f"--workdir {label!r} exists but is not a directory: {path}")
+        return
+    if not create:
+        raise typer.BadParameter(
+            f"--workdir {label!r} does not exist: {path}\n"
+            "Pass --create-workdir to create it, or pick an existing folder. "
+            "One folder maps to one Gateway identity, so the workdir should be a "
+            "real workspace you intend the agent to operate in."
+        )
+    try:
+        path.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise typer.BadParameter(f"Could not create --workdir {path}: {exc}") from exc
+
+
 def _gateway_local_config_text(*, agent_name: str, gateway_url: str, workdir: str | None = None) -> str:
     lines = [
         "[gateway]",
@@ -6901,13 +6935,37 @@ def _approval_required_guidance(
 def local_init(
     agent_name: str = typer.Argument(..., help="Local Gateway agent name"),
     gateway_url: str = typer.Option("http://127.0.0.1:8765", "--url", help="Local Gateway UI/API URL"),
-    workdir: str = typer.Option(None, "--workdir", help="Workspace folder to configure; defaults to CWD"),
+    workdir: str = typer.Option(
+        None,
+        "--workdir",
+        help=(
+            "Workspace folder to configure; defaults to CWD. One folder maps to one durable "
+            "Gateway identity. The folder must already exist; pass --create-workdir to create it."
+        ),
+    ),
+    create_workdir: bool = typer.Option(
+        False,
+        "--create-workdir",
+        help=(
+            "Create the workdir (and any missing parent directories) instead of failing when "
+            "it doesn't exist. Use when you are intentionally provisioning a new workspace."
+        ),
+    ),
     connect: bool = typer.Option(True, "--connect/--no-connect", help="Immediately request Gateway approval/session"),
     force: bool = typer.Option(False, "--force", help="Overwrite an existing .ax/config.toml"),
     as_json: bool = JSON_OPTION,
 ):
-    """Write a Gateway-native local config that contains no PAT or token file."""
-    root = Path(workdir or Path.cwd()).expanduser().resolve()
+    """Write a Gateway-native local config that contains no PAT or token file.
+
+    The workdir is the durable binding for this Gateway identity: one folder
+    or container maps to exactly one registry row. By default the workdir
+    must already exist — bind to a real workspace, do not let the CLI silently
+    fabricate one. Pass ``--create-workdir`` when you are intentionally
+    provisioning a new folder for the agent.
+    """
+    raw_workdir = workdir or str(Path.cwd())
+    root = Path(raw_workdir).expanduser().resolve()
+    _ensure_workdir(root, create=create_workdir, raw_input=raw_workdir)
     ax_dir = root / ".ax"
     config_path = ax_dir / "config.toml"
     if config_path.exists() and not force:

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -108,6 +108,88 @@ def test_gateway_local_init_writes_tokenless_config(monkeypatch, tmp_path):
     assert json.loads(result.output)["token_stored"] is False
 
 
+def test_gateway_local_init_rejects_missing_workdir_by_default(monkeypatch, tmp_path):
+    """Default behavior: --workdir must already exist; bail rather than silently mkdir."""
+    monkeypatch.setattr(
+        gateway_cmd,
+        "_request_local_connect",
+        lambda **kwargs: pytest.fail("connect must not run when workdir is rejected"),
+    )
+    missing = tmp_path / "agents" / "mac_backend"
+    assert not missing.exists()
+
+    result = runner.invoke(
+        app,
+        ["gateway", "local", "init", "mac_backend", "--workdir", str(missing)],
+    )
+
+    assert result.exit_code != 0
+    assert "does not exist" in result.output
+    assert "--create-workdir" in result.output
+    assert not missing.exists(), "workdir must not be created without --create-workdir"
+    assert not (missing / ".ax").exists()
+
+
+def test_gateway_local_init_with_create_workdir_provisions_directory(monkeypatch, tmp_path):
+    """`--create-workdir` opts in to making the missing folder."""
+    calls = {}
+    monkeypatch.setattr(
+        gateway_cmd,
+        "_request_local_connect",
+        lambda **kwargs: calls.setdefault("connect", kwargs)
+        or {"status": "approved", "session_token": "tok", "agent": {"name": kwargs["agent_name"]}},
+    )
+
+    new_workdir = tmp_path / "agents" / "fresh"
+    assert not new_workdir.exists()
+
+    result = runner.invoke(
+        app,
+        [
+            "gateway",
+            "local",
+            "init",
+            "fresh",
+            "--workdir",
+            str(new_workdir),
+            "--create-workdir",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert new_workdir.is_dir()
+    assert (new_workdir / ".ax" / "config.toml").exists()
+
+
+def test_gateway_local_init_rejects_workdir_pointing_at_a_file(monkeypatch, tmp_path):
+    """If --workdir resolves to an existing file, fail with a clear error."""
+    monkeypatch.setattr(
+        gateway_cmd,
+        "_request_local_connect",
+        lambda **kwargs: pytest.fail("connect must not run when workdir is invalid"),
+    )
+    file_path = tmp_path / "not-a-dir.txt"
+    file_path.write_text("nope")
+
+    result = runner.invoke(
+        app,
+        ["gateway", "local", "init", "x", "--workdir", str(file_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "not a directory" in result.output
+
+
+def test_ensure_workdir_helper_no_create_when_exists(tmp_path):
+    """The helper is a no-op when the workdir already exists as a directory."""
+    existing = tmp_path / "already_here"
+    existing.mkdir()
+    # Should not raise; should not modify anything observable.
+    gateway_cmd._ensure_workdir(existing, create=False)
+    assert existing.is_dir()
+
+
 def test_existing_agent_home_space_prefers_backend_default_space():
     class FakeClient:
         def list_agents(self):

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -1,5 +1,6 @@
 import io
 import json
+import re
 import socket
 import sys
 import threading
@@ -18,6 +19,12 @@ from ax_cli.commands import gateway as gateway_cmd
 from ax_cli.main import app
 
 runner = CliRunner()
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
 
 
 class _FakeTokenExchanger:
@@ -123,9 +130,12 @@ def test_gateway_local_init_rejects_missing_workdir_by_default(monkeypatch, tmp_
         ["gateway", "local", "init", "mac_backend", "--workdir", str(missing)],
     )
 
+    # Rich/Typer can split flag names with ANSI color escapes on color-capable
+    # terminals (CI), so normalize before substring asserts.
+    output = _strip_ansi(result.output)
     assert result.exit_code != 0
-    assert "does not exist" in result.output
-    assert "--create-workdir" in result.output
+    assert "does not exist" in output
+    assert "--create-workdir" in output
     assert not missing.exists(), "workdir must not be created without --create-workdir"
     assert not (missing / ".ax").exists()
 


### PR DESCRIPTION
## Summary

Phase-1 of aX task `6829c5e8` ("Gateway workdir picker and create-folder UX for folder-bound agents"). Tightens `ax gateway local init` so the workdir is an explicit, validated binding rather than a path the CLI silently fabricates on a typo.

## Why

The aX task description is explicit on the operating principle:

> one workdir/container → one durable Gateway identity, writes `.ax/config.toml` there, **and may create the directory only when the user intentionally chooses that.**

Today's `ax gateway local init --workdir <path>` does not honor that last clause. It runs:

```python
root = Path(workdir or Path.cwd()).expanduser().resolve()
ax_dir = root / ".ax"
...
ax_dir.mkdir(parents=True, exist_ok=True)
```

`parents=True, exist_ok=True` silently fabricates every missing directory along the way. A typo like `--workdir /Use/me/agents/mac_backend` (missing the `r` in `/Users`) creates the entire chain `/Use/me/agents/mac_backend/.ax/` from scratch, then attaches a Gateway identity to that fabricated empty folder. The operator never finds out.

## What this PR adds

* **New helper `_ensure_workdir(path, *, create, raw_input)`** — validates the workdir before any config write:
  * Existing directory → pass.
  * Existing file → error with a clear "not a directory" message.
  * Missing path with `create=False` → error with an actionable hint pointing at `--create-workdir`, plus the one-folder-one-identity invariant inline so the operator can reason about the right answer.
  * Missing path with `create=True` → `mkdir(parents=True, exist_ok=False)` so the operator's intent is recorded.
* **`ax gateway local init --create-workdir`** — opt-in flag. Default behavior is now fail-closed: pick an existing folder, or explicitly say "yes, provision this one."
* **Help text** on `--workdir` now leads with the one-folder-one-identity invariant so the contract is visible at the CLI surface, not just buried in spec docs.

```bash
# Default — workdir must already exist
$ ax gateway local init mac_backend --workdir /Users/Brand/agents/mac_backend
[ok if the folder exists]

$ ax gateway local init mac_backend --workdir /Use/me/typo
Error: --workdir '/Use/me/typo' does not exist: /Use/me/typo
Pass --create-workdir to create it, or pick an existing folder.
One folder maps to one Gateway identity, so the workdir should be a
real workspace you intend the agent to operate in.

# Opt in to creating
$ ax gateway local init mac_backend --workdir /Users/Brand/agents/fresh --create-workdir
Gateway local config written: /Users/Brand/agents/fresh/.ax/config.toml
```

## Direction check

* **Identity boundary**: tightens the workdir → identity binding called out as repo-critical in CLAUDE.md ("Workspace identity matters... call out behavior where `.ax/config.toml`, Gateway pass-through registration, or a runtime fingerprint could collapse distinct sessions into one apparent agent"). A silently-fabricated workdir is the most direct way that boundary gets eroded.
* **Operator UX**: actionable error, fail-closed, the answer (`--create-workdir`) is one flag away. No new abstractions.
* **Backwards compatibility**: this is a behavior change. Existing scripts that rely on the silent-mkdir path will start failing until they pass `--create-workdir`. That's the point — silent-mkdir was the bug. The error message tells the operator exactly what to add.

## Out of scope (intentional)

`ax gateway agents add --workdir` for Hermes, Claude Code Channel, and other folder-bound managed templates has the same silent-mkdir behavior, but at runtime startup (`gateway.py:_HermesSentinelRuntime` calls `workdir.mkdir(parents=True, exist_ok=True)` at line 4580 when the runtime launches). Tightening that path risks regressing already-registered agents whose workdir was historically created that way — those rows would start failing on next start.

A follow-up PR can reuse the same `_ensure_workdir` helper at `_register_managed_agent` time once the migration story for existing rows is settled. The helper is shaped to make that direct.

## Test plan

- [x] `uv run --with pytest pytest tests/test_gateway_commands.py -k "local_init or ensure_workdir"` — 5/5 pass
- [x] `uv run --with pytest pytest` — net **+4 passes** vs `main`, no new failures (all remaining failures are pre-existing Windows-environment issues)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke: `ax gateway local init test --workdir ~/agents/does-not-exist` → fails with hint
- [ ] Manual smoke: same command + `--create-workdir` → directory provisioned, `.ax/config.toml` written, no surprise parent dirs
- [ ] Manual smoke: `--workdir` pointing at an existing file (`~/.bashrc`) → fails with "not a directory"

## Related

* aX task: `6829c5e8` (this is the Phase-1 slice covering `ax gateway local init`; managed-agent templates follow up separately)
