### PR TITLE
feat(gateway): make agent space moves reversible with --revert

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -3612,13 +3612,25 @@ def _spaces_payload() -> dict:
     return payload
 
 
-def _move_managed_agent_space(name: str, new_space_id: str) -> dict:
+def _move_managed_agent_space(name: str, new_space_id: str | None, *, revert: bool = False) -> dict:
     name = name.strip()
-    new_space_id = new_space_id.strip()
     if not name:
         raise ValueError("Managed agent name is required.")
-    if not new_space_id:
-        raise ValueError("Target space is required.")
+    if revert:
+        if new_space_id and new_space_id.strip():
+            raise ValueError("Pass either --space or --revert, not both.")
+        registry_for_revert = load_gateway_registry()
+        revert_entry = find_agent_entry(registry_for_revert, name)
+        if not revert_entry:
+            raise LookupError(f"Managed agent not found: {name}")
+        previous = str(revert_entry.get("previous_space_id") or "").strip()
+        if not previous:
+            raise ValueError(f"@{name} has no recorded previous space to revert to. Use --space <id> instead.")
+        new_space_id = previous
+    else:
+        new_space_id = (new_space_id or "").strip()
+        if not new_space_id:
+            raise ValueError("Target space is required.")
     client = _load_gateway_user_client()
     new_space_id = resolve_space_id(client, explicit=new_space_id)
     registry = load_gateway_registry()
@@ -3703,10 +3715,26 @@ def _move_managed_agent_space(name: str, new_space_id: str) -> dict:
             # Resync best-effort; the placement write already succeeded.
             continue
     previous_space_id = str(entry.get("space_id") or "").strip() or None
+    previous_space_name = str(entry.get("active_space_name") or entry.get("space_name") or "").strip() or None
     if backend_allowed_spaces is not None:
         entry["allowed_spaces"] = backend_allowed_spaces
     apply_entry_current_space(entry, backend_space_id, space_name=backend_space_name)
     ensure_gateway_identity_binding(registry, entry, session=load_gateway_session())
+    # Persist the prior space so `ax gateway agents move <name> --revert` can
+    # find its way back without the operator needing to remember the UUID.
+    # Only record when the move actually changed spaces — a no-op move
+    # (already in the requested space) shouldn't blank the revert pointer.
+    if previous_space_id and previous_space_id != backend_space_id:
+        entry["previous_space_id"] = previous_space_id
+        if previous_space_name:
+            entry["previous_space_name"] = previous_space_name
+    # Mark the entry as moving for any concurrent send guard / UI panel that
+    # reads `current_status`. Cleared once the rebind wait below resolves
+    # (or the deadline elapses) so a stuck move doesn't permanently freeze
+    # sends. The send guard itself raises off `_identity_space_send_guard`
+    # via `annotate_runtime_health`; this surface is for human-readable text.
+    entry["current_status"] = "moving"
+    entry["current_activity"] = f"Moving to {backend_space_name or backend_space_id}; sends paused until reconnect."
     # Capture the rebind marker BEFORE writing the registry so the wait below
     # is guaranteed to see only post-move runtime/listener events.
     rebind_marker = datetime.now(timezone.utc).isoformat()
@@ -3747,6 +3775,19 @@ def _move_managed_agent_space(name: str, new_space_id: str) -> dict:
             if any((event.get("ts") or "") > rebind_marker and event.get("event") in ready_events for event in recent):
                 break
             time.sleep(0.2)
+    # Reconnect window has resolved (or its 5s deadline elapsed). Clear the
+    # human-readable "moving" status so subsequent sends through the
+    # send-guard read normal state. Re-read the registry first because a
+    # concurrent runtime/listener event may have already updated the entry.
+    registry_after = load_gateway_registry()
+    settled = find_agent_entry(registry_after, name)
+    if settled is not None and str(settled.get("current_status") or "") == "moving":
+        settled["current_status"] = None
+        settled["current_activity"] = None
+        save_gateway_registry(registry_after)
+        # Mirror onto the local entry so the return value reflects the cleared state.
+        entry["current_status"] = None
+        entry["current_activity"] = None
     return annotate_runtime_health(entry, registry=registry)
 
 
