### PR TITLE
feat(gateway): bundle unread inbox into managed-agent send + channel reply

### DIFF
--- a/ax_cli/commands/channel.py
+++ b/ax_cli/commands/channel.py
@@ -569,6 +569,36 @@ def _enrich_prompt_for_agent(
     return prompt.rstrip() + "\n\n---\n" + "\n\n".join(blocks)
 
 
+def _format_inbox_bundle_for_mcp(bundle: dict[str, Any]) -> str:
+    """Render an inbox bundle (from `_poll_channel_inbox_after_reply`) as a
+    human-readable second text item for an MCP tool response.
+
+    Shape matches what an LLM caller can act on directly: a one-line summary
+    of the unread count, then per-message lines with sender + first-line
+    preview. Capped at 5 messages in the body to keep the response compact —
+    the full list is still in the bundle if a richer client wants it.
+    """
+    messages = bundle.get("messages") or []
+    unread_count = bundle.get("unread_count") or len(messages)
+    lines = [
+        f"INBOX while you were drafting: {unread_count} unread message(s) addressed to @{bundle.get('agent') or 'this agent'}.",
+    ]
+    for msg in messages[:5]:
+        if not isinstance(msg, dict):
+            continue
+        sender = msg.get("agent_name") or msg.get("user_name") or msg.get("sender") or "unknown"
+        msg_id = msg.get("id") or msg.get("message_id") or ""
+        first_line = ""
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            first_line = content.strip().splitlines()[0][:160]
+        suffix = f" ({msg_id})" if msg_id else ""
+        lines.append(f"  - @{sender}{suffix}: {first_line}")
+    if len(messages) > 5:
+        lines.append(f"  ... and {len(messages) - 5} more (full list in bundle).")
+    return "\n".join(lines)
+
+
 class ChannelBridge:
     def __init__(
         self,
@@ -770,7 +800,11 @@ class ChannelBridge:
                 "tools": [
                     {
                         "name": "reply",
-                        "description": "Reply to an aX channel message in-thread.",
+                        "description": (
+                            "Reply to an aX channel message in-thread. The response includes any "
+                            "aX messages that arrived addressed to this agent while the reply was "
+                            "being composed, so two agents don't talk past each other."
+                        ),
                         "inputSchema": {
                             "type": "object",
                             "properties": {
@@ -778,6 +812,24 @@ class ChannelBridge:
                                 "reply_to": {
                                     "type": "string",
                                     "description": "aX message_id to reply to. Defaults to the latest inbound message.",
+                                },
+                                "inbox": {
+                                    "type": "boolean",
+                                    "description": (
+                                        "Include unread messages addressed to this agent in the response. "
+                                        "Default true; pass false to skip the post-send inbox poll."
+                                    ),
+                                },
+                                "inbox_wait": {
+                                    "type": "number",
+                                    "description": (
+                                        "Seconds to wait for inbound messages after sending. "
+                                        "Default 2; 0 only checks immediately."
+                                    ),
+                                },
+                                "inbox_limit": {
+                                    "type": "number",
+                                    "description": "Max inbound messages to bundle (default 10).",
                                 },
                             },
                             "required": ["text"],
@@ -916,17 +968,40 @@ class ChannelBridge:
                 last_work_completed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 backlog_depth=self.mention_queue.qsize(),
             )
-            await self.send_response(
-                request_id,
+
+            # Bundle "what arrived while you were drafting" into the response.
+            # Same intent as `_send_from_managed_agent`'s inbox bundling for
+            # the CLI agents-send path: closes aX task 663d9e6f. Default ON;
+            # the caller can pass {"inbox": false} to skip.
+            include_inbox = arguments.get("inbox") is not False
+            inbox_bundle = None
+            inbox_error = None
+            if include_inbox and self.agent_id:
+                try:
+                    inbox_bundle = await self._poll_channel_inbox_after_reply(
+                        wait_seconds=int(arguments.get("inbox_wait", 2) or 0),
+                        limit=int(arguments.get("inbox_limit", 10) or 10),
+                    )
+                except Exception as exc:
+                    inbox_error = str(exc)
+
+            response_content: list[dict[str, Any]] = [
                 {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"sent reply to {reply_to}" + (f" ({sent_id})" if sent_id else ""),
-                        }
-                    ]
-                },
-            )
+                    "type": "text",
+                    "text": f"sent reply to {reply_to}" + (f" ({sent_id})" if sent_id else ""),
+                }
+            ]
+            if inbox_bundle and inbox_bundle.get("messages"):
+                response_content.append(
+                    {
+                        "type": "text",
+                        "text": _format_inbox_bundle_for_mcp(inbox_bundle),
+                    }
+                )
+            elif inbox_error:
+                response_content.append({"type": "text", "text": f"(inbox poll failed: {inbox_error})"})
+
+            await self.send_response(request_id, {"content": response_content})
             self.log(f"replied to {reply_to}")
         except Exception as exc:  # pragma: no cover - exercised in live runs
             await self.send_response(
@@ -936,6 +1011,52 @@ class ChannelBridge:
                     "isError": True,
                 },
             )
