### PR TITLE
feat(gateway): accept --space slug/name on local + agents CLI commands

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -81,6 +81,7 @@ from ..gateway import (
     load_recent_gateway_activity,
     load_space_cache,
     looks_like_space_uuid,
+    lookup_space_in_cache,
     ollama_setup_status,
     record_gateway_activity,
     remove_agent_entry,
@@ -932,6 +933,42 @@ def _local_session_inbox(
         ),
         "session": session,
     }
+
+
+def _resolve_space_via_cache(value: str | None) -> str | None:
+    """Cache-only space resolver for the pass-through (`local_*`) commands.
+
+    Pass-through agents must not need the user PAT, so we cannot fall back
+    to a fresh `client.list_spaces()` here — that would defeat the trust
+    boundary. The on-disk space cache (populated by any prior user-side
+    Gateway command) is the authoritative source on the agent side.
+
+    Returns the canonical UUID for a slug or name when found, the original
+    UUID-like input verbatim, or ``None`` if neither (caller decides whether
+    to error or pass through).
+
+    This intentionally diverges from `config.resolve_space_id()`, which
+    requires an authoring client and falls back to upstream `list_spaces`.
+    """
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    # UUID-like passes through unchanged.
+    try:
+        from uuid import UUID
+
+        UUID(raw)
+        return raw
+    except ValueError:
+        pass
+    cached = lookup_space_in_cache(raw)
+    if cached:
+        sid = str(cached.get("id") or cached.get("space_id") or "").strip()
+        if sid:
+            return sid
+    return None
 
 
 def _normalize_runtime_type(runtime_type: str) -> str:
@@ -7531,7 +7568,13 @@ def local_send(
         None, "--session-token", envvar="AX_GATEWAY_SESSION", help="Gateway session token"
     ),
     content: str = typer.Argument(..., help="Message content"),
-    space_id: str = typer.Option(None, "--space-id", help="Space to send into"),
+    space_id: str = typer.Option(
+        None,
+        "--space",
+        "--space-id",
+        "-s",
+        help="Space to send into. Accepts a slug, name, or UUID; slug/name resolves through the local space cache.",
+    ),
     agent_name: str = typer.Option(
         None, "--agent", "--name", help="Approved local pass-through agent to connect as if no session token is set"
     ),
@@ -7565,7 +7608,20 @@ def local_send(
     ),
     as_json: bool = JSON_OPTION,
 ):
