### PR TITLE
docs(scenarios): add rotate-an-agent-PAT scenario

### DIFF
--- a/docs/scenarios/rotate-agent-pat.md
+++ b/docs/scenarios/rotate-agent-pat.md
@@ -44,20 +44,22 @@ revoke it.
    `axctl credentials audit --strict` to make policy violations fail loudly.
 
 2. **Mint the replacement.** Match the audience and expiry of the old
-   token. Save to a new path so the old token file is untouched.
+   token. Save to a separate directory so the old token file is untouched.
 
    ```bash
    axctl token mint <agent> \
        --audience <cli|mcp|both> \
        --expires <days> \
-       --save-to <new-token-file> \
+       --save-to <new-token-dir> \
        --profile <new-profile> \
        --no-print-token
    ```
 
-   `--no-print-token` keeps the secret out of your shell history. The
-   command writes the token to `<new-token-file>` with mode `0600` and
-   registers `<new-profile>` against it.
+   `--save-to` takes a directory (typically the agent's `.ax/` directory,
+   e.g. `/home/agent/.ax`); the token file and `config.toml` are written
+   inside it. `--no-print-token` keeps the secret out of your shell
+   history. The token file is mode `0600`, and `<new-profile>` is
+   registered against it.
 
 3. **Verify the new profile.**
 
@@ -102,6 +104,6 @@ After the rotation:
 |---|---|---|
 | Agent fails right after step 4. | Revoked the old credential before the new one was actually serving traffic. | Re-run step 2 to mint another replacement, verify, then revoke. The originally-revoked id stays revoked. |
 | `credentials list` shows 3+ active PATs for the agent. | A previous rotation aborted between mint and revoke. | Stop. Identify each `credential_id`, decide which is current, and revoke the rest before issuing more. More than two active PATs per agent is a security hygiene issue. |
-| `profile verify` fails on the new profile. | Token file moved, host/workdir changed since `axctl token mint` ran, or the file was tampered with. | Inspect `<new-token-file>` permissions and contents. If intentional (e.g. rotated to a new host), re-run `axctl profile add` from the new location. |
+| `profile verify` fails on the new profile. | Token file moved, host/workdir changed since `axctl token mint` ran, or the file was tampered with. | Inspect the token file inside `<new-token-dir>` (permissions and contents). If intentional (e.g. rotated to a new host), re-run `axctl profile add` from the new location. |
 | `auth whoami` returns the user, not the agent. | Wrong audience minted, or the new profile isn't active yet. | Check that step 2 used the same audience as the old PAT, and that `axctl profile use <new-profile>` (or the appropriate env vars) selected the agent profile. |
 | Honeypot / fingerprint alert fires during step 3. | The new token was used from a different machine or workspace than where it was minted. | Treat as a security event, not a rotation problem. See [`docs/credential-security.md`](../credential-security.md). |

--- a/docs/scenarios/rotate-agent-pat.md
+++ b/docs/scenarios/rotate-agent-pat.md
@@ -3,6 +3,14 @@
 Replace an agent's PAT without downtime by minting the new token first,
 verifying it works, then revoking the old one.
 