+
+    async def _poll_channel_inbox_after_reply(
+        self,
+        *,
+        wait_seconds: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        """After a channel reply lands, return any unread messages addressed
+        to this agent so the caller doesn't talk past whatever arrived while
+        the reply was being composed.
+
+        Mirrors the wait-loop shape of ``_poll_managed_agent_inbox_after_send``
+        in ``commands/gateway.py``: poll once immediately, then keep polling
+        on ``poll_interval`` until messages arrive or the deadline elapses.
+        Uses the channel's already-authenticated agent client so no extra
+        identity setup is needed.
+        """
+        deadline = time.monotonic() + max(0, int(wait_seconds))
+        capped_limit = max(1, min(int(limit), 100))
+        poll_interval = 1.0
+        while True:
+            data = await asyncio.to_thread(
+                self.client.list_messages,
+                limit=capped_limit,
+                space_id=self.space_id,
+                agent_id=self.agent_id,
+                unread_only=True,
+                mark_read=True,
+                channel="main",
+            )
+            messages = (
+                data if isinstance(data, list) else (data.get("messages") if isinstance(data, dict) else []) or []
+            )
+            unread_count = (
+                data.get("unread_count") if isinstance(data, dict) and "unread_count" in data else len(messages)
+            )
+            bundle: dict[str, Any] = {
+                "agent": self.agent_name,
+                "agent_id": self.agent_id,
+                "space_id": self.space_id,
+                "messages": messages,
+                "unread_count": unread_count,
+            }
+            if messages or wait_seconds <= 0 or time.monotonic() >= deadline:
+                return bundle
+            await asyncio.sleep(poll_interval)
 
     async def handle_request(self, request: dict[str, Any]) -> None:
         request_id = request.get("id")

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -2079,6 +2079,42 @@ def _sync_passive_queue_after_manual_send(
         )
 
 
+def _poll_managed_agent_inbox_after_send(
+    *,
+    name: str,
+    space_id: str | None,
+    limit: int,
+    wait_seconds: int,
+    channel: str = "main",
+    poll_interval: float = 1.0,
+) -> dict:
+    """Bundle "what arrived while you were drafting" for a managed-agent send.
+
+    Mirrors ``_poll_local_inbox_over_http``'s wait loop, but uses the
+    in-process ``_inbox_for_managed_agent`` (Live Listener / managed-agent
+    path) instead of the local-session HTTP proxy. Closes aX task
+    ``663d9e6f``: every send-as-agent path should return inbound messages
+    that arrived during the send so two agents don't talk past each other.
+
+    ``mark_read=True`` so the same messages don't re-appear on the next
+    poll. The wait loop exits as soon as we have messages or the deadline
+    elapses.
+    """
+    deadline = time.monotonic() + max(0, int(wait_seconds))
+    while True:
+        result = _inbox_for_managed_agent(
+            name=name,
+            limit=max(1, int(limit)),
+            channel=channel,
+            space_id=space_id,
+            unread_only=True,
+            mark_read=True,
+        )
+        if result.get("messages") or wait_seconds <= 0 or time.monotonic() >= deadline:
+            return result
+        time.sleep(poll_interval)
+
+
 def _send_from_managed_agent(
     *,
     name: str,
@@ -2088,6 +2124,10 @@ def _send_from_managed_agent(
     space_id: str | None = None,
     sent_via: str = "gateway_cli",
     metadata_extra: dict[str, object] | None = None,
+    include_inbox: bool = True,
+    inbox_wait: int = 2,
+    inbox_limit: int = 10,
+    inbox_channel: str = "main",
 ) -> dict:
     if not content.strip():
         raise ValueError("Message content is required.")
@@ -2144,7 +2184,22 @@ def _send_from_managed_agent(
             reply_message_id=str(payload.get("id") or "") or None,
             reply_preview=message_content[:120] or None,
         )
-    return {"agent": entry.get("name"), "message": payload, "content": message_content}
+    response: dict = {"agent": entry.get("name"), "message": payload, "content": message_content}
+    if include_inbox:
+        try:
+            response["inbox"] = _poll_managed_agent_inbox_after_send(
+                name=str(entry.get("name") or name),
+                space_id=selected_space_id,
+                limit=inbox_limit,
+                wait_seconds=inbox_wait,
+                channel=inbox_channel,
+            )
+        except Exception as exc:
+            # Inbox bundling is a best-effort enhancement on top of the send.
+            # If it fails (transient API error, etc.) we still return the send
+            # result the operator/agent actually depends on.
+            response["inbox_error"] = str(exc)
+    return response
 
 
 def _inbox_for_managed_agent(
@@ -5636,6 +5691,9 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         content=str(body.get("content") or ""),
                         to=str(body.get("to") or "").strip() or None,
                         parent_id=str(body.get("parent_id") or "").strip() or None,
+                        # UI has its own inbox panel that polls separately;
+                        # don't make every UI send block on a 2s post-send poll.
+                        inbox_wait=0,
                     )
                     _write_json_response(self, payload, status=HTTPStatus.CREATED)
                     return
@@ -7764,11 +7822,34 @@ def send_as_agent(
     content: str = typer.Argument(..., help="Message content"),
     to: str = typer.Option(None, "--to", help="Prepend a mention like @codex automatically"),
     parent_id: str = typer.Option(None, "--parent-id", help="Reply inside an existing thread"),
+    include_inbox: bool = typer.Option(
+        True,
+        "--inbox/--no-inbox",
+        help="After sending, include unread messages addressed to this agent in the response. "
+        "Default ON so two agents don't talk past each other when one replies while the other is mid-draft.",
+    ),
+    inbox_wait: int = typer.Option(
+        2,
+        "--inbox-wait",
+        min=0,
+        help="Seconds to wait for inbound messages after sending. 0 only checks immediately.",
+    ),
+    inbox_limit: int = typer.Option(
+        10, "--inbox-limit", min=1, max=100, help="Max inbound messages to bundle in the response."
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Send a message as a Gateway-managed agent."""
     try:
-        result = _send_from_managed_agent(name=name, content=content, to=to, parent_id=parent_id)
+        result = _send_from_managed_agent(
+            name=name,
+            content=content,
+            to=to,
+            parent_id=parent_id,
+            include_inbox=include_inbox,
+            inbox_wait=inbox_wait,
+            inbox_limit=inbox_limit,
+        )
     except ValueError as exc:
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
@@ -7780,6 +7861,21 @@ def send_as_agent(
     if isinstance(result["message"], dict) and result["message"].get("id"):
         err_console.print(f"  id = {result['message']['id']}")
     err_console.print(f"  content = {result['content']}")
+    inbox = result.get("inbox") if isinstance(result.get("inbox"), dict) else None
+    if inbox:
+        unread = inbox.get("unread_count") or 0
+        if unread:
+            err_console.print(
+                f"[yellow]Inbox while drafting:[/yellow] {unread} unread message(s) addressed to @{result['agent']}"
+            )
+            for msg in (inbox.get("messages") or [])[:5]:
+                if not isinstance(msg, dict):
+                    continue
+                sender = msg.get("agent_name") or msg.get("user_name") or msg.get("sender") or "unknown"
+                preview = str(msg.get("content") or "").strip().splitlines()[0][:120] if msg.get("content") else ""
+                err_console.print(f"  - @{sender}: {preview}")
+    elif result.get("inbox_error"):
+        err_console.print(f"[dim]Inbox poll failed: {result['inbox_error']}[/dim]")
 
 
 @agents_app.command("inbox")

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -165,6 +165,151 @@ def test_channel_reply_preserves_explicit_mentions_for_routing():
     assert client.sent[0]["metadata"]["mentions"] == ["nemotron"]
 
 
+# --- Inbox bundling on channel reply (aX task 663d9e6f) -------------------
+
+
+class _InboxClient(FakeClient):
+    """FakeClient that also supports list_messages so the inbox poll lands."""
+
+    def __init__(self, *, list_messages_response, **kwargs):
+        super().__init__(**kwargs)
+        self._list_messages_response = list_messages_response
+        self.list_messages_calls: list[dict] = []
+
+    def list_messages(self, *, limit=None, space_id=None, agent_id=None, unread_only=None, mark_read=None, channel=None):
+        self.list_messages_calls.append(
+            {
+                "limit": limit,
+                "space_id": space_id,
+                "agent_id": agent_id,
+                "unread_only": unread_only,
+                "mark_read": mark_read,
+                "channel": channel,
+            }
+        )
+        return self._list_messages_response
+
+
+def _send_response_for(bridge: CaptureBridge) -> dict:
+    """Return the response payload the bridge wrote for the most recent reply."""
+    for payload in reversed(bridge.writes):
+        if isinstance(payload, dict) and payload.get("result") and "content" in payload["result"]:
+            return payload["result"]
+    raise AssertionError("no MCP response written")
+
+
+def test_channel_reply_bundles_unread_inbox_in_response_by_default():
+    """Default ON: a reply should return what arrived while the agent was drafting."""
+    inbox_response = {
+        "messages": [
+            {"id": "m-1", "content": "@peer-agent ping from alex", "agent_name": "alex"},
+            {"id": "m-2", "content": "@peer-agent follow-up", "agent_name": "alex"},
+        ],
+        "unread_count": 2,
+    }
+    client = _InboxClient(list_messages_response=inbox_response)
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "thanks!", "inbox_wait": 0}},
+        )
+    )
+
+    assert client.sent[0]["content"] == "thanks!"
+    assert client.list_messages_calls, "list_messages must run on the post-reply inbox poll"
+    assert client.list_messages_calls[0]["unread_only"] is True
+    assert client.list_messages_calls[0]["mark_read"] is True
+    assert client.list_messages_calls[0]["agent_id"] == "agent-123"
+
+    response = _send_response_for(bridge)
+    assert len(response["content"]) == 2  # send confirmation + inbox bundle
+    inbox_text = response["content"][1]["text"]
+    assert "INBOX while you were drafting" in inbox_text
+    assert "2 unread message(s)" in inbox_text
+    assert "@alex" in inbox_text
+    assert "ping from alex" in inbox_text
+
+
+def test_channel_reply_skips_inbox_when_arg_is_false():
+    """`inbox: false` opts out of the post-reply poll entirely."""
+    client = _InboxClient(list_messages_response={"messages": [], "unread_count": 0})
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "no inbox please", "inbox": False}},
+        )
+    )
+
+    assert not client.list_messages_calls, "inbox=false must skip the post-reply poll"
+    response = _send_response_for(bridge)
+    assert len(response["content"]) == 1  # just the send confirmation, no inbox item
+
+
+def test_channel_reply_omits_inbox_section_when_no_unread():
+    """No unread messages → response stays single-item, not noisy."""
+    client = _InboxClient(list_messages_response={"messages": [], "unread_count": 0})
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "quiet send", "inbox_wait": 0}},
+        )
+    )
+
+    assert client.list_messages_calls, "poll still runs to verify quiet"
+    response = _send_response_for(bridge)
+    assert len(response["content"]) == 1
+
+
+def test_format_inbox_bundle_for_mcp_caps_at_five():
+    """The render helper truncates long inbox lists to keep the MCP item compact."""
+    bundle = {
+        "agent": "peer-agent",
+        "messages": [
+            {"id": f"m-{i}", "content": f"msg {i}", "agent_name": "alex"} for i in range(10)
+        ],
+        "unread_count": 10,
+    }
+    text = channel_mod._format_inbox_bundle_for_mcp(bundle)
+    assert "10 unread message(s)" in text
+    # 5 visible items + 1 "and N more" line.
+    assert text.count("@alex") == 5
+    assert "and 5 more" in text
+
+
+def test_channel_reply_shows_inbox_error_when_poll_fails():
+    """If list_messages raises, the response still ships the send confirmation
+    plus a `(inbox poll failed: ...)` line so the agent knows something missed."""
+
+    class _RaisingClient(FakeClient):
+        def list_messages(self, **_kwargs):
+            raise RuntimeError("upstream 503")
+
+    client = _RaisingClient()
+    bridge = CaptureBridge(client)
+    bridge._last_message_id = "incoming-123"
+
+    asyncio.run(
+        bridge.handle_tool_call(
+            1,
+            {"name": "reply", "arguments": {"text": "even on error", "inbox_wait": 0}},
+        )
+    )
+
+    response = _send_response_for(bridge)
+    assert len(response["content"]) == 2
+    assert "inbox poll failed" in response["content"][1]["text"]
+    assert "upstream 503" in response["content"][1]["text"]
+
+
 def test_channel_can_publish_working_status_on_delivery():
     client = FakeClient("axp_a_AgentKey.Secret")
     bridge = CaptureBridge(client)

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -3850,7 +3850,10 @@ def test_gateway_agents_send_uses_managed_identity(monkeypatch, tmp_path):
     assert payload["content"] == "@codex hello there"
     assert payload["message"]["metadata"]["gateway"]["sent_via"] == "gateway_cli"
     recent = gateway_core.load_recent_gateway_activity()
-    assert recent[-1]["event"] == "manual_message_sent"
+    # The send event must appear, but is no longer guaranteed to be last —
+    # the default-on post-send inbox poll (aX task 663d9e6f) appends a
+    # `managed_inbox_polled` event after it.
+    assert any(item["event"] == "manual_message_sent" for item in recent)
 
 
 def test_gateway_agents_send_rejects_user_bootstrap_pat(monkeypatch, tmp_path):
@@ -3967,7 +3970,10 @@ def test_gateway_agents_send_acknowledges_pending_inbox_message(monkeypatch, tmp
     assert updated["processed_count"] == 1
     assert updated["last_reply_message_id"] == "msg-sent-1"
     recent = gateway_core.load_recent_gateway_activity()
-    assert recent[-1]["event"] == "manual_queue_acknowledged"
+    # Same nuance as the sister test: the queue-ack event is in the recent
+    # log but no longer trailing because the default-on post-send inbox
+    # poll appends afterwards.
+    assert any(item["event"] == "manual_queue_acknowledged" for item in recent)
 
 
 def test_gateway_agents_send_blocks_identity_mismatch(monkeypatch, tmp_path):
@@ -7104,6 +7110,101 @@ def test_apply_entry_current_space_uses_global_cache_for_unknown_new_space(monke
     assert entry["active_space_name"] == "Claude Code Workshop"
     assert entry["default_space_id"] == new_space
     assert entry["default_space_name"] == "Claude Code Workshop"
+
+
+def test_send_from_managed_agent_bundles_unread_inbox_by_default(monkeypatch, tmp_path):
+    """ax-cli-dev 663d9e6f: every send-as-agent path should bundle "what arrived
+    while you were drafting" so two agents don't talk past each other."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    # Seed a pending message so unread_only's intersection returns it.
+    gateway_core.save_agent_pending_messages(
+        "cli_god",
+        [{"message_id": "msg-1", "content": "first inbound", "queued_at": "2026-05-08T00:00:00Z"}],
+    )
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "send", "cli_god", "thanks!", "--inbox-wait", "0", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["agent"] == "cli_god"
+    assert payload["content"] == "thanks!"
+    assert "inbox" in payload, "default-on inbox bundling missing from response"
+    inbox = payload["inbox"]
+    assert inbox["agent"] == "cli_god"
+    assert inbox["unread_count"] == 1
+    assert any(m.get("id") == "msg-1" for m in inbox["messages"])
+
+
+def test_send_from_managed_agent_skips_inbox_when_disabled(monkeypatch, tmp_path):
+    """`--no-inbox` opts out of the post-send poll entirely."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    gateway_core.save_agent_pending_messages(
+        "cli_god",
+        [{"message_id": "msg-1", "content": "first inbound", "queued_at": "2026-05-08T00:00:00Z"}],
+    )
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "send", "cli_god", "skip inbox", "--no-inbox", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert "inbox" not in payload
+    assert "inbox_error" not in payload
+    # Pending queue is preserved because the post-send poll never ran.
+    assert len(gateway_core.load_agent_pending_messages("cli_god")) == 1
+
+
+def test_send_from_managed_agent_inbox_error_does_not_break_send(monkeypatch, tmp_path):
+    """If the post-send poll raises, the send result still ships and the error
+    is surfaced as inbox_error so the caller sees the partial outcome."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    def boom(**_kwargs):
+        raise RuntimeError("upstream 503")
+
+    monkeypatch.setattr(gateway_cmd, "_poll_managed_agent_inbox_after_send", boom)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "send", "cli_god", "even on error", "--inbox-wait", "0", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    # Send still succeeded.
+    assert payload["agent"] == "cli_god"
+    assert payload["content"] == "even on error"
+    assert payload["message"]["id"] == "msg-sent-1"
+    # Error path surfaces.
+    assert payload.get("inbox_error") == "upstream 503"
+    assert "inbox" not in payload
+
+
+def test_send_from_managed_agent_inbox_returns_empty_when_no_unread(monkeypatch, tmp_path):
+    """An empty inbox still returns the bundle structure with messages=[] and
+    unread_count=0 so callers can rely on the field shape."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    # No pending messages seeded, so unread_only intersection -> empty list.
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "send", "cli_god", "quiet send", "--inbox-wait", "0", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("inbox") is not None
+    assert payload["inbox"]["messages"] == []
+    assert payload["inbox"]["unread_count"] == 0
 
 
 def test_inbox_for_managed_agent_clears_pending_queue_on_mark_read(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes aX task `663d9e6f` ("[P0] Bundle unread inbox into managed-agent send response"). Brings the Live Listener (`ax gateway agents send`) and channel-MCP (`reply` tool) paths into parity with the pass-through path that already supports `--inbox/--no-inbox/--inbox-wait/--inbox-limit`.

## Why

From the task description:

> Two agents talking past each other was the dangerous case: agent A sends a reply while agent B is mid-draft; B's reply ships before B can see what A just sent.

The pass-through path was already fixed. The other two send-as-agent surfaces were not:

```python
# ax gateway local send (pass-through) — has --inbox/--inbox-wait/--inbox-limit:
ax gateway local send --workdir . "thanks!"  # response.inbox = {messages, unread_count}

# ax gateway agents send (Live Listener) — no inbox bundle:
ax gateway agents send my-agent "thanks!"  # response = {agent, message, content} only

# mcp__ax-channel__reply (channel-attached) — no inbox bundle:
reply({text: "thanks!"})  # response.content = [{type: text, text: "sent reply ..."}] only
```

Default opt-out is the right shape per the task: *"talking past each other is the dangerous case."*

## Changes

### `_send_from_managed_agent` + `ax gateway agents send` CLI

Four new keyword arguments mirroring the existing pass-through flags: `include_inbox` (default True), `inbox_wait` (default 2s), `inbox_limit` (default 10), `inbox_channel` (default "main"). After the platform accepts the send, a wait-loop poll runs against `_inbox_for_managed_agent` with `unread_only=True, mark_read=True` and bundles the result into the response payload as:

```python
inbox: {agent, agent_id, space_id, messages, unread_count}
```

The poll is best-effort — if it raises, the send result still ships and the error surfaces as `inbox_error` so the caller sees the partial outcome instead of a masked successful send.

The CLI command exposes the matching `--inbox/--no-inbox`, `--inbox-wait`, `--inbox-limit` flags. Human output gets a yellow-highlighted "Inbox while drafting: N unread message(s)" summary plus the first 5 sender/preview pairs when there's something there.

```text
$ ax gateway agents send wishy "thanks for the heads up"
Sent as managed agent: @wishy
  id = msg-abc-123
  content = thanks for the heads up
Inbox while drafting: 2 unread message(s) addressed to @wishy
  - @alex: hold off — the test is still flaky
  - @sam: actually nevermind, false alarm
```

### Channel MCP `reply` tool

The `inputSchema` adds optional `inbox` (boolean), `inbox_wait` (number), `inbox_limit` (number) parameters; default opts in. After the send, the bridge polls `self.client.list_messages(unread_only=True, mark_read=True)` via `asyncio.to_thread` and renders the result as a second `text` content item using the new `_format_inbox_bundle_for_mcp` module-level helper. Empty inbox → response stays single-item and quiet. Poll error → response gets a `(inbox poll failed: ...)` line without breaking the send.

The format helper caps at 5 visible messages with an "and N more" footer so the MCP response stays compact even on busy spaces.

### UI handler `/api/agents/<name>/send`

Passes `inbox_wait=0` so every operator-driven send through the dashboard doesn't block on a 2-second post-send poll. The UI has its own inbox panel that polls separately on its own cadence. Already-pending messages still show up in the bundle (`unread_only=True` against the local pending queue is immediate); only the wait-loop is short-circuited.

## Direction check

* **Operator UX**: matches the surface the pass-through path already established. Same flag names, same defaults, same JSON shape — operators don't have to learn a third pattern.
* **Best-effort by design**: `inbox_error` in the response is intentional. The send is the operation that *must* succeed atomically; the inbox bundle is enrichment. A 5xx on the inbox endpoint should never look like a failed send.
* **Default ON because silence is dangerous**: per the task description, the failure mode being prevented is silent — two agents producing replies that ignore each other's just-sent messages. Default-off would have the same pre-fix behavior with extra ceremony.
* **No new abstractions across paths**: the channel path uses an in-class `_poll_channel_inbox_after_reply` async helper because it has to interleave with the bridge's existing event loop; the CLI path uses the sync `_poll_managed_agent_inbox_after_send` module helper because it's called from synchronous typer command handlers. Both are ~30 lines and read cleanly side-by-side.

## Two pre-existing tests loosened (not changed in spirit)

`test_gateway_agents_send_uses_managed_identity` and `test_gateway_agents_send_acknowledges_pending_inbox_message` asserted `recent[-1]["event"]` was the send event. With the default-on inbox poll, `recent[-1]` is now `managed_inbox_polled` because the poll runs after the send. Loosened to `any(item["event"] == "manual_message_sent" for item in recent)` — the send event still appears in the log, just not last. Original intent (the send fired) is preserved.

## Test plan

- [x] `uv run --with pytest pytest tests/test_gateway_commands.py -k "send_from_managed_agent or test_gateway_agents_send"` — 8/8 pass
- [x] `uv run --with pytest pytest tests/test_channel.py -k "channel_reply or format_inbox"` — 6/6 pass
- [x] `uv run --with pytest pytest` — net **+9 passes** vs `main`, no new failures (42 pre-existing failures unchanged from main baseline)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke: agent A sends, agent B's `ax gateway agents send` from a fresh terminal returns A's send in the `inbox` field.
- [ ] Manual smoke: same scenario via channel MCP `reply` — second `text` content item lists A's message with sender + preview.
- [ ] Manual smoke: UI dashboard send — completes promptly (no 2s block), inbox panel still updates on its own polling cadence.

## Related

* aX task: `663d9e6f` (this PR closes the residual gap; PR #173's mailbox stack landed the prerequisite UI/queue infrastructure)
* Pattern source: `ax gateway local send` already had `--inbox/--no-inbox/--inbox-wait/--inbox-limit` (`commands/gateway.py`, the `local_send` typer command). This PR mirrors that surface onto two more send paths.
