### PR TITLE
docs: use canonical echo_test template id everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Use the dashboard's **Connect agent** flow or the equivalent CLI commands:
 ```bash
 ax gateway agents add demo-hermes --template hermes
 ax gateway agents add gemma4 --template ollama --ollama-model gemma4:latest
-ax gateway agents add echo-bot --template echo
+ax gateway agents add echo-bot --template echo_test
 ax gateway agents add notifications --template service_account
 ```
 
@@ -287,7 +287,7 @@ The main runtime families are:
 | --- | --- | --- |
 | `hermes` | Coding agents with tools, repo access, and session continuity | Long-running supervised listener |
 | `ollama` | Local models such as Gemma or Nemotron | Gateway-managed local bridge with transcript-backed memory |
-| `echo` | Smoke tests and demos | Built-in test runtime |
+| `echo_test` | Smoke tests and demos | Built-in test runtime |
 | `service_account` | Named notification sources, reminders, alerting, and probes | Gateway sender identity, not a live agent |
 | `pass_through` | Codex, Claude Code, scripts, or assistants that check a mailbox | Polling mailbox, approval required |
 | `claude_code_channel` | Attached Claude Code sessions over MCP/channel | Live attached session observed by Gateway |

--- a/docs/gateway-agent-runtimes.md
+++ b/docs/gateway-agent-runtimes.md
@@ -135,7 +135,7 @@ CLI access and `.mcp.json` there for Claude Code MCP/channel delivery.
 Use command bridges for simple adapters, demos, and smoke tests.
 
 ```bash
-ax gateway agents add echo-bot --template echo
+ax gateway agents add echo-bot --template echo_test
 ax gateway agents add probe \
   --type exec \
   --exec "python3 examples/gateway_probe/probe_bridge.py" \

--- a/skills/gateway-agent-setup/SKILL.md
+++ b/skills/gateway-agent-setup/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when the task is:
    - Managed agents get their own Gateway-owned runtime token and identity.
 
 2. Prefer Gateway-native templates first.
-   - `echo`
+   - `echo_test`
    - `ollama`
    - `hermes`
    - `claude_code_channel`
@@ -69,7 +69,7 @@ Pick the template that matches the asset class and intake model you want.
 Examples:
 
 ```bash
-uv run ax gateway agents add echo-bot --template echo
+uv run ax gateway agents add echo-bot --template echo_test
 uv run ax gateway agents add northstar --template hermes --workdir /absolute/path/to/hermes-workspace
 uv run ax gateway agents add ollama-bot --template ollama
 uv run ax gateway agents add orion --template claude_code_channel --workdir /absolute/path/to/claude-workspace


### PR DESCRIPTION
## Summary

Closes #149.

`README.md`, `docs/gateway-agent-runtimes.md`, and the `gateway-agent-setup` skill all show `--template echo` and list the row as `echo` in the templates table. The canonical template id is `echo_test` — that's what `ax gateway templates` returns, what `add_agent`'s `--template` help text already lists (`ax_cli/commands/gateway.py:7763`), and what the in-tree runtime catalog uses (`ax_cli/gateway_runtime_types.py`).

## Why

Two surfaces (the help text + the templates listing) say `echo_test`, three docs say `echo`. Operators copy-pasting from any of the three docs can reasonably wonder which one is right. Naming consistency across all user-facing surfaces removes that friction.

## Note on stale framing in the issue

The issue's repro claims `ax gateway agents add echo-bot --template echo` fails with `Unknown template: echo`. That isn't true today — `agent_template_definition` aliases `echo` → `echo_test` at `ax_cli/gateway_runtime_types.py:572-579`:

```python
def agent_template_definition(template_id: str) -> dict[str, Any]:
    normalized = template_id.lower().strip()
    if normalized == "echo":
        normalized = "echo_test"
    ...
```

So the command actually succeeds today. The doc fix is still warranted for naming consistency, but I want reviewers to see the framing change rather than have it discovered later.

## Changes

- **`README.md:271`** — `ax gateway agents add echo-bot --template echo` → `--template echo_test`.
- **`README.md:290`** — templates table row `\`echo\`` → `\`echo_test\``.
- **`docs/gateway-agent-runtimes.md:138`** — same `--template` substitution.
- **`skills/gateway-agent-setup/SKILL.md:30`** — `\`echo\`` in the "Prefer Gateway-native templates first" list → `\`echo_test\``.
- **`skills/gateway-agent-setup/SKILL.md:72`** — same `--template` substitution.

5 lines changed across 3 files.

## Direction check

- **Trust boundary**: untouched. Docs only.
- **Operator UX**: a strict improvement. Two surfaces (help text, templates listing) already use `echo_test`; this aligns the third (docs) with them, so operators no longer see two parallel names.
- **No code changes**: the `echo` → `echo_test` alias in `gateway_runtime_types.py` is preserved, so any existing scripts or operator habits using `--template echo` keep working.

## Out of scope

- **Removing the `echo` alias** in `agent_template_definition`. It's a backwards-compatibility shim and likely worth keeping. Removing it is a separate decision.
- **`docs/gateway-agent-runtimes.md:41`** lists `\`echo_test\` / \`echo\`` as runtime modes (not templates). That section is about runtime types, where `echo` is a real value (see `demo.html:714` mapping `runtime === "echo"`). Left alone — the framing there is correct, just nuanced.
- **Specs (`specs/GATEWAY-AUTH-TIERS-001/spec.md`)** also have `--template echo`. Specs document past design decisions; updating them is a separate concern from operator-facing docs.
- **JS UI mapping (`ax_cli/static/demo.html:714`)** intentionally accepts both `echo_test` and `echo` for icon resolution — defensive code, no change.

## Test plan

- [x] `git diff --stat` — confirms 3 files / 5 lines changed.
- [x] `uv run --with ruff ruff check .` — clean (no Python touched, but verified).
- [x] `uv run --with ruff ruff format --check ax_cli/` — clean.
- [x] Verified with `Grep` that no other instances of `ax gateway agents add ... --template echo` (without `_test`) remain in user-facing docs.

Manual smoke (operator):

- [ ] Copy-paste `ax gateway agents add echo-bot --template echo_test` from the README and confirm it registers.
- [ ] Run `ax gateway templates` and confirm the row reads `echo_test`, matching the table at `README.md:290`.

## Related

- GitHub issue: #149
- Related code: `ax_cli/gateway_runtime_types.py:572-579` (`echo` → `echo_test` alias)
- Related help text: `ax_cli/commands/gateway.py:7763` (already lists `echo_test`)
