### PR TITLE
feat(gateway): opt-in session-continuity challenge for pass-through send

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,36 @@ run from that directory and omit identity flags. Avoid `--agent` in normal
 agent instructions; Gateway should resolve the registry row from the local
 config and fingerprint.
 
+### Optional: session-continuity challenge
+
+`AX_GATEWAY_SESSION_CHALLENGE=1` on the Gateway daemon enables a Phase-1
+opt-in challenge cycle on the `/local/send` path. This is a session-retention
+test and a guard against accidental identity sharing when several ephemeral
+sessions run from the same workdir — **not default onboarding**, and not a
+substitute for fingerprint-based registry approval.
+
+When enabled, the first send under a session is rejected with a short code
+the agent must echo on the next send via `--session-proof`. Each successful
+send rotates the code and returns the next one in the response payload as
+`next_session_proof`:
+
+```text
+$ AX_GATEWAY_SESSION_CHALLENGE=1 ax gateway start ...
+
+# In the agent's workdir:
+$ ax gateway local send --workdir . "first send"
+Error: session_challenge_required: 4HTQR8U. Re-run with --session-proof <code>
+       to confirm session continuity.
+
+$ ax gateway local send --workdir . "first send" --session-proof 4HTQR8U
+Sent through Gateway as @mac_frontend
+Next session-proof: K2FQEK_E (echo this with --session-proof on the next send)
+```
+
+A wrong proof fails with `invalid_session_proof: expected <code>` so the
+operator can recover by re-running once without `--session-proof` to re-issue
+the challenge. With the env var unset, behavior is unchanged.
+
 ### Space Binding
 
 Each Gateway-managed agent has one current `space_id`. Normal sends, mailbox

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import getpass
 import json
 import os
+import secrets
 import shlex
 import shutil
 import signal