@@ -7715,12 +7756,29 @@ def test_agent(
 @agents_app.command("move")
 def move_agent(
     name: str = typer.Argument(..., help="Managed agent name"),
-    space_id: str = typer.Option(..., "--space", "--space-id", "-s", help="Target space slug, name, or id"),
+    space_id: str = typer.Option(None, "--space", "--space-id", "-s", help="Target space slug, name, or id"),
+    revert: bool = typer.Option(
+        False,
+        "--revert",
+        help=(
+            "Move the agent back to its previous space. "
+            "Mutually exclusive with --space; requires a prior move on this entry."
+        ),
+    ),
     as_json: bool = JSON_OPTION,
 ):
-    """Move a Gateway-managed agent to another allowed space."""
+    """Move a Gateway-managed agent to another allowed space.
+
+    Pass ``--space`` to move to a specific space, or ``--revert`` to move
+    back to the previously-recorded space without retyping its id. The
+    revert pointer is captured automatically on every successful move,
+    so the standard "move out, move back" loop works without bookkeeping.
+    """
+    if not revert and not (space_id and space_id.strip()):
+        err_console.print("[red]Provide --space or --revert.[/red]")
+        raise typer.Exit(1)
     try:
-        result = _move_managed_agent_space(name, space_id)
+        result = _move_managed_agent_space(name, space_id, revert=revert)
     except (LookupError, ValueError) as exc:
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
@@ -7733,6 +7791,9 @@ def move_agent(
     err_console.print(
         f"  space = {result.get('active_space_name') or result.get('active_space_id') or result.get('space_id')}"
     )
+    if result.get("previous_space_id"):
+        previous_label = result.get("previous_space_name") or result.get("previous_space_id")
+        err_console.print(f"  previous = {previous_label} (use --revert to move back)")
 
 
 @agents_app.command("doctor")

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -3498,6 +3498,151 @@ def test_gateway_move_updates_routing_for_test_messages(monkeypatch, tmp_path):
     assert sent_messages[-1]["content"].startswith("@mover ")
 
 
+def _seed_revertable_mover(tmp_path, monkeypatch):
+    """Set up an agent in space-1 plus a fake user client that allows moves."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "operator",
+        }
+    )
+    token_file = tmp_path / "mover.token"
+    token_file.write_text("axp_a_mover.secret")
+    allowed_spaces = [
+        {"space_id": "space-1", "name": "Old Space", "is_default": True},
+        {"space_id": "space-2", "name": "New Space", "is_default": False},
+    ]
+    registry = gateway_core.load_gateway_registry()
+    registry["agents"] = [
+        {
+            "name": "mover",
+            "agent_id": "agent-mover",
+            "space_id": "space-1",
+            "active_space_name": "Old Space",
+            "base_url": "https://paxai.app",
+            "runtime_type": "echo",
+            "template_id": "echo_test",
+            "desired_state": "running",
+            "effective_state": "running",
+            "transport": "gateway",
+            "credential_source": "gateway",
+            "allowed_spaces": allowed_spaces,
+            "token_file": str(token_file),
+        }
+    ]
+    gateway_core.ensure_gateway_identity_binding(
+        registry, registry["agents"][0], session=gateway_core.load_gateway_session()
+    )
+    gateway_core.save_gateway_registry(registry)
+
+    class _FakeMover:
+        def __init__(self):
+            self.space_id = "space-1"
+            self.calls = []
+
+        def set_agent_placement(self, identifier, *, space_id, pinned=False):
+            self.calls.append({"identifier": identifier, "space_id": space_id})
+            self.space_id = space_id
+            return {"agent_id": identifier, "space_id": space_id}
+
+        def get_agent_placement(self, identifier):
+            return {"agent_id": identifier, "name": "mover", "space_id": self.space_id}
+
+        def get_agent(self, identifier):
+            return {"agent": {"id": identifier, "name": "mover", "space_id": self.space_id}}
+
+        def list_spaces(self):
+            return {
+                "spaces": [
+                    {"id": "space-1", "name": "Old Space", "slug": "old-space"},
+                    {"id": "space-2", "name": "New Space", "slug": "new-space"},
+                ]
+            }
+
+    fake = _FakeMover()
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: fake)
+    return fake
+
+
+def test_gateway_move_records_previous_space_for_revert(monkeypatch, tmp_path):
+    """A successful move persists previous_space_id so --revert can find its way back."""
+    fake = _seed_revertable_mover(tmp_path, monkeypatch)
+
+    moved = gateway_cmd._move_managed_agent_space("mover", "new-space")
+
+    assert moved["space_id"] == "space-2"
+    assert moved["previous_space_id"] == "space-1"
+    assert moved["previous_space_name"] == "Old Space"
+    stored = gateway_core.find_agent_entry(gateway_core.load_gateway_registry(), "mover")
+    assert stored["previous_space_id"] == "space-1"
+    assert stored["previous_space_name"] == "Old Space"
+    # current_status was set to "moving" mid-move and cleared once the rebind
+    # window resolved (no daemon running in the test, so the wait short-circuits).
+    assert stored.get("current_status") in (None, "")
+    assert stored.get("current_activity") in (None, "")
+    assert fake.calls[-1]["space_id"] == "space-2"
+
+
+def test_gateway_move_revert_returns_to_previous_space(monkeypatch, tmp_path):
+    """--revert uses the persisted previous_space_id without requiring --space."""
+    _seed_revertable_mover(tmp_path, monkeypatch)
+
+    gateway_cmd._move_managed_agent_space("mover", "new-space")
+    reverted = gateway_cmd._move_managed_agent_space("mover", None, revert=True)
+
+    assert reverted["space_id"] == "space-1"
+    assert reverted["active_space_name"] == "Old Space"
+    # After reverting, the previous-space pointer now points at the space we
+    # just left ("space-2") so a second --revert would go back there again.
+    assert reverted["previous_space_id"] == "space-2"
+    stored = gateway_core.find_agent_entry(gateway_core.load_gateway_registry(), "mover")
+    assert stored["space_id"] == "space-1"
+    assert stored["previous_space_id"] == "space-2"
+
+
+def test_gateway_move_revert_without_history_errors_clearly(monkeypatch, tmp_path):
+    """Reverting an agent that's never been moved fails with an actionable message."""
+    _seed_revertable_mover(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="no recorded previous space"):
+        gateway_cmd._move_managed_agent_space("mover", None, revert=True)
+
+
+def test_gateway_move_revert_and_explicit_space_are_mutually_exclusive(monkeypatch, tmp_path):
+    """Passing both --space and --revert is rejected before any backend call."""
+    _seed_revertable_mover(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="not both"):
+        gateway_cmd._move_managed_agent_space("mover", "new-space", revert=True)
+
+
+def test_gateway_move_cli_requires_one_of_space_or_revert(monkeypatch, tmp_path):
+    """The CLI command rejects an invocation with neither --space nor --revert."""
+    _seed_revertable_mover(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["gateway", "agents", "move", "mover"])
+
+    assert result.exit_code == 1
+    assert "Provide --space or --revert" in result.output
+
+
+def test_gateway_move_no_op_does_not_overwrite_previous_space(monkeypatch, tmp_path):
+    """A move-to-same-space short-circuits and must not blank the revert pointer."""
+    _seed_revertable_mover(tmp_path, monkeypatch)
+
+    # First move records space-1 as previous.
+    gateway_cmd._move_managed_agent_space("mover", "new-space")
+    # Now move to the SAME space (no-op).
+    gateway_cmd._move_managed_agent_space("mover", "new-space")
+
+    stored = gateway_core.find_agent_entry(gateway_core.load_gateway_registry(), "mover")
+    assert stored["previous_space_id"] == "space-1"
+
+
 def test_gateway_move_waits_for_listener_ready_after_runtime_start(monkeypatch, tmp_path):
     config_dir = tmp_path / "config"
     monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))


