### PR TITLE
docs: community standards — issue templates, CoC, CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug in axctl / ax-gateway
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of axctl are you using? (`axctl --version`)
+      placeholder: "0.4.0"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Run `axctl ...`
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      placeholder: "3.13"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: Paste any relevant log output (automatically formatted as code).
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your suggestion! Please describe the feature you'd like to see.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered?
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Reporting
+
+Report unacceptable behavior to **support@ax-platform.com**.
+
+All reports will be reviewed and investigated promptly and fairly. The project team is obligated to maintain confidentiality with regard to the reporter.
+
+## Full Text
+
+The complete code of conduct is available at:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,41 @@
-# Contributing
+# Contributing to ax-gateway
 
-Thanks for improving `axctl`. This repository is public-facing, so changes
-should be easy for operators to understand, test, and release.
+Thanks for improving ax-gateway / `axctl`. This repository is public-facing, so
+changes should be easy for operators to understand, test, and release.
+
+## Code of Conduct
+
+This project is governed by our [Code of Conduct](./CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold it. Report unacceptable behavior to
+**support@ax-platform.com**.
+
+## New Here?
+
+If you are joining the project for the first time:
+
+1. Read through this guide and the [Development Setup](#development-setup) section below
+2. Browse **[Good First Issues](https://github.com/ax-platform/ax-gateway/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** —
+   small, well-scoped tasks tagged for newcomers
+
+## Getting Started
+
+### Prerequisites
+
+- **Python 3.13+**
+- **Git**
+
+### Fork & Clone
+
+1. Fork this repository on GitHub
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/ax-gateway.git
+   cd ax-gateway
+   ```
+3. Add upstream remote:
+   ```bash
+   git remote add upstream https://github.com/ax-platform/ax-gateway.git
+   ```
 
 ## Contributor License Agreement (CLA)
 
@@ -28,22 +62,22 @@ local development.
 
 ## Branches
 
-- `main` is the integration and release branch. Branch off `main` for all work.
-- `dev/staging` is dormant and should not be used as a base branch.
-- All changes reach `main` through a reviewed PR.
+- `main` is the integration and release branch. Branch all new work from `main`.
+- `dev/staging` is dormant as of 2026-05-07 and far behind `main`. Do not branch
+  from it — PRs cut from `dev/staging` will silently revert recent work.
 
 ## Commit Style
 
 Use Conventional Commits so Release Please can generate the changelog and
 version bump correctly:
 
-- `fix:` for compatible bug fixes.
-- `feat:` for user-visible CLI capability.
-- `docs:`, `test:`, `ci:`, `chore:`, and `style:` for non-release metadata.
+- `fix:` for compatible bug fixes
+- `feat:` for user-visible CLI capability
+- `docs:`, `test:`, `ci:`, `chore:`, and `style:` for non-release metadata
 - Use `!` or a `BREAKING CHANGE:` footer only when the operator-facing contract
-  changes incompatibly.
+  changes incompatibly
 
-## Auth And Credentials
+## Security and Credentials
 
 `axctl` handles user PATs, agent PATs, exchanged JWTs, and profile metadata.
 Treat identity boundaries as part of the product contract:
@@ -56,6 +90,17 @@ Treat identity boundaries as part of the product contract:
 - Update tests and docs for any token, profile, JWT, or identity behavior
   change.
 
+## Pull Request Guidelines
+
+Before submitting:
+
+- Code runs without errors
+- `pytest tests/ -v --tb=short` passes
+- `ruff check ax_cli/` and `ruff format --check ax_cli/` pass
+- `python -m build` succeeds
+- No sensitive data committed
+- Branch is up to date with target branch
+
 ## Release Process
 
 See [docs/release-process.md](docs/release-process.md).
@@ -67,3 +112,13 @@ The short version:
 3. Release Please opens a release PR.
 4. Merge the release PR after reviewing the version and changelog.
 5. GitHub Release publication triggers PyPI publishing.
+
+## Community & Support
+
+- **GitHub Issues**: [Report bugs or request features](https://github.com/ax-platform/ax-gateway/issues)
+- **Security Vulnerabilities**: See [SECURITY.md](./SECURITY.md) — do not open a public issue
+
+## License
+
+By contributing to ax-gateway, you agree that your contributions will be
+licensed under the **MIT License**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you are joining the project for the first time:
 
 ### Prerequisites
 
-- **Python 3.13+**
+- **Python 3.11+**
 - **Git**
 
 ### Fork & Clone


### PR DESCRIPTION
## Summary

- Add GitHub issue templates (bug report + feature request)
- Add Code of Conduct
- Expand CONTRIBUTING.md with fork/clone instructions, CoC link, and updated branch guidance (main-only workflow)

Cherry-picked from #144 (closed — scope too broad). Forward references to onboarding docs stripped so this PR stands alone.

## Validation

- [x] This is docs/config-only — no Python code changed
- [x] No token, profile, PAT, JWT, or agent identity behavior changed

## Test plan

- [ ] Verify issue templates render correctly on the repo's "New Issue" page
- [ ] Verify CONTRIBUTING.md links resolve (CoC, Good First Issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)