@@ -543,6 +544,101 @@ def _connect_local_pass_through_agent(
     return payload
 
 
+def _gateway_session_challenge_enabled() -> bool:
+    """Phase-1 opt-in flag for the pass-through session challenge.
+
+    Closes aX task ``68cb4d29`` (Phase-1: ``/local/send`` only). Truthy values
+    on ``AX_GATEWAY_SESSION_CHALLENGE`` enable the challenge cycle. Anything
+    else — including an unset env var — preserves the current easy path so
+    operators who haven't opted in see no behavior change.
+
+    The challenge is intentionally testing-flavored, not production hardening:
+    use it as a memory/session-retention probe, and as a guard against
+    accidental identity sharing when several ephemeral sessions run from the
+    same workdir.
+    """
+    raw = os.environ.get("AX_GATEWAY_SESSION_CHALLENGE", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _generate_session_challenge_code() -> str:
+    """Short URL-safe code suitable for an operator to read and echo back.
+
+    Uppercased so it's distinct from any base64-shaped token in the same
+    output and easy to type. ~6–8 chars depending on the random bytes' shape.
+    """
+    return secrets.token_urlsafe(4).upper()
+
+
+def _find_local_session_record(registry: dict, session_id: str) -> dict | None:
+    """Look up the registry record for a verified local session id."""
+    target = (session_id or "").strip()
+    if not target:
+        return None
+    for item in registry.get("local_sessions") or []:
+        if str(item.get("session_id") or "") == target:
+            return item
+    return None
+
+
+def _ensure_session_challenge(
+    registry: dict,
+    session_id: str,
+    *,
+    provided_proof: str | None,
+) -> str:
+    """Verify or issue a session-continuity challenge.
+
+    Returns the next challenge code (the proof the caller should echo back
+    on the *next* send) when the provided proof matches the stored one.
+
+    Raises ``ValueError`` with a structured error message in two cases:
+    no stored challenge yet (a new one is issued for the next send), or
+    proof mismatch / missing proof against an existing stored challenge.
+    Both error messages start with a recognizable prefix so callers can
+    surface them without further parsing.
+    """
+    record = _find_local_session_record(registry, session_id)
+    if record is None:
+        # The token verified upstream, but the registry record is gone —
+        # treat as a hard rejection rather than auto-issuing a challenge for
+        # an unknown session.
+        raise ValueError("session_challenge_unknown_session: no record for this session.")
+
+    stored = str(record.get("challenge_code") or "").strip()
+    proof = str(provided_proof or "").strip()
+
+    if not stored:
+        # First send under the flag for this session: issue a challenge and
+        # require the caller to echo it on the next send.
+        new_code = _generate_session_challenge_code()
+        record["challenge_code"] = new_code
+        record["challenge_issued_at"] = datetime.now(timezone.utc).isoformat()
+        save_gateway_registry(registry)
+        raise ValueError(
+            f"session_challenge_required: {new_code}. Re-run with --session-proof <code> to confirm session continuity."
+        )
+
+    if not proof:
+        raise ValueError(
+            f"session_challenge_required: {stored}. Re-run with --session-proof <code> to confirm session continuity."
+        )
+
+    if proof != stored:
+        raise ValueError(
+            f"invalid_session_proof: expected {stored}. "
+            "Run once without --session-proof to re-issue the challenge if you've lost it."
+        )
+
+    # Valid proof: rotate the code so the caller has a fresh proof for the
+    # next send. Each successful send consumes one code.
+    new_code = _generate_session_challenge_code()
+    record["challenge_code"] = new_code
+    record["challenge_issued_at"] = datetime.now(timezone.utc).isoformat()
+    save_gateway_registry(registry)
+    return new_code
+
+
 def _send_local_session_message(*, session_token: str, body: dict) -> dict:
     registry = load_gateway_registry()
     session = verify_local_session_token(registry, session_token)
@@ -566,6 +662,19 @@ def _send_local_session_message(*, session_token: str, body: dict) -> dict:
         raise ValueError("space_id is required.")
     if not content:
         raise ValueError("content is required.")
+
+    # aX task 68cb4d29: Phase-1 opt-in session-continuity challenge. Only
+    # gates the /local/send path for now; everything else (inbox poll,
+    # generic proxy methods) keeps the easy path. When the env flag is
+    # not set, this is a no-op — preserving the current behavior.
+    next_session_proof: str | None = None
+    if _gateway_session_challenge_enabled():
+        next_session_proof = _ensure_session_challenge(
+            registry,
+            str(session.get("session_id") or ""),
+            provided_proof=str(body.get("session_proof") or "").strip() or None,
+        )
+
     client = _load_managed_agent_client(entry)
     metadata = {
         **(body.get("metadata") if isinstance(body.get("metadata"), dict) else {}),
@@ -604,7 +713,10 @@ def _send_local_session_message(*, session_token: str, body: dict) -> dict:
         message_id=(payload.get("message") or {}).get("id"),
         attachment_count=len(attachments_payload or []),
     )
-    return {"agent": entry.get("name"), "message": payload, "session": session}
+    response = {"agent": entry.get("name"), "message": payload, "session": session}
+    if next_session_proof is not None:
+        response["next_session_proof"] = next_session_proof
+    return response
 
 
 def _create_local_session_task(*, session_token: str, body: dict) -> dict:
@@ -7298,6 +7410,16 @@ def local_send(
         help="Seconds to wait for inbound messages after sending. Use 0 to only check immediately.",
     ),
     inbox_limit: int = typer.Option(10, "--inbox-limit", min=1, max=100, help="Max inbound messages to return."),
+    session_proof: str = typer.Option(
+        None,
+        "--session-proof",
+        help=(
+            "Echo back the challenge code Gateway issued on the previous send. "
+            "Only required when AX_GATEWAY_SESSION_CHALLENGE is enabled on the Gateway "
+            "(opt-in session-continuity test). On a successful send under the flag, the "
+            "response includes next_session_proof for the following call."
+        ),
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Send through an approved local pass-through Gateway session."""
@@ -7320,6 +7442,8 @@ def local_send(
     )
 
     body = {"content": content, "space_id": space_id, "parent_id": parent_id}
+    if session_proof:
+        body["session_proof"] = session_proof.strip()
     try:
         response = httpx.post(
             f"{gateway_url.rstrip('/')}/local/send",
@@ -7335,6 +7459,12 @@ def local_send(
             detail = exc.response.json().get("error", detail)
         except Exception:
             pass
+        # Surface session-challenge errors so the operator can see the code
+        # and the next step without sifting through generic "send failed" text.
+        if isinstance(detail, str) and (
+            detail.startswith("session_challenge_required:") or detail.startswith("invalid_session_proof:")
+        ):
+            raise typer.BadParameter(detail) from exc
         raise typer.BadParameter(f"Gateway local send failed: {detail}") from exc
     except Exception as exc:
         raise typer.BadParameter(f"Gateway local send failed: {exc}") from exc
@@ -7372,6 +7502,11 @@ def local_send(
         print_json(payload)
         return
     console.print(f"[green]Sent through Gateway[/green] as @{payload.get('agent')}")
+    if payload.get("next_session_proof"):
+        console.print(
+            f"[cyan]Next session-proof:[/cyan] {payload['next_session_proof']} "
+            "(echo this with --session-proof on the next send)"
+        )
     _print_pending_reply_warning_local(pending)
     inbox_payload = payload.get("inbox") if isinstance(payload.get("inbox"), dict) else {}
     messages = inbox_payload.get("messages") if isinstance(inbox_payload, dict) else []

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -133,6 +133,142 @@ def test_existing_agent_home_space_prefers_backend_current_space():
     )
 
 
+def _seed_local_session_for_challenge(tmp_path, monkeypatch):
+    """Set up a minimal approved managed agent + active local session."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "operator",
+        }
+    )
+    token_file = tmp_path / "challenge-agent.token"
+    token_file.write_text("axp_a_test.secret")
+    entry = {
+        "name": "challenge-agent",
+        "agent_id": "agent-challenge",
+        "space_id": "space-1",
+        "base_url": "https://paxai.app",
+        "token_file": str(token_file),
+        "approval_state": "approved",
+        "attestation_state": "verified",
+    }
+    registry = {"agents": [entry]}
+    session_payload = gateway_core.issue_local_session(registry, entry)
+    registry = {"agents": [entry], "local_sessions": registry["local_sessions"]}
+    gateway_core.save_gateway_registry(registry)
+
+    class _SilentSendClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def send_message(self, space_id, content, **_kwargs):
+            return {"message": {"id": "msg-sent-1", "space_id": space_id, "content": content}}
+
+    monkeypatch.setattr(gateway_cmd, "AxClient", _SilentSendClient)
+    monkeypatch.setattr(gateway_cmd, "_load_managed_agent_client", lambda entry: _SilentSendClient())
+    return session_payload["session_token"]
+
+
+def test_session_challenge_disabled_by_default(monkeypatch, tmp_path):
+    """Flag off → send returns normal payload, no challenge surface."""
+    monkeypatch.delenv("AX_GATEWAY_SESSION_CHALLENGE", raising=False)
+    token = _seed_local_session_for_challenge(tmp_path, monkeypatch)
+
+    payload = gateway_cmd._send_local_session_message(
+        session_token=token,
+        body={"content": "hello", "space_id": "space-1"},
+    )
+
+    assert payload["agent"] == "challenge-agent"
+    assert "next_session_proof" not in payload
+    # Registry session record stays clean — no challenge state written.
+    record = gateway_cmd._find_local_session_record(
+        gateway_core.load_gateway_registry(), payload["session"]["session_id"]
+    )
+    assert "challenge_code" not in record
+
+
+def test_session_challenge_first_send_issues_code_and_rejects(monkeypatch, tmp_path):
+    """Flag on, no proof → raise with structured `session_challenge_required: <code>`
+    and persist the code on the session record so the next send can verify."""
+    monkeypatch.setenv("AX_GATEWAY_SESSION_CHALLENGE", "1")
+    token = _seed_local_session_for_challenge(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError) as excinfo:
+        gateway_cmd._send_local_session_message(
+            session_token=token,
+            body={"content": "hello", "space_id": "space-1"},
+        )
+    msg = str(excinfo.value)
+    assert msg.startswith("session_challenge_required:")
+    # Code from the message ("session_challenge_required: ABCD. ...").
+    issued_code = msg.split(":", 1)[1].strip().split(".", 1)[0].strip()
+    assert issued_code, "challenge code must appear in the error"
+    # Stored on the session record for the next send to verify against.
+    registry_after = gateway_core.load_gateway_registry()
+    record = registry_after["local_sessions"][0]
+    assert record["challenge_code"] == issued_code
+    assert "challenge_issued_at" in record
+
+
+def test_session_challenge_valid_proof_rotates_and_returns_next_code(monkeypatch, tmp_path):
+    """Flag on, second send with the matching proof → succeeds, response carries
+    a fresh `next_session_proof` so the caller can present it on the next send."""
+    monkeypatch.setenv("AX_GATEWAY_SESSION_CHALLENGE", "1")
+    token = _seed_local_session_for_challenge(tmp_path, monkeypatch)
+
+    # First call issues the challenge.
+    with pytest.raises(ValueError) as first:
+        gateway_cmd._send_local_session_message(
+            session_token=token, body={"content": "first", "space_id": "space-1"}
+        )
+    issued = str(first.value).split(":", 1)[1].strip().split(".", 1)[0].strip()
+
+    # Second call with the matching proof succeeds and rotates.
+    payload = gateway_cmd._send_local_session_message(
+        session_token=token,
+        body={"content": "second", "space_id": "space-1", "session_proof": issued},
+    )
+    assert payload["agent"] == "challenge-agent"
+    next_code = payload["next_session_proof"]
+    assert next_code, "rotated challenge code missing from response"
+    assert next_code != issued, "code must rotate on every successful send"
+
+    # Stored code matches the rotated one.
+    record = gateway_core.load_gateway_registry()["local_sessions"][0]
+    assert record["challenge_code"] == next_code
+
+
+def test_session_challenge_wrong_proof_rejected(monkeypatch, tmp_path):
+    """Flag on, mismatched proof → structured `invalid_session_proof: expected <code>`."""
+    monkeypatch.setenv("AX_GATEWAY_SESSION_CHALLENGE", "1")
+    token = _seed_local_session_for_challenge(tmp_path, monkeypatch)
+
+    # Issue a challenge first.
+    with pytest.raises(ValueError) as first:
+        gateway_cmd._send_local_session_message(
+            session_token=token, body={"content": "first", "space_id": "space-1"}
+        )
+    issued = str(first.value).split(":", 1)[1].strip().split(".", 1)[0].strip()
+
+    with pytest.raises(ValueError) as wrong:
+        gateway_cmd._send_local_session_message(
+            session_token=token,
+            body={"content": "second", "space_id": "space-1", "session_proof": "WRONG-CODE"},
+        )
+    msg = str(wrong.value)
+    assert msg.startswith("invalid_session_proof:")
+    assert issued in msg, "error must surface the expected code so the operator can recover"
+    # The stored code must NOT have rotated — a wrong proof doesn't burn the
+    # current challenge.
+    record = gateway_core.load_gateway_registry()["local_sessions"][0]
+    assert record["challenge_code"] == issued
+
+
 def test_local_session_send_hydrates_space_from_database(monkeypatch, tmp_path):
     config_dir = tmp_path / "config"
     monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))


