### PR TITLE
fix(client): name HTML-from-send-message as routing-metadata failure

### DIFF
--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -350,6 +350,13 @@ class AxClient:
                     "with an explicit reason such as quota, rate limit, name conflict, or feature flag; "
                     "the CLI cannot safely infer the denied create reason from the SPA shell."
                 )
+            elif method == "POST" and path == "/api/v1/messages":
+                detail = (
+                    "Send-message returned HTML instead of JSON. The hosted /api/v1/messages POST route "
+                    "is being captured by the SPA frontend, so reply metadata (parent_id, mentions, "
+                    "attachments) cannot reach the conversation; agent-to-agent reply routing fails on "
+                    "this path until the backend route is restored."
+                )
             else:
                 detail = f"Expected JSON but got HTML from {r.url} — the frontend may be catching this API route"
             raise httpx.HTTPStatusError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -235,6 +235,28 @@ def test_parse_json_names_agent_create_html_shell_as_api_contract_failure():
     assert "name conflict" in message
 
 
+def test_parse_json_names_send_message_html_shell_as_routing_failure():
+    """Parallel of the agents-create case: when the hosted SPA captures
+    POST /api/v1/messages, the CLI cannot post reply metadata, so the
+    error message names that consequence rather than the generic
+    'frontend may be catching this route' hint."""
+    client = AxClient("https://example.com", "legacy-token")
+    response = httpx.Response(
+        200,
+        text="<!DOCTYPE html><html></html>",
+        headers={"content-type": "text/html"},
+        request=httpx.Request("POST", "https://example.com/api/v1/messages"),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        client._parse_json(response)
+
+    message = str(exc.value)
+    assert "Send-message returned HTML instead of JSON" in message
+    assert "parent_id" in message
+    assert "agent-to-agent reply routing" in message
+
+
 def test_record_tool_call_posts_audit_payload():
     client = AxClient("https://example.com", "legacy-token", agent_id="agent-123", agent_name="codex")
     response = httpx.Response(


### PR DESCRIPTION
## Summary

When the hosted SPA captures `POST /api/v1/messages` and returns HTML, the CLI's generic `_parse_json` hint ("Expected JSON but got HTML from \<URL\> — the frontend may be catching this API route") doesn't name the actual consequence: reply metadata (parent_id, mentions, attachments) can't reach the conversation, so agent-to-agent reply routing silently fails on that path. Add a route-specific branch to `_parse_json` for the messages-create case, parallel to the existing agents-create handling at `ax_cli/client.py:347–352`.

aX task: `47d3b9a5` (CLI-side slice).

## Why

`_parse_json` already gives `POST /api/v1/agents` a custom error message that names the API-contract gap when HTML comes back. The send-message route deserves the same treatment — operators who hit the bug today see a generic hint that says nothing about *what's broken from their perspective* (their reply doesn't route). With a route-specific message, the failure mode is diagnosable from one error line.

## Changes

- `ax_cli/client.py` — add `elif method == "POST" and path == "/api/v1/messages":` branch in `_parse_json`, modeled on the existing agents-create case. The new error names the routing-metadata consequence directly.
- `tests/test_client.py` — add `test_parse_json_names_send_message_html_shell_as_routing_failure`, parallel to the existing `test_parse_json_names_agent_create_html_shell_as_api_contract_failure`.

29 insertions, 0 deletions across two files.

## Direction check

- **Trust boundary**: unchanged. `_parse_json` is called the same way by every code path that uses the central `AxClient`; this only changes the *text* of an exception that already gets raised, not when it gets raised.
- **Operator UX**: a strict improvement. The previous error said where the HTML came from; the new error says what stops working as a result — the operator can decide whether to retry, escalate, or use a different path without re-deriving the failure mode.

## Out of scope

- **The actual `/api/v1/messages` HTML return is a paxai.app backend bug**, not a CLI bug. The fix lives in the hosted API repo. This PR only improves the CLI's diagnosable error when that backend bug recurs.
- **Reply metadata preservation** (the "Codex-pass-through is patching client-side" piece called out in the original task body) has already shipped in **PR #155**. This PR does *not* re-do that work.
- **Other API routes** that might also be SPA-captured (`/api/v1/contexts`, `/api/v1/keys`, etc.) — adding route-specific guidance for each is a follow-up. The pattern is now established at two routes if those become needed.

## Test plan

- [x] `uv run --with pytest pytest tests/test_client.py -k "parse_json or html" -v` — 3 passed
- [x] `uv run --with pytest pytest --deselect tests/test_agents_test_invoking_principal.py::test_default_sender_is_invoking_principal_from_workspace_config -q` — 42 failed (matches `main`'s known Windows-environment flake count; no new failures)
- [x] `uv run --with ruff ruff check .` — clean
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean

Manual smoke (operator):

- [ ] Trigger the HTML response from `/api/v1/messages` against a workspace where the bug reproduces (madtank's, per the task description) and confirm the CLI surfaces the new "Send-message returned HTML…" message rather than the generic "frontend may be catching this API route" hint.

## Related

- aX task: `47d3b9a5` (CLI-side slice; backend `/api/v1/messages` HTML return tracked separately)
- Related merged PR: #155 (preserved reply metadata through the Gateway local-send path — the client-side patching this task description originally referenced)
- Related code: `ax_cli/client.py:_parse_json` already does this for `POST /api/v1/agents`
