### PR TITLE
fix(gateway): allow multi-tenant workdir reconnect for already-registered agents

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -451,6 +451,22 @@ def _connect_local_pass_through_agent(
         )
         raise ValueError("fingerprint_mismatch")
 
+    # Look up the requested agent by name FIRST. If it already exists in the
+    # registry, the operator has previously approved this identity at this
+    # workdir (or anywhere) and is just (re-)connecting. Multi-tenant case:
+    # cli_god and pulse-cc can both legitimately operate from the same
+    # physical workdir, each with its own registry row. Running the
+    # collision check before the by-name lookup would have rejected
+    # cli_god's reconnect just because pulse-cc's row also fingerprints
+    # this directory.
+    if entry is None:
+        entry = find_agent_entry(registry, normalized_name)
+
+    # Collision check only runs when the requested name is genuinely new
+    # (no existing registry row). This still protects against accidental
+    # duplicate registrations — registering a fresh agent at a workdir
+    # already owned by a different agent surfaces the explicit error so
+    # the operator can decide how to proceed.
     if entry is None:
         collision = _find_local_origin_collision(
             registry,
@@ -463,11 +479,10 @@ def _connect_local_pass_through_agent(
                 "Gateway identity mismatch: "
                 f"this local origin is already registered as @{existing_name}. "
                 "Use that repo-local .ax/config.toml identity, reconnect by registry ref, "
-                "or remove/rename the existing registry row before requesting a new agent name."
+                "or remove/rename the existing registry row before requesting a new agent name. "
+                "If multiple agents legitimately share this workdir, register the new agent "
+                "from a different working directory first, then it can re-connect from here."
             )
-
-    if entry is None:
-        entry = find_agent_entry(registry, normalized_name)
     if entry is None:
         if not auto_create:
             raise LookupError(f"Managed agent not found: {normalized_name}")

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -1346,6 +1346,116 @@ def test_gateway_local_connect_rejects_second_identity_from_same_origin(monkeypa
         gateway_cmd._connect_local_pass_through_agent(agent_name="frontend_sentinel", fingerprint=changed_name)
 
 
+def test_gateway_local_connect_allows_existing_agent_to_reconnect_when_workdir_is_shared(
+    monkeypatch, tmp_path
+):
+    """Multi-tenant case: cli_god and pulse-cc legitimately share a workdir.
+
+    If pulse-cc was registered first and cli_god's row also exists, cli_god
+    re-connecting from the same physical workdir must NOT be rejected as a
+    fingerprint collision — the operator has already approved both identities.
+
+    Regression guard for aX task b4ecca83.
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "jacob",
+        }
+    )
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: _FakeUserClient())
+    monkeypatch.setattr(gateway_cmd, "_hydrate_entry_space_from_database", lambda *a, **k: None)
+
+    shared_fingerprint = {
+        "pid": 999999,
+        "parent_pid": 1,
+        "cwd": str(tmp_path),
+        "exe_path": sys.executable,
+        "user": "jacob",
+    }
+    pulse_fingerprint = {**shared_fingerprint, "agent_name": "pulse-cc"}
+    cli_god_fingerprint = {**shared_fingerprint, "agent_name": "cli_god"}
+
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [
+        {
+            "name": "pulse-cc",
+            "agent_id": "agent-pulse",
+            "space_id": "space-1",
+            "template_id": "pass_through",
+            "runtime_type": "inbox",
+            "approval_state": "approved",
+            "attestation_state": "verified",
+            "local_fingerprint": pulse_fingerprint,
+        },
+        {
+            "name": "cli_god",
+            "agent_id": "agent-cli-god",
+            "space_id": "space-1",
+            "template_id": "pass_through",
+            "runtime_type": "inbox",
+            "approval_state": "approved",
+            "attestation_state": "verified",
+            "local_fingerprint": cli_god_fingerprint,
+        },
+    ]
+    gateway_core.save_gateway_registry(registry)
+
+    # cli_god re-connects from the same workdir pulse-cc also uses.
+    # Before the fix this raised ValueError("Gateway identity mismatch: ...
+    # already registered as @pulse-cc"); now it should succeed because
+    # cli_god's own registry row is found by name first, before the
+    # collision check runs.
+    result = gateway_cmd._connect_local_pass_through_agent(
+        agent_name="cli_god", fingerprint=cli_god_fingerprint
+    )
+    assert result["agent"]["name"] == "cli_god"
+    assert result["agent"]["agent_id"] == "agent-cli-god"
+
+
+def test_gateway_local_connect_still_blocks_fresh_name_when_workdir_is_owned(monkeypatch, tmp_path):
+    """The fresh-name protection must still fire when registering a brand-new
+    agent at a workdir already owned by a different agent.
+
+    This is the same shape as the existing
+    ``rejects_second_identity_from_same_origin`` test but explicitly framed as
+    the "after the fix, the protection still exists" guard so a future
+    refactor can't quietly silence it.
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    fingerprint = {
+        "agent_name": "owner",
+        "pid": 999999,
+        "parent_pid": 1,
+        "cwd": str(tmp_path),
+        "exe_path": sys.executable,
+        "user": "anyone",
+    }
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [
+        {
+            "name": "owner",
+            "agent_id": "agent-owner",
+            "space_id": "space-1",
+            "template_id": "pass_through",
+            "runtime_type": "inbox",
+            "local_fingerprint": dict(fingerprint),
+        }
+    ]
+    gateway_core.save_gateway_registry(registry)
+
+    fresh_attempt = {**fingerprint, "agent_name": "newbie"}
+    with pytest.raises(ValueError, match="already registered as @owner"):
+        gateway_cmd._connect_local_pass_through_agent(
+            agent_name="newbie", fingerprint=fresh_attempt
+        )
+
+
 def test_find_agent_entry_by_ref_matches_row_and_stable_prefix():
     registry = {
         "agents": [


### PR DESCRIPTION
## Summary

Closes aX task `b4ecca83` ("[P1] Workdir-collision blocks managed agents that share a folder"). Two managed agents that legitimately operate from the same physical workdir (the task's reproducer: `cli_god` + `pulse-cc` both in `/Users/jacob/claude_home/ax-cli/`) can now both run `ax tasks create`, `ax gateway local inbox`, etc. from that workdir without one displacing the other.

## Why

From the task's reproducer:

```
- Repo workdir already registered to @pulse-cc.
- ax gateway local inbox --agent cli_god --workdir <repo>
    → "Gateway identity mismatch: this local origin is already registered as @pulse-cc."
- ax gateway local inbox --ref cli_god → "registry_ref_not_attachable".
- ax tasks create from this workdir tries cli_god (per .ax/config.toml),
  workdir-fingerprint says pulse-cc → same mismatch error. Tasks creation blocked entirely.
```

This is exactly the boundary CLAUDE.md flags as repo-critical:

> Multiple assistants can share a directory; call out behavior where `.ax/config.toml`, Gateway pass-through registration, or a runtime fingerprint could collapse distinct sessions into one apparent agent.

## Root cause

In `_connect_local_pass_through_agent`, the fingerprint-collision check ran *before* looking up the requested agent name in the registry:

```python
# Before:
if entry is None:
    collision = _find_local_origin_collision(...)
    if collision is not None:
        raise ValueError("Gateway identity mismatch: ... already registered as @pulse-cc")

if entry is None:
    entry = find_agent_entry(registry, normalized_name)  # ← cli_god's row would have been found here
```

Once the collision check fired (any other agent's row touched this fingerprint), the function raised before reaching the by-name lookup that would have found `cli_god`'s existing row. The collision check was treating the workdir as a single-tenant ownership key, but the registry already supports multiple agents — there was no architectural reason for the check to fire here.

## Fix

A small, surgical reorder. Look up the requested name in the registry **first**. If it has its own row, the operator has already approved this identity at this workdir (or anywhere) and is just (re-)connecting — use it and skip the collision check.

```python
# After:
if entry is None:
    entry = find_agent_entry(registry, normalized_name)

if entry is None:
    # Collision check only runs when the name is genuinely fresh.
    collision = _find_local_origin_collision(...)
    if collision is not None:
        raise ValueError(...)
```

The collision check still fires when the requested name is genuinely new — registering a fresh agent at a workdir already owned by a different agent surfaces the same explicit error so the operator can decide how to proceed. Plus a closing line in that error pointing at the multi-tenant workaround:

> If multiple agents legitimately share this workdir, register the new agent from a different working directory first, then it can re-connect from here.

## Tests

`tests/test_gateway_commands.py`:

* `test_gateway_local_connect_allows_existing_agent_to_reconnect_when_workdir_is_shared` — new regression guard for `b4ecca83`. Sets up `pulse-cc` and `cli_god` rows both fingerprinted at `tmp_path`, both pre-approved; calls `_connect_local_pass_through_agent(agent_name="cli_god")` and verifies it succeeds with the right `agent_id`. Before the fix this raised `Gateway identity mismatch ... already registered as @pulse-cc`.
* `test_gateway_local_connect_still_blocks_fresh_name_when_workdir_is_owned` — new "the protection still exists after the fix" guard. Registers a brand-new `newbie` at a workdir already owned by `owner`; still raises the collision error so a future refactor can't silently silence the protection.
* `test_gateway_local_connect_rejects_second_identity_from_same_origin` (pre-existing) — continues to pass unchanged. Same shape as the new guard but framed as "renaming an existing agent's identity from inside its own workdir."

## Direction check

* **Identity boundary** (CLAUDE.md): the fix tightens the boundary in the right direction. Registry rows are the unit of identity; the fingerprint is corroborating evidence, not the primary key. The collision check is now what it was always intended to be — a guard against accidental duplicate registrations, not a single-tenant lock on the workdir.
* **No new abstractions**: 13 lines of real change (the rest is comments + the new error-message hint). Could have been smaller, but the reorder benefits from the explanatory comments since the *why* is non-obvious from reading the function.
* **Backwards compatibility**: the only behavior change is in the previously-failing case (existing agent reconnects from a workdir other agents also touch). All existing single-tenant flows are unchanged. Operators relying on the previous behavior of rejecting any reconnect from a multi-touched workdir as a safety guard would see fewer rejections — but that "safety" was actively blocking the documented multi-tenant use case, so the trade is positive.

## Out of scope

The task lists three design options:

1. **Multi-tenant fingerprint as primary data model** — explicit set of approved agents per workdir. Bigger refactor; not needed since the registry already supports this implicitly.
2. **Per-agent subdir convention** — fingerprint as `workdir + agent_name`. Orthogonal; doesn't address the immediate reproducer.
3. **Honor `.ax/config.toml` as authoritative for single-tenant repos** — what this PR implements as a behavior change rather than a data-model change.

An `--allow-shared-workdir` opt-in flag for registering a *brand-new* agent at an already-owned workdir is a natural follow-up if the existing collision-error workaround proves too friction-heavy in practice. Skipped here because the friction is one-time per agent (operator registers the new agent from a fresh dir, then it can re-connect from anywhere) and the fix's primary win is unblocking the *common* multi-tenant case.

## Test plan

- [x] `uv run --with pytest pytest tests/test_gateway_commands.py -k "rejects_second_identity or allows_existing_agent or still_blocks_fresh_name"` — 3/3 pass
- [x] `uv run --with pytest pytest` — net **+2 passes** vs `main`, no new failures (42 pre-existing failures unchanged from main baseline)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke matching the task's reproducer: register two agents from the same physical workdir; confirm both can `ax tasks create` / `ax gateway local inbox` from that workdir without rejecting each other.
- [ ] Manual smoke for the protection: try to register a fresh third agent name from the same workdir; confirm the error fires with the multi-tenant hint.

## Related

* aX task: `b4ecca83`
* CLAUDE.md identity-boundary invariant