### PR DESCRIPTION
## Summary

Closes aX task `5b425d88` ("Gateway: make agent space moves reversible and boring"). Operators can now move a managed agent to an allowed space and move it back without retyping the previous space id — identity, mailbox state, and registry binding are preserved across both legs.

## Why

From the task description:

> Implement and document a simple move / move back flow for Gateway-managed agents. Agents and users should be able to move an agent to an allowed space, wait through any brief reconnect/freeze state, then move it back without losing identity, mailbox state, or registry binding. During reconnect, disable or block send actions with clear activity text.

Today, `ax gateway agents move <name> --space <id>` works one direction, but the operator has to remember and retype the previous space id to come back. There's no breadcrumb. Operators end up keeping a notes file or grepping `ax gateway agents show` output.

## Changes

Three small additions, all in the move flow that already existed in `_move_managed_agent_space`:

* **Persist `previous_space_id`** (and `previous_space_name`) on the entry every time a move actually changes spaces. A no-op move (already in the requested space) short-circuits without touching the revert pointer, so the standard move-out → move-back loop survives accidental re-moves.

* **`revert` keyword** on the helper. When True, it reads `previous_space_id` off the entry and uses that as the target. Passing both `--space` and `--revert` is rejected with a clear message; reverting an entry with no recorded previous space surfaces an actionable error pointing at `--space <id>`.