### PR DESCRIPTION
## Summary

Closes aX task `68cb4d29` (Phase-1: `/local/send` only). Adds an **opt-in** session-continuity challenge for pass-through sends. Disabled by default — existing easy path is preserved unchanged.

Enable with `AX_GATEWAY_SESSION_CHALLENGE=1` on the Gateway daemon.

## Behavior

When the flag is on:

```text
$ ax gateway local send --workdir . "first send"
Error: session_challenge_required: 4HTQR8U. Re-run with --session-proof <code>
       to confirm session continuity.

$ ax gateway local send --workdir . "first send" --session-proof 4HTQR8U
Sent through Gateway as @mac_frontend
Next session-proof: K2FQEK_E (echo this with --session-proof on the next send)

$ ax gateway local send --workdir . "third send" --session-proof WRONG
Error: invalid_session_proof: expected K2FQEK_E. Run once without --session-proof
       to re-issue the challenge if you've lost it.
```

* First send under a session is rejected with `session_challenge_required: <code>`. The code is persisted on the local-session record.
* Subsequent send with the matching `session_proof` succeeds, the stored code rotates, and the response payload includes `next_session_proof` for the following call.
* Wrong proof is rejected with `invalid_session_proof: expected <code>`. The current challenge is **not** burned by a wrong attempt — only a successful send rotates it, so the operator can recover without losing state.

