### PR TITLE
docs: replace dev/staging references with main

### DIFF
--- a/docs/gateway-agent-runtimes.md
+++ b/docs/gateway-agent-runtimes.md
@@ -22,8 +22,8 @@ Gateway keeps those pieces, but moves operator management into one place:
 - Show liveness, queue state, activity, and tool signals.
 - Provide a single CLI/UI for dev, staging, and production operators.
 
-Use separate Gateway state per environment. `AX_GATEWAY_ENV=dev/staging` stores
-state under `~/.ax/gateway/envs/dev-staging`, while `AX_GATEWAY_ENV=prod`
+Use separate Gateway state per environment. `AX_GATEWAY_ENV=dev` stores
+state under `~/.ax/gateway/envs/dev`, while `AX_GATEWAY_ENV=prod`
 stores a separate registry, session, PID file, UI state, queues, and agent token
 files. `AX_GATEWAY_DIR=/path/to/gateway-state` is available when a deployment
 needs an explicit state root.

--- a/docs/gateway-demo-script.md
+++ b/docs/gateway-demo-script.md
@@ -8,7 +8,7 @@ but to prove the product shape:
 one trusted local Gateway -> many agent runtimes -> shared aX spaces -> visible activity
 ```
 
-![Gateway overview](images/gateway-demo-overview.svg)
+![Gateway overview](images/gateway-demo-overview.png)
 
 ## Demo Goal
 

--- a/docs/operator-qa-runbook.md
+++ b/docs/operator-qa-runbook.md
@@ -138,7 +138,7 @@ matrix row.
 
 ## Promotion Drift Check
 
-Use this before promoting dev/staging behavior or when comparing environments:
+Use this before promoting changes or when comparing environments:
 
 ```bash
 axctl qa matrix \
@@ -286,7 +286,7 @@ verification fails, so a shell can silently keep its previous identity unless
 ## Sample Release Flow
 
 ```bash
-git checkout dev/staging
+git checkout main
 git pull --ff-only
 
 uv run ruff check .

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,14 +1,14 @@
 # Release Process
 
-`axctl` releases are designed for dev/staging co-promotion and automatic PyPI
+`axctl` releases are designed for main-branch integration and automatic PyPI
 publication.
 
 ## Flow
 
-1. Merge feature work into `dev/staging`.
-2. Validate `dev/staging` with automated tests, package build when needed, and
+1. Branch off `main` and open a PR against `main`.
+2. Validate with automated tests, package build when needed, and
    the operator QA sequence in [Operator QA Runbook](./operator-qa-runbook.md).
-3. Promote `dev/staging` to `main` with a reviewed PR.
+3. Merge the PR into `main` after review.
 4. Release Please opens or updates a release PR on `main` with:
    - `pyproject.toml` version bump
    - `.release-please-manifest.json` version bump
@@ -94,8 +94,8 @@ not to arbitrary commits.
 
 Current steady-state:
 
-1. Feature work lands in `dev/staging`.
-2. A reviewed promotion PR lands on `main`.
+1. Feature work lands in `main` via reviewed PRs.
+2. CI validates the merge.
 3. Release Please opens a release PR that only changes release metadata.
 4. A human reviews and merges the release PR.
 5. Release Please creates the GitHub tag/release.
@@ -113,8 +113,8 @@ Use SemVer, with normal `0.x` pre-1.0 semantics:
 - `feat:` creates a minor release for user-visible CLI capability.
 - Breaking CLI changes should be rare; if needed before 1.0, document them
   clearly in the release notes and prefer a minor bump.
-- Batch related `dev/staging` work into coherent releases instead of publishing
-  every small commit independently.
+- Batch related work into coherent releases instead of publishing every small
+  commit independently.
 
 For `axctl`, a good release is one that an operator can understand from the
 changelog: what changed, why it matters, and whether any setup or credential

--- a/specs/SEND-TO-AGENT-001/spec.md
+++ b/specs/SEND-TO-AGENT-001/spec.md
@@ -224,7 +224,7 @@ transcript.
 
 - [ ] Command shape (§3.1) reviewed and agreed by team
 - [ ] Envelope (§3.2) publishable as a JSON schema / TS types
-- [ ] `ax tasks send` and `ax alerts send` implemented on dev/staging
+- [ ] `ax tasks send` and `ax alerts send` implemented on main
 - [ ] Outgoing message has exactly **one** transcript object (not a pair)
 - [ ] Receiver's frontend renders one card with task/alert context + Open button
 - [ ] Delivery receipts stream per SEND-RECEIPTS-001


### PR DESCRIPTION
## Summary

- Replace stale `dev/staging` references with `main` across docs and specs
- Aligns documentation with the main-only shipping flow (CLAUDE.md, PR #166)

Cherry-picked from #144 (closed — scope too broad).

### Files changed

- `docs/release-process.md` — dev/staging → main throughout
- `docs/operator-qa-runbook.md` — dev/staging → main (2 spots)
- `docs/gateway-demo-script.md` — image ref `.svg` → `.png`
- `docs/gateway-agent-runtimes.md` — env var example `dev/staging` → `dev`
- `specs/SEND-TO-AGENT-001/spec.md` — 1 line: dev/staging → main

## Validation

- [x] This is docs/specs-only — no Python code changed
- [x] No token, profile, PAT, JWT, or agent identity behavior changed

## Test plan

- [x] Verify all changed files are text-only ref replacements
- [ ] Spot-check that no remaining dev/staging refs exist in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)