* **`ax gateway agents move --revert` flag.** The command's `--space` is no longer mandatory — one-of either flag is required. Help text explains the loop. Human output now surfaces the `previous` space label so operators can see the revert path is available without running `agents show`.

```text
$ ax gateway agents move my-bot --space ax-cli-dev
Managed agent moved: @my-bot
  space = ax-cli-dev
  previous = madtank-workspace (use --revert to move back)

$ ax gateway agents move my-bot --revert
Managed agent moved: @my-bot
  space = madtank-workspace
  previous = ax-cli-dev (use --revert to move back)
```

## Reconnect freeze signal

During the brief reconnect window the entry's `current_status` flips to `"moving"` with `current_activity = "Moving to <space>; sends paused until reconnect."` so anything reading the registry while the move is in flight (UI panel, concurrent send guard) sees the freeze explicitly. The status is cleared once the existing rebind wait resolves (or its 5s deadline elapses), so a stuck move can't permanently freeze sends.

The **hard** send-block continues to come from `_identity_space_send_guard` via the existing `BLOCKED` confidence state in `annotate_runtime_health` — this PR's `current_status` surface is the human-readable signal layered on top, not a replacement for the existing protection.

## Direction check

* **Identity boundary** (CLAUDE.md): the previous-space pointer lives on the same registry entry as the agent identity, so it survives across processes and Gateway restarts. Reverting doesn't synthesize new identity — it walks back to a space the agent was already approved in.
* **Backwards compatible**: existing `ax gateway agents move <name> --space <id>` invocations work unchanged. The `--space` argument went from mandatory to "one of `--space` or `--revert`" — scripts that always pass `--space` keep working. The new error path (`Provide --space or --revert.`) only fires when neither is given, which previously was a typer hard error anyway.
* **No new abstractions**: 75 lines of additions in `_move_managed_agent_space` and the CLI command, no new modules, no new helpers beyond a small test fixture. Reuses the existing `apply_entry_current_space`, `_space_name_for_id`, and rebind-wait machinery.

## Tests

Six new cases on top of the two pre-existing move tests (which still pass unchanged):

* `test_gateway_move_records_previous_space_for_revert` — move captures `previous_space_id` + `previous_space_name`; the moving status was set during the move and cleared after
* `test_gateway_move_revert_returns_to_previous_space` — `--revert` walks back without `--space`; the revert pointer rotates so a second `--revert` goes back the other way
* `test_gateway_move_revert_without_history_errors_clearly` — reverting an entry with no recorded previous space → actionable error
* `test_gateway_move_revert_and_explicit_space_are_mutually_exclusive` — both flags → rejected before backend call
* `test_gateway_move_cli_requires_one_of_space_or_revert` — neither flag → CLI exits 1 with `Provide --space or --revert.`
* `test_gateway_move_no_op_does_not_overwrite_previous_space` — moving to the same space twice does not blank the revert pointer

## Out of scope

* UI `Revert` button in the agent drawer — the underlying registry fields are now there for the UI to read; surfacing them is a frontend follow-up.
* Multi-hop history navigation — only the immediate previous space is tracked. By design: the documented loop is move-out then move-back, not arbitrary history.
* Audit-log changes beyond the existing `managed_agent_moved_space` event.

## Test plan

- [x] `uv run --with pytest pytest tests/test_gateway_commands.py -k "move"` — 12/12 pass (6 new + 6 pre-existing)
- [x] `uv run --with pytest pytest` — net **+6 passes** vs `main`, no new failures (42 pre-existing failures unchanged from main baseline)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke from a Gateway-bound workdir: move an agent to ax-cli-dev, run `ax gateway agents show <name>` and confirm `previous_space_id` is set, then `--revert` and confirm it walks back cleanly. Send a test message after each move and confirm it routes to the active space.

## Related

* aX task: `5b425d88`
* Builds on PR #173's active-space SSOT (`apply_entry_current_space`, the global space cache) which made this much simpler than it would have been before — registry now has one source of truth for the active space, so the previous pointer is just one more field on the same entry.