## What this is for

Per the task description: a **session-retention test** and a guard against accidental identity sharing when several ephemeral sessions run from the same workdir. Two short-lived processes that both hold the same session token can each send once before they need to coordinate the rotated code — surfacing the sharing they might otherwise miss. Useful as a developer/QA tool, not as production hardening.

The README explicitly frames it as such: *"a session-retention test and a guard against accidental identity sharing when several ephemeral sessions run from the same workdir — not default onboarding, and not a substitute for fingerprint-based registry approval."*

## Implementation

`ax_cli/commands/gateway.py`:

* `_gateway_session_challenge_enabled()` — env-flag gate. Truthy values: `1`, `true`, `yes`, `on`. Anything else (including unset) keeps the existing easy path.
* `_generate_session_challenge_code()` — uppercased `secrets.token_urlsafe(4)`, ~6–8 chars. Distinct from any base64-shaped token in the same output, easy to read and echo.
* `_find_local_session_record()` and `_ensure_session_challenge()` — the storage + verify/rotate cycle against `registry["local_sessions"]`. Both error paths use a recognizable prefix (`session_challenge_required:` / `invalid_session_proof:`) so the CLI can surface them without further parsing.
* `_send_local_session_message` calls `_ensure_session_challenge` before the upstream send when the flag is on. When off, that block is a no-op — the existing easy path runs unchanged. Successful send returns `next_session_proof` in the response payload.
* `local_send` CLI command:
  * New `--session-proof` flag, included in the request body when present
  * Challenge errors surfaced as `typer.BadParameter(detail)` so the operator sees the code without the generic "Gateway local send failed:" wrapper
  * `Next session-proof: <code>` printed after a successful send under the flag

