### PR TITLE
ci(claude): grant pull-requests + issues write to Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
The Claude Code Review and @claude responder workflows had
pull-requests: read and issues: read, which prevented the action from
posting reviews/replies on PRs and issues. Promoting both to write so
the action can post comments, reactions, and reviews. id-token: write
is already set; keeping actions: read on the responder workflow.

https://claude.ai/code/session_01Y4ckMPtqW7NC1yjuXEnnDf