+> **Scope:** this page documents the current PAT-based rotation path for
+> existing agent credentials. Gateway's intended direction is OAuth/device
+> login plus Gateway-brokered credentials — normal onboarding should not
+> require operators or agents to copy PATs manually. See
+> [DEVICE-TRUST-001](../../specs/DEVICE-TRUST-001/spec.md) and
+> [GATEWAY-AUTH-TIERS-001](../../specs/GATEWAY-AUTH-TIERS-001/spec.md) for
+> the trust-boundary direction.
+
 Background: [`docs/credential-security.md`](../credential-security.md#agent-pat-rotation)
 and [`docs/agent-authentication.md`](../agent-authentication.md#rotation-with-existing-cli-commands)
 explain the policy. This page is the operator runbook.

--- a/docs/scenarios/rotate-agent-pat.md
+++ b/docs/scenarios/rotate-agent-pat.md
@@ -1,0 +1,99 @@
+# Rotate an Agent PAT
+
+Replace an agent's PAT without downtime by minting the new token first,
+verifying it works, then revoking the old one.
+
+Background: [`docs/credential-security.md`](../credential-security.md#agent-pat-rotation)
+and [`docs/agent-authentication.md`](../agent-authentication.md#rotation-with-existing-cli-commands)
+explain the policy. This page is the operator runbook.
+
+## Goal
+
+Cut over `<agent>` to a fresh PAT with no failed requests in between. The
+old credential keeps working until the new one verifies; only then do you
+revoke it.
+
+## Prerequisites
+
+- A user bootstrap login — `axctl auth whoami` returns your user, not the
+  agent.
+- The agent already exists and you know its name and audience (`cli`,
+  `mcp`, or `both`).
+- The agent's existing profile is already registered. If not, register it
+  first with `axctl profile add` so you have a baseline to compare against.
+
+## Steps
+
+1. **Inventory current credentials.**
+
+   ```bash
+   axctl credentials list --json
+   axctl credentials audit
+   ```
+
+   Note the `credential_id` of the PAT you intend to replace and confirm
+   the agent has exactly one active PAT today. In automation use
+   `axctl credentials audit --strict` to make policy violations fail loudly.
+
+2. **Mint the replacement.** Match the audience and expiry of the old
+   token. Save to a new path so the old token file is untouched.
+
+   ```bash
+   axctl token mint <agent> \
+       --audience <cli|mcp|both> \
+       --expires <days> \
+       --save-to <new-token-file> \
+       --profile <new-profile> \
+       --no-print-token
+   ```
+
+   `--no-print-token` keeps the secret out of your shell history. The
+   command writes the token to `<new-token-file>` with mode `0600` and
+   registers `<new-profile>` against it.
+
+3. **Verify the new profile.**
+
+   ```bash
+   axctl profile verify <new-profile>
+   axctl auth whoami --json
+   ```
+
+   `profile verify` re-checks the token fingerprint, hostname, and workdir
+   hash. `auth whoami` proves the new PAT actually exchanges for a JWT
+   end-to-end. Both must succeed before continuing.
+
+4. **Revoke the old credential.** Use the `credential_id` recorded in
+   step 1, not the new one.
+
+   ```bash
+   axctl credentials revoke <old-credential-id>
+   ```
+
+5. **Confirm cleanup.**
+
+   ```bash
+   axctl credentials list --json
+   ```
+
+   The old `credential_id` should now show `lifecycle_state: revoked`. The
+   agent should have exactly one active PAT — the replacement.
+
+## Verify
+
+After the rotation:
+
+- `axctl credentials list` shows one active PAT for the agent.
+- `axctl credentials audit` reports no policy violations.
+- The agent's normal workflow (send / listen / mcp call, whatever it does
+  in production) succeeds with the new profile.
+- The old token file can be deleted.
+
+## What can go wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Agent fails right after step 4. | Revoked the old credential before the new one was actually serving traffic. | Re-run step 2 to mint another replacement, verify, then revoke. The originally-revoked id stays revoked. |
+| `credentials list` shows 3+ active PATs for the agent. | A previous rotation aborted between mint and revoke. | Stop. Identify each `credential_id`, decide which is current, and revoke the rest before issuing more. More than two active PATs per agent is a security hygiene issue. |
+| `profile verify` fails on the new profile. | Token file moved, host/workdir changed since `axctl token mint` ran, or the file was tampered with. | Inspect `<new-token-file>` permissions and contents. If intentional (e.g. rotated to a new host), re-run `axctl profile add` from the new location. |
+| `auth whoami` returns the user, not the agent. | Wrong audience minted, or the new profile isn't active yet. | Check that step 2 used the same audience as the old PAT, and that `axctl profile use <new-profile>` (or the appropriate env vars) selected the agent profile. |
+| Honeypot / fingerprint alert fires during step 3. | The new token was used from a different machine or workspace than where it was minted. | Treat as a security event, not a rotation problem. See [`docs/credential-security.md`](../credential-security.md). |


### PR DESCRIPTION
Closes #186 - adds the operator runbook for rotating an agent PAT.

The rotation policy already lives in `docs/credential-security.md` and
`docs/agent-authentication.md`. This page turns it into a task-oriented
scenario the operator can follow top to bottom: Goal → Prerequisites →
Steps -> Verify -> What can go wrong.

The "What can go wrong" table covers the three failure modes the issue called out - revoking before testing, ending up with more than two active PATs, and wrong audience - plus the two adjacent ones operators actually hit (profile verify failure, fingerprint/honeypot alerts).

The issue referenced `docs/scenarios/debug-stuck-agent.md` as a template, but neither that file nor the `docs/scenarios/` directory existed in the tree. This PR creates the directory along with the new doc. If a preferred scenario template lands later, happy to retro-fit.

## Validation
- [x] linked files (`docs/credential-security.md`, `docs/agent-authentication.md`) exist
- [x] section anchors (`#agent-pat-rotation`, `#rotation-with-existing-cli-commands`) resolve
- [x] all CLI commands and flags referenced verified against `ax_cli/commands/{credentials,mint,profile,auth}.py`
- [x] `pre-commit run --files docs/scenarios/rotate-agent-pat.md` clean

## Release notes
- [x] internal/docs-only - does not need a package release

## Credential / auth impact
- [x] No identity behavior changed (docs-only)