`README.md`: new "Optional: session-continuity challenge" subsection under "Pass-through Mailboxes" with the example flow and the reframing.

## Direction check

* **Backwards compatible by default**: env flag unset → zero behavior change. The challenge gate is a single conditional inside `_send_local_session_message`; everything outside that block is identical to before.
* **Operator UX**: structured error messages with the next-step hint inline (`Re-run with --session-proof <code>`) so the operator never has to dig for the recovery path. The CLI surfaces these errors as the primary message, not nested inside "send failed" wrapping.
* **Recoverable**: a wrong proof doesn't burn the current challenge, so an operator who typos the code can retry. Lost the code entirely → run once without `--session-proof` to re-issue. The cycle is forgiving by design.
* **Trust boundary**: the challenge is tied to the local-session record (which is itself anchored to the approved fingerprint binding), not to the raw PAT. Per the task: *"challenge is tied to Gateway local state plus approved directory fingerprint, not a raw PAT."*

## Out of scope (Phase 2+)

* Per-agent flag granularity (registry-level toggle alongside the env-var gate).
* Applying the challenge to inbox polls and other proxy methods.
* CLI auto-retry — kept manual on purpose so the friction is visible (which is the whole point of the test).
* Cross-process identity-sharing detection beyond the inherent property of the cycle.

## Test plan

- [x] `uv run --with pytest pytest tests/test_gateway_commands.py -k "session_challenge" -v` — 4/4 pass:
  - `test_session_challenge_disabled_by_default` — flag off, send works normally, no `next_session_proof` in response, no challenge state on the session record
  - `test_session_challenge_first_send_issues_code_and_rejects` — flag on, no proof, structured error, code persisted
  - `test_session_challenge_valid_proof_rotates_and_returns_next_code` — flag on, valid proof, response carries new `next_session_proof`, code rotated
  - `test_session_challenge_wrong_proof_rejected` — flag on, mismatched proof, structured error surfaces expected code, current challenge NOT rotated
- [x] `uv run --with pytest pytest` — net **+4 passes** vs `main`, no new failures (42 pre-existing failures unchanged from main baseline)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke from a Gateway-bound workdir with `AX_GATEWAY_SESSION_CHALLENGE=1`:
  - `ax gateway local send "first"` → fails with code
  - same with `--session-proof <code>` → succeeds, next code printed
  - same with wrong code → fails with expected-code message, original code unchanged

## Related

* aX task: `68cb4d29` (this PR is the Phase-1 slice; out-of-scope items are listed above)
