### PR TITLE
fix(gateway): validate Host header to block DNS rebinding

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -5294,12 +5294,39 @@ def _read_json_request(handler: BaseHTTPRequestHandler) -> dict:
     return payload
 
 
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1"})
+
+
+def _is_request_host_allowed(host_header: str | None) -> bool:
+    # Block DNS-rebinding: only accept Host headers that resolve to loopback.
+    # Port is left open so `ax gateway start --port` keeps working.
+    if not host_header:
+        return False
+    candidate = host_header.strip()
+    if not candidate:
+        return False
+    hostname = candidate.rsplit(":", 1)[0] if ":" in candidate else candidate
+    return hostname.lower() in _LOOPBACK_HOSTNAMES
+
+
 def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
     class GatewayUiHandler(BaseHTTPRequestHandler):
         def log_message(self, format: str, *args) -> None:  # noqa: A003
             return
 
+        def _reject_unauthorized_host(self) -> bool:
+            if _is_request_host_allowed(self.headers.get("Host")):
+                return False
+            _write_json_response(
+                self,
+                {"error": "Forbidden: Host header is not loopback."},
+                status=HTTPStatus.FORBIDDEN,
+            )
+            return True
+
         def do_GET(self) -> None:  # noqa: N802
+            if self._reject_unauthorized_host():
+                return
             parsed = urlparse(self.path)
             if parsed.path == "/":
                 _write_html_response(self, _render_gateway_demo_page(refresh_ms=refresh_ms))
@@ -5422,6 +5449,8 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
             _write_json_response(self, {"error": "not found"}, status=HTTPStatus.NOT_FOUND)
 
         def do_POST(self) -> None:  # noqa: N802
+            if self._reject_unauthorized_host():
+                return
             parsed = urlparse(self.path)
             try:
                 body = _read_json_request(self)

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -1758,7 +1758,7 @@ def test_gateway_ui_agent_reject_marks_pending_approval_rejected(monkeypatch, tm
     class FakeHandler(handler_cls):
         def __init__(self):
             self.path = "/api/agents/reject-ui-bot/reject"
-            self.headers = {"Content-Length": "2"}
+            self.headers = {"Content-Length": "2", "Host": "127.0.0.1"}
             self.rfile = __import__("io").BytesIO(b"{}")
             self.status = None
             self.body = b""

--- a/tests/test_gateway_host_header.py
+++ b/tests/test_gateway_host_header.py
@@ -1,0 +1,113 @@
+import io
+import json
+
+import pytest
+
+from ax_cli.commands import gateway as gateway_cmd
+
+
+def _make_handler(host_header, *, method="GET", path="/healthz", body=b""):
+    handler_cls = gateway_cmd._build_gateway_ui_handler(activity_limit=5, refresh_ms=1000)
+
+    class FakeHandler(handler_cls):
+        def __init__(self):
+            self.path = path
+            headers = {}
+            if host_header is not None:
+                headers["Host"] = host_header
+            if method == "POST":
+                headers["Content-Length"] = str(len(body))
+            self.headers = headers
+            self.rfile = io.BytesIO(body)
+            self.status = None
+            self.body = b""
+
+        def send_response(self, status):
+            self.status = status
+
+        def send_header(self, *args, **kwargs):
+            return None
+
+        def end_headers(self):
+            return None
+
+        @property
+        def wfile(self):
+            outer = self
+
+            class Writer:
+                def write(self, data):
+                    outer.body += data
+
+            return Writer()
+
+    return FakeHandler()
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "127.0.0.1:8765", "localhost", "localhost:9000", "LocalHost:8765"],
+)
+def test_loopback_host_passes(host):
+    assert gateway_cmd._is_request_host_allowed(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "evil.example.com",
+        "evil.example.com:8765",
+        "192.168.1.1",
+        "127.0.0.1.evil.com",
+        "",
+        None,
+        "  ",
+    ],
+)
+def test_non_loopback_host_blocked(host):
+    assert gateway_cmd._is_request_host_allowed(host) is False
+
+
+def test_get_with_loopback_host_is_served():
+    handler = _make_handler("127.0.0.1:8765", method="GET", path="/healthz")
+    handler.do_GET()
+
+    assert handler.status == 200
+    assert json.loads(handler.body.decode("utf-8")) == {"ok": True}
+
+
+def test_get_with_evil_host_is_rejected_403():
+    handler = _make_handler("evil.example.com", method="GET", path="/healthz")
+    handler.do_GET()
+
+    assert handler.status == 403
+    payload = json.loads(handler.body.decode("utf-8"))
+    assert "Host" in payload["error"]
+
+
+def test_get_without_host_header_is_rejected_403():
+    handler = _make_handler(None, method="GET", path="/healthz")
+    handler.do_GET()
+
+    assert handler.status == 403
+
+
+def test_post_with_evil_host_short_circuits_before_handler(tmp_path, monkeypatch):
+    # Wire AX_CONFIG_DIR so any code paths that read registry don't blow up;
+    # the rejection should fire before that code runs anyway.
+    monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path))
+    handler = _make_handler("evil.example.com", method="POST", path="/api/agents", body=b"{}")
+    handler.do_POST()
+
+    assert handler.status == 403
+
+
+def test_post_with_loopback_host_reaches_handler(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_CONFIG_DIR", str(tmp_path))
+    # Send a request body that the route will accept far enough to NOT be a 403.
+    # /api/agents requires a name; an empty body reaches the handler and returns
+    # a 4xx other than 403, proving the Host check did not short-circuit.
+    handler = _make_handler("127.0.0.1:8765", method="POST", path="/api/agents", body=b"{}")
+    handler.do_POST()
+
+    assert handler.status != 403


### PR DESCRIPTION
Closes #184 

Adds Host header validation in `GatewayUiHandler.do_GET`/`do_POST`. Requests with a non-loopback Host get `403 Forbidden`; loopback (`localhost`, `127.0.0.1`) on any port pass.

The issue's literal allowlist hardcodes `:8765`. I check only the hostname so `ax gateway start --port` keeps working. DNS rebinding is a hostname attack, not a port one, so this doesn't weaken the protection. Happy to swap to a strict allowlist if preferred.

Tests in `tests/test_gateway_host_header.py` cover loopback pass, evil/empty Host reject, and POST short-circuiting before the route handler. The existing `FakeHandler` mock in `test_gateway_commands.py` needed `"Host"`added — other handler tests use real httpx and weren't affected.

## Validation
- [x] pytest (773 passed)
- [x] ruff check / format
- [x] python -m build / twine check

## Release notes
- [x] fix (security hardening)

## Credential / auth impact
- [x] No identity behavior changed