### PR TITLE
feat(keys): add --audience flag to ax keys create

### DIFF
--- a/ax_cli/commands/keys.py
+++ b/ax_cli/commands/keys.py
@@ -22,6 +22,11 @@ def create(
         "--bound-agent-id",
         help="Bind the new PAT to this agent UUID (inherits allowed-spaces; use for agent runtime tokens)",
     ),
+    audience: Optional[str] = typer.Option(
+        None,
+        "--audience",
+        help="Token audience: cli, mcp, or both (only meaningful with --bound-agent-id)",
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Create a new API key."""
@@ -31,6 +36,7 @@ def create(
             name,
             allowed_agent_ids=agent_id or None,
             bound_agent_id=bound_agent_id,
+            audience=audience,
         )
     except httpx.HTTPStatusError as e:
         handle_error(e)

--- a/tests/test_keys_commands.py
+++ b/tests/test_keys_commands.py
@@ -11,7 +11,7 @@ def test_keys_create_passes_bound_agent_id(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def create_key(self, name, *, allowed_agent_ids=None, bound_agent_id=None):
+        def create_key(self, name, *, allowed_agent_ids=None, bound_agent_id=None, audience=None):
             captured["name"] = name
             captured["allowed_agent_ids"] = allowed_agent_ids
             captured["bound_agent_id"] = bound_agent_id
@@ -39,7 +39,7 @@ def test_keys_create_passes_scope_and_bound_agent_id(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def create_key(self, name, *, allowed_agent_ids=None, bound_agent_id=None):
+        def create_key(self, name, *, allowed_agent_ids=None, bound_agent_id=None, audience=None):
             captured["allowed_agent_ids"] = allowed_agent_ids
             captured["bound_agent_id"] = bound_agent_id
             return {"credential_id": "c2"}


### PR DESCRIPTION
Closes #177

`ax keys create` already exposes `--bound-agent-id` but had no way to set the token audience. `AxClient.create_key()` already accepted `audience`, this just wires it through to the CLI.

```bash
ax keys create my-agent-key \
  --bound-agent-id <agent-uuid> \
  --audience both