-    """Send through an approved local pass-through Gateway session."""
+    """Send through an approved local pass-through Gateway session.
+
+    The ``--space`` option accepts a slug, name, or UUID. Slugs and names
+    resolve through the local space cache so pass-through agents do not
+    need a user PAT just to translate a friendly name into a UUID.
+    """
+    if space_id:
+        resolved = _resolve_space_via_cache(space_id)
+        if resolved is None:
+            raise typer.BadParameter(
+                f"Could not resolve space '{space_id}' from the local space cache. "
+                "Pass a UUID, or run `ax spaces list` once from the user side to populate the cache."
+            )
+        space_id = resolved
     try:
         resolved_session_token, connect_payload = _resolve_local_gateway_session(
             session_token=session_token,
@@ -7673,7 +7729,13 @@ def local_inbox(
     ),
     limit: int = typer.Option(20, "--limit", min=1, max=100, help="Max messages to return"),
     channel: str = typer.Option("main", "--channel", help="Message channel"),
-    space_id: str = typer.Option(None, "--space-id", help="Space to poll"),
+    space_id: str = typer.Option(
+        None,
+        "--space",
+        "--space-id",
+        "-s",
+        help="Space to poll. Accepts a slug, name, or UUID; slug/name resolves through the local space cache.",
+    ),
     agent_name: str = typer.Option(
         None, "--agent", "--name", help="Approved local pass-through agent to connect as if no session token is set"
     ),
@@ -7702,7 +7764,20 @@ def local_inbox(
     gateway_url: str = typer.Option("http://127.0.0.1:8765", "--url", help="Local Gateway UI/API URL"),
     as_json: bool = JSON_OPTION,
 ):
-    """Poll an approved local pass-through Gateway inbox."""
+    """Poll an approved local pass-through Gateway inbox.
+
+    The ``--space`` option accepts a slug, name, or UUID. Slugs and names
+    resolve through the local space cache; pass-through agents do not need
+    a user PAT for the lookup.
+    """
+    if space_id:
+        resolved = _resolve_space_via_cache(space_id)
+        if resolved is None:
+            raise typer.BadParameter(
+                f"Could not resolve space '{space_id}' from the local space cache. "
+                "Pass a UUID, or run `ax spaces list` once from the user side to populate the cache."
+            )
+        space_id = resolved
     try:
         resolved_session_token, connect_payload = _resolve_local_gateway_session(
             session_token=session_token,
@@ -7770,7 +7845,13 @@ def add_agent(
     exec_cmd: str = typer.Option(None, "--exec", help="Advanced override for exec-based templates"),
     workdir: str = typer.Option(None, "--workdir", help="Advanced working directory override"),
     ollama_model: str = typer.Option(None, "--ollama-model", help="Ollama model override for the Ollama template"),
-    space_id: str = typer.Option(None, "--space-id", help="Target space (defaults to gateway session)"),
+    space_id: str = typer.Option(
+        None,
+        "--space",
+        "--space-id",
+        "-s",
+        help="Target space (defaults to gateway session). Accepts a slug, name, or UUID.",
+    ),
     audience: str = typer.Option("both", "--audience", help="Minted PAT audience"),
     description: str = typer.Option(None, "--description", help="Create/update description"),
     model: str = typer.Option(None, "--model", help="Create/update model"),
@@ -7790,7 +7871,25 @@ def add_agent(
     start: bool = typer.Option(True, "--start/--no-start", help="Desired running state after registration"),
     as_json: bool = JSON_OPTION,
 ):
-    """Register a managed agent and mint a Gateway-owned PAT for it."""
+    """Register a managed agent and mint a Gateway-owned PAT for it.
+
+    The ``--space`` option accepts a slug, name, or UUID. Slug/name resolution
+    runs through the local space cache first; if that misses, the resolution
+    falls through to the gateway user client's ``list_spaces`` lookup.
+    """
+    if space_id:
+        cached = _resolve_space_via_cache(space_id)
+        if cached is not None:
+            space_id = cached
+        else:
+            try:
+                client = _load_gateway_user_client()
+                space_id = resolve_space_id(client, explicit=space_id)
+            except (typer.Exit, typer.BadParameter):
+                raise
+            except Exception as exc:
+                err_console.print(f"[red]Could not resolve space '{space_id}': {exc}[/red]")
+                raise typer.Exit(1)
     selected_template = template_id or ("echo_test" if not runtime_type else None)
     try:
         resolved_prompt = _resolve_system_prompt_input(
@@ -8123,7 +8222,13 @@ def inbox_for_agent(
     name: str = typer.Argument(..., help="Managed agent name"),
     limit: int = typer.Option(20, "--limit", min=1, max=200, help="Max messages to return"),
     channel: str = typer.Option("main", "--channel", help="Message channel"),
-    space_id: str = typer.Option(None, "--space-id", help="Override the agent's home space"),
+    space_id: str = typer.Option(
+        None,
+        "--space",
+        "--space-id",
+        "-s",
+        help="Override the agent's home space. Accepts a slug, name, or UUID.",
+    ),
     unread_only: bool = typer.Option(
         False,
         "--unread-only/--all",
@@ -8145,7 +8250,20 @@ def inbox_for_agent(
     agents — uses the agent's Gateway-loaded credentials, so no PAT is exposed
     to the caller. Pairs with `ax gateway agents send` for a uniform read/write
     surface from any operator seat without needing the channel MCP attached.
+
+    The ``--space`` option accepts a slug, name, or UUID. Slugs and names
+    resolve through the local space cache; the operator's user PAT is not
+    required for this lookup.
     """
+    if space_id:
+        resolved = _resolve_space_via_cache(space_id)
+        if resolved is None:
+            err_console.print(
+                f"[red]Could not resolve space '{space_id}' from the local space cache. "
+                "Pass a UUID, or run `ax spaces list` once to populate the cache.[/red]"
+            )
+            raise typer.Exit(1)
+        space_id = resolved
     try:
         result = _inbox_for_managed_agent(
             name=name,

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -7598,6 +7598,169 @@ def test_send_from_managed_agent_inbox_returns_empty_when_no_unread(monkeypatch,
     assert payload["inbox"]["unread_count"] == 0
 
 
+# --- Slug-aware --space coverage (aX task 39f4de3f) -------------------------
+
+
+def test_resolve_space_via_cache_passes_uuid_through_unchanged():
+    uuid_in = "12345678-1234-4234-8234-123456789012"
+    assert gateway_cmd._resolve_space_via_cache(uuid_in) == uuid_in
+
+
+def test_resolve_space_via_cache_resolves_slug_via_cache(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_space_cache(
+        [
+            {"id": "12345678-1234-4234-8234-123456789012", "name": "ax-cli-dev", "slug": "ax-cli-dev"},
+            {"id": "abcdef01-2345-4234-8234-123456789012", "name": "Other", "slug": "other"},
+        ]
+    )
+
+    assert gateway_cmd._resolve_space_via_cache("ax-cli-dev") == "12345678-1234-4234-8234-123456789012"
+
+
+def test_resolve_space_via_cache_returns_none_for_unknown_slug(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_space_cache([])
+
+    assert gateway_cmd._resolve_space_via_cache("never-seen") is None
+
+
+def test_resolve_space_via_cache_returns_none_for_empty_input():
+    assert gateway_cmd._resolve_space_via_cache(None) is None
+    assert gateway_cmd._resolve_space_via_cache("") is None
+    assert gateway_cmd._resolve_space_via_cache("   ") is None
+
+
+def test_local_send_resolves_slug_before_proxying(monkeypatch, tmp_path):
+    """`ax gateway local send --space <slug>` resolves through the cache and
+    forwards a UUID to the daemon, so the upstream API never sees the slug."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_space_cache(
+        [{"id": "12345678-1234-4234-8234-123456789012", "name": "ax-cli-dev", "slug": "ax-cli-dev"}]
+    )
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeHttpResponse({"agent": "codex-pass-through", "message": {"id": "msg-1"}})
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        return _FakeHttpResponse({"agent": "codex-pass-through", "messages": [], "count": 0})
+
+    def fake_resolve_session(**kwargs):
+        captured["session_space_id"] = kwargs.get("space_id")
+        return ("axgw_s_test.session", {"status": "approved"})
+
+    monkeypatch.setattr(gateway_cmd, "_resolve_local_gateway_session", fake_resolve_session)
+    monkeypatch.setattr(gateway_cmd, "_check_local_pending_replies", lambda **_: {"count": 0, "message_ids": []})
+    monkeypatch.setattr(gateway_cmd.httpx, "post", fake_post)
+    monkeypatch.setattr(gateway_cmd.httpx, "get", fake_get)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "local", "send", "hello", "--space", "ax-cli-dev", "--no-inbox", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["json"]["space_id"] == "12345678-1234-4234-8234-123456789012"
+    assert captured["session_space_id"] == "12345678-1234-4234-8234-123456789012"
+
+
+def test_local_send_unknown_slug_errors_with_actionable_hint(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_space_cache([])
+
+    monkeypatch.setattr(
+        gateway_cmd,
+        "_resolve_local_gateway_session",
+        lambda **kwargs: pytest.fail("session must not be opened when slug fails to resolve"),
+    )
+
+    result = runner.invoke(
+        app,
+        ["gateway", "local", "send", "hello", "--space", "never-seen", "--no-inbox"],
+    )
+
+    assert result.exit_code != 0
+    assert "Could not resolve space" in result.output
+    assert "ax spaces list" in result.output
+
+
+def test_local_inbox_resolves_slug_before_proxying(monkeypatch, tmp_path):
+    """Same slug → UUID resolution applies to ax gateway local inbox."""
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_space_cache(
+        [{"id": "12345678-1234-4234-8234-123456789012", "name": "ax-cli-dev", "slug": "ax-cli-dev"}]
+    )
+    captured = {}
+
+    def fake_resolve_session(**kwargs):
+        captured["session_space_id"] = kwargs.get("space_id")
+        return ("axgw_s_test.session", None)
+
+    def fake_poll(**kwargs):
+        captured["poll_space_id"] = kwargs.get("space_id")
+        return {"agent": "codex-pass-through", "messages": []}
+
+    monkeypatch.setattr(gateway_cmd, "_resolve_local_gateway_session", fake_resolve_session)
+    monkeypatch.setattr(gateway_cmd, "_poll_local_inbox_over_http", fake_poll)
+
+    result = runner.invoke(
+        app,
+        ["gateway", "local", "inbox", "--space", "ax-cli-dev", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["session_space_id"] == "12345678-1234-4234-8234-123456789012"
+    assert captured["poll_space_id"] == "12345678-1234-4234-8234-123456789012"
+
+
+def test_agents_inbox_resolves_slug_before_lookup(monkeypatch, tmp_path):
+    """`ax gateway agents inbox --space <slug>` also resolves through the cache."""
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    gateway_core.save_space_cache(
+        [{"id": "space-1", "name": "Test Space", "slug": "test-space"}]
+    )
+    monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
+    captured = {}
+
+    real_inbox = gateway_cmd._inbox_for_managed_agent
+
+    def spy_inbox(*, name, limit, channel, space_id, unread_only, mark_read):
+        captured["space_id"] = space_id
+        return real_inbox(
+            name=name, limit=limit, channel=channel, space_id=space_id,
+            unread_only=unread_only, mark_read=mark_read,
+        )
+
+    monkeypatch.setattr(gateway_cmd, "_inbox_for_managed_agent", spy_inbox)
+
+    result = runner.invoke(
+        app, ["gateway", "agents", "inbox", "cli_god", "--space", "test-space", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["space_id"] == "space-1"
+
+
+def test_agents_inbox_unknown_slug_errors_clearly(monkeypatch, tmp_path):
+    _seed_managed_inbox_agent(tmp_path, monkeypatch)
+    gateway_core.save_space_cache([])
+
+    result = runner.invoke(
+        app, ["gateway", "agents", "inbox", "cli_god", "--space", "never-seen"]
+    )
+
+    assert result.exit_code != 0
+    assert "Could not resolve space" in result.output
+
+
 def test_inbox_for_managed_agent_clears_pending_queue_on_mark_read(monkeypatch, tmp_path):
     """`ax gateway agents inbox <name> --mark-read` must clear the local
     pending queue so backlog_depth/queue_depth go to 0. Without this fix


### PR DESCRIPTION
## Summary

Closes the CLI-side scope of aX task `39f4de3f` ("Add human-friendly `--space` name/slug option across Gateway and CLI commands"). The slug-cache infrastructure was already in place from PR #173; this PR threads `--space slug/name` acceptance through the high-traffic Gateway commands that still required UUIDs.

## Wired surfaces

| Command | Before | After |
|---|---|---|
| `ax gateway local send` | `--space-id <uuid>` only | `--space ax-cli-dev` ✓ |
| `ax gateway local inbox` | `--space-id <uuid>` only | `--space ax-cli-dev` ✓ |
| `ax gateway agents inbox` | `--space-id <uuid>` only | `--space ax-cli-dev` ✓ |
| `ax gateway agents add` | `--space-id <uuid>` only | `--space ax-cli-dev` ✓ |

Existing `--space-id` and `-s` aliases kept on every command for backwards compatibility — same pattern as `ax tasks` and `ax send` use already.

## The trust-boundary detail

The pass-through commands (`local send`, `local inbox`) use a **cache-only** resolver, not the full `config.resolve_space_id` path. The whole point of pass-through is that the agent doesn't hold the user PAT, and `resolve_space_id` would fall back to a fresh `client.list_spaces()` that requires one.

The local space cache is populated by any prior user-side Gateway command (`ax spaces list`, `ax gateway spaces use`, the slug resolver inside `_resolve_space_ref`), so by the time the operator is working from the agent shell the cache is warm. When a slug doesn't resolve:

* **`local send` / `local inbox`** fail closed with a clear hint:
  > Could not resolve space '<value>' from the local space cache. Pass a UUID, or run `ax spaces list` once from the user side to populate the cache.
* **`agents add`** falls through to the user client's `resolve_space_id` (this command already requires a user PAT to register the agent — no boundary cost).
* **`agents inbox`** fails closed with the same cache-only message — operates on the agent's brokered identity, so the user PAT is intentionally absent.

This avoids quietly elevating to the user PAT just to translate a friendly name.

## Implementation

* New `_resolve_space_via_cache(value)` helper:
  * UUID-like input passes through unchanged
  * Slugs/names look up via `lookup_space_in_cache` (already exists)
  * Unknown returns `None` for the caller to error or fall back
* Each touched command resolves `--space` before calling the body helper, so the proxy/upstream path always sees a UUID
* Each command's docstring explains the resolution model so operators reading `--help` know whether the cache-only or fallback path runs

Total real-code change is ~50 lines in `commands/gateway.py` plus the helper. No new modules.

## Tests

`tests/test_gateway_commands.py` adds 9 new tests:

* `_resolve_space_via_cache` unit tests: UUID passthrough, slug-via-cache hit, unknown-slug returns None, empty-input edges
* End-to-end via Click runner for each of the four wired commands:
  * `local send` (slug → daemon body uses UUID, session helper sees UUID)
  * `local send` unknown slug → exits with the actionable hint
  * `local inbox` (slug → both session and poll helpers see UUID)
  * `agents inbox` (slug → managed-agent lookup uses UUID)
  * `agents inbox` unknown slug → exits cleanly

## Direction check

* **Operator UX**: removes one of the most common copy-paste annoyances — operators no longer need to grep `ax spaces list` for a UUID just to send into a known space. Slugs are the friendly form the operator already knows.
* **Trust boundary preserved**: pass-through commands stay user-PAT-free. Cache-only resolution is the right call — the alternative (fallback to fresh list_spaces) would have required loading the user client and broken the boundary.
* **Backwards compatible**: existing `--space-id` invocations work unchanged. The new `--space` alias is additive.
* **No new abstractions**: one small helper, four commands updated, all using the same pattern. If a fifth or sixth command needs the same treatment, the helper is in place.

## Out of scope

* `ax gateway local connect`, `ax gateway local init` — same pattern would apply, but these commands use `--space-id` for a different purpose (initial home space hint to the daemon) and the path through `_register_managed_agent` already does its own resolution. Not the same surface.
* `ax gateway agents update --space-id` — exists but is rarely the right way to move an agent (use `ax gateway agents move` per PR #201).
* `--space-id` on `gateway start` and registry-bootstrap surfaces — administrative / setup context, less frequent operator traffic.

Each of those could be wired with the same pattern in a follow-up if usage justifies it.

## Test plan

- [x] `uv run --with pytest pytest tests/test_gateway_commands.py -k "resolve_space_via_cache or local_send_resolves_slug or local_send_unknown_slug or local_inbox_resolves_slug or agents_inbox_resolves_slug or agents_inbox_unknown_slug"` — 9/9 pass
- [x] `uv run --with pytest pytest` — net **+9 passes** vs `main`, no new failures (42 pre-existing failures unchanged from main baseline)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean
- [ ] Manual smoke from a Gateway-bound workdir: `ax gateway local send "hello" --space ax-cli-dev` after the cache is warm — confirm send routes correctly.
- [ ] Manual smoke from a fresh shell with empty cache: same command fails with the actionable hint.
- [ ] Manual smoke: `ax gateway agents add my-bot --template echo --space ax-cli-dev` — confirm agent registers with the right space.

## Related

* aX task: `39f4de3f`
* Builds on PR #173's `lookup_space_in_cache` and `save_space_cache` helpers (the slug cache is what makes this possible without a user PAT)
* Same flag pattern as `ax tasks`/`ax send` already use via `messages.SPACE_OPTION` and `tasks.SPACE_OPTION`
