### PR TITLE
ci: add CLA enforcement via CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,28 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLA:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/ax-platform/ax-gateway/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: madtank,sarob,viewsonic-max,dependabot*,github-actions*,claude*

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,60 @@
+# aX Platform Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to the aX Platform open-source ecosystem.
+
+By submitting a pull request, you agree to the terms of this Contributor License Agreement ("Agreement").
+This Agreement ensures that contributions to the **ax-gateway** project may be used freely by the aX Platform team and our users.
+
+## Definitions
+
+- **"You"** (or **"Your"**) means the individual or legal entity submitting a Contribution. For legal entities, the entity making a Contribution and all its affiliates are considered a single Contributor.
+- **"Contribution"** means any original work of authorship, including any modifications or additions to existing work, that you submit to the project via pull request, issue, or any other mechanism.
+- **"Project"** means the ax-gateway repository and any related aX Platform repositories governed by this Agreement.
+
+## 1. License Grant
+
+You grant aX Platform a perpetual, worldwide, irrevocable, non-exclusive, royalty-free license to:
+
+- Use, reproduce, modify, distribute, and create derivative works from Your Contribution.
+- Sublicense Your Contribution as necessary for distribution under the Project license.
+- Include Your Contribution in current or future commercial or open-source versions of the Project.
+
+## 2. Ownership & Originality
+
+You represent that:
+
+- The Contribution is Your original work, OR You have the rights necessary to submit it.
+- Your employer (if applicable) has authorized this Contribution or waived any IP claims.
+- You are legally permitted to grant the rights in this Agreement.
+
+## 3. Third-Party Content
+
+If Your Contribution includes or is derived from work not owned by You, You must:
+
+- Identify the original source, author, and license of such work in the pull request description.
+- Confirm that the license of the third-party work permits inclusion in an MIT-licensed project.
+- Clearly mark which portions of the Contribution are third-party content.
+
+## 4. License of the Project
+
+You agree that Your Contributions will be submitted under the same license used by the Project (MIT license unless otherwise stated).
+
+## 5. Patent Grant
+
+You grant aX Platform a non-exclusive, worldwide, royalty-free, irrevocable patent license to make, have made, use, sell, offer to sell, import, and otherwise transfer Your Contribution, where such license applies only to patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the Project.
+
+## 6. Disclaimer of Warranty
+
+Your Contribution is provided "AS IS", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and non-infringement. You are not expected to provide support for Your Contribution.
+
+## 7. Notification
+
+You agree to notify the Project maintainers if You become aware that any representation made in this Agreement is or becomes inaccurate.
+
+## 8. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws of the State of California, United States, without regard to its conflict of law provisions.
+
+---
+
+By responding "I have read the CLA Document and I hereby sign the CLA" through the automated GitHub system, you agree to the terms of this Agreement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,14 @@
 Thanks for improving `axctl`. This repository is public-facing, so changes
 should be easy for operators to understand, test, and release.
 
+## Contributor License Agreement (CLA)
+
+Before we can accept your first pull request, you must sign our
+[Contributor License Agreement](CLA.md). This is handled automatically by the
+CLA Assistant bot on GitHub. When you open your first PR, you will receive a
+comment with a link to sign the CLA. You only need to sign once. Without a
+signed CLA, the PR cannot be merged.
+
 ## Development Setup
 
 ```bash
@@ -20,9 +28,9 @@ local development.
 
 ## Branches
 
-- `dev/staging` is the fast integration branch.
-- `main` is the public release branch.
-- Promotion to `main` should happen through a reviewed PR.
+- `main` is the integration and release branch. Branch off `main` for all work.
+- `dev/staging` is dormant and should not be used as a base branch.
+- All changes reach `main` through a reviewed PR.
 
 ## Commit Style
 
@@ -54,8 +62,8 @@ See [docs/release-process.md](docs/release-process.md).
 
 The short version:
 
-1. Land work in `dev/staging`.
-2. Promote `dev/staging` to `main`.
+1. Branch off `main` and open a PR.
+2. Merge to `main` after review and CI pass.
 3. Release Please opens a release PR.
 4. Merge the release PR after reviewing the version and changelog.
 5. GitHub Release publication triggers PyPI publishing.

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,0 +1,3 @@
+{
+  "signatures": []
+}


### PR DESCRIPTION
## Summary

- Add CLA document (`CLA.md`) modeled on Apache ICLA with definitions,
  third-party disclosure, warranty disclaimer, notification duty, patent
  scope, and governing law sections
- Add CLA Assistant workflow (`.github/workflows/cla.yml`) using
  `contributor-assistant/github-action@v2.6.1` to gate PRs from external
  contributors
- Add empty signature store (`signatures/cla.json`)
- Update `CONTRIBUTING.md` with CLA section and fix stale `dev/staging`
  branch references to reflect the current main-only shipping flow

Allowlisted users (skip signing): madtank, sarob, viewsonic-max,
dependabot, github-actions, claude bots.

## CLA coverage vs. open standards

Benchmarked against Apache ICLA v2.0, Project Harmony, and GitHub/Microsoft
CLA templates. The following clauses were added to close gaps found in the
original ax-agent-studio CLA:

| Clause | Source standard | Section |
|---|---|---|
| Definitions ("You", "Contribution", "Project") | Apache, Harmony, Microsoft | Definitions |
| Third-party content disclosure obligation | Apache, Microsoft | §3 |
| Warranty disclaimer ("AS-IS") | All major CLAs | §6 |
| Notification of inaccuracy | Apache | §7 |
| Governing law (California) | Harmony, Microsoft | §8 |
| Scoped sublicense rights | Harmony | §1 |
| Patent claims scoped to necessarily-infringed | Apache | §5 |

Related to #144

## Test plan

- [ ] Open a test PR from a non-allowlisted account and verify the CLA
      bot comments with a signing prompt
- [ ] Verify allowlisted users do not get prompted
- [ ] Confirm the `recheck` comment re-triggers the status check
- [ ] Verify CI still passes with the new workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)