### PR TITLE
feat: add --bound-agent-id flag to ax keys create

### DIFF
--- a/ax_cli/commands/keys.py
+++ b/ax_cli/commands/keys.py
@@ -17,12 +17,21 @@ def create(
     agent_id: Optional[list[str]] = typer.Option(
         None, "--scope-to-agent", help="Restrict this key to a specific agent UUID (repeatable)"
     ),
+    bound_agent_id: Optional[str] = typer.Option(
+        None,
+        "--bound-agent-id",
+        help="Bind the new PAT to this agent UUID (inherits allowed-spaces; use for agent runtime tokens)",
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Create a new API key."""
     client = get_client()
     try:
-        data = client.create_key(name, allowed_agent_ids=agent_id or None)
+        data = client.create_key(
+            name,
+            allowed_agent_ids=agent_id or None,
+            bound_agent_id=bound_agent_id,
+        )
     except httpx.HTTPStatusError as e:
         handle_error(e)
     if as_json:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -417,6 +417,43 @@ class TestCredentialManagement:
         assert body["agent_scope"] == "agents"
         assert body["allowed_agent_ids"] == ["agent-123"]
 
+    def test_create_key_with_bound_agent_id(self):
+        client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")
+        response = httpx.Response(
+            201,
+            json={"credential_id": "cred-1", "token": "axp_a_…"},
+            request=httpx.Request("POST", "https://example.com/api/v1/keys"),
+        )
+        client._http.post = MagicMock(return_value=response)
+
+        client.create_key("bound-key", bound_agent_id="a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["name"] == "bound-key"
+        assert body["bound_agent_id"] == "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+        assert "agent_scope" not in body
+
+    def test_create_key_with_bound_agent_id_and_scope(self):
+        client = AxClient("https://example.com", "axp_u_UserKey.UserSecret")
+        response = httpx.Response(
+            201,
+            json={},
+            request=httpx.Request("POST", "https://example.com/api/v1/keys"),
+        )
+        client._http.post = MagicMock(return_value=response)
+
+        agent_uuid = "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22"
+        client.create_key(
+            "combo",
+            allowed_agent_ids=[agent_uuid],
+            bound_agent_id=agent_uuid,
+        )
+
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["agent_scope"] == "agents"
+        assert body["allowed_agent_ids"] == [agent_uuid]
+        assert body["bound_agent_id"] == agent_uuid
+
     def test_create_task_sends_assignee_id_in_body(self):
         client = AxClient("https://example.com", "legacy-token", agent_id="creator-agent")
         response = httpx.Response(

--- a/tests/test_keys_commands.py
+++ b/tests/test_keys_commands.py
@@ -1,0 +1,66 @@
+import json
+
+from typer.testing import CliRunner
+
+from ax_cli.main import app
+
+runner = CliRunner()
+
+
+def test_keys_create_passes_bound_agent_id(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def create_key(self, name, *, allowed_agent_ids=None, bound_agent_id=None):
+            captured["name"] = name
+            captured["allowed_agent_ids"] = allowed_agent_ids
+            captured["bound_agent_id"] = bound_agent_id
+            return {"credential_id": "c1", "token": "axp_a_test"}
+
+    monkeypatch.setattr("ax_cli.commands.keys.get_client", lambda: FakeClient())
+
+    uuid = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+    result = runner.invoke(
+        app,
+        ["keys", "create", "--name", "orion", "--bound-agent-id", uuid, "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "name": "orion",
+        "allowed_agent_ids": None,
+        "bound_agent_id": uuid,
+    }
+    payload = json.loads(result.output)
+    assert payload["credential_id"] == "c1"
+    assert payload["token"] == "axp_a_test"
+
+
+def test_keys_create_passes_scope_and_bound_agent_id(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def create_key(self, name, *, allowed_agent_ids=None, bound_agent_id=None):
+            captured["allowed_agent_ids"] = allowed_agent_ids
+            captured["bound_agent_id"] = bound_agent_id
+            return {"credential_id": "c2"}
+
+    monkeypatch.setattr("ax_cli.commands.keys.get_client", lambda: FakeClient())
+
+    aid = "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22"
+    result = runner.invoke(
+        app,
+        [
+            "keys",
+            "create",
+            "--name",
+            "combo",
+            "--scope-to-agent",
+            aid,
+            "--bound-agent-id",
+            aid,
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["allowed_agent_ids"] == [aid]
+    assert captured["bound_agent_id"] == aid


### PR DESCRIPTION
## Summary

What changed and why?

## Validation

- [ ] `pytest tests/ -v --tb=short`
- [ ] `ruff check ax_cli/`
- [ ] `ruff format --check ax_cli/`
- [ ] `python -m build && twine check dist/*`
- [ ] `axctl auth doctor` reviewed for the target env/space, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior
- [ ] `axctl qa preflight` passed for the target env/space before MCP Jam, widget, or Playwright validation
- [ ] `axctl qa matrix` passed before promotion or cross-env/release validation
- [ ] Live aX smoke test, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior

## Release Notes

- [ ] This should appear in the changelog (`feat:`, `fix:`, or breaking change)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [ ] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated
