### PR TITLE
docs: add 6 architecture decision records (ADRs)

### DIFF
--- a/docs/adr/ADR-001-gateway-localhost-only.md
+++ b/docs/adr/ADR-001-gateway-localhost-only.md
@@ -1,0 +1,37 @@
+# ADR-001: Gateway Binds to 127.0.0.1 Only
+
+**Status:** Accepted
+
+## Context
+
+Gateway serves an HTTP API and operator UI on a local port. During early
+development, the question arose whether Gateway should bind to `0.0.0.0`
+(accessible from the LAN) or `127.0.0.1` (localhost only).
+
+Gateway manages agent credentials, proxies authenticated API calls, and can
+start/stop local agent runtimes. Exposing these capabilities to the network
+would create a large attack surface — any device on the local network could
+register agents, read inboxes, and proxy API calls using the operator's
+credentials.
+
+## Decision
+
+Gateway binds exclusively to `127.0.0.1:8765`. No LAN exposure.
+
+## Consequences
+
+- **Positive:** The trust boundary is the local machine. Only processes running
+  on the same host can reach Gateway. This matches the threat model: Gateway
+  trusts the local operator and their local agent processes.
+- **Positive:** No need for authentication on the Gateway HTTP API itself — the
+  OS network stack provides the access control.
+- **Negative:** Remote operators cannot access the Gateway UI without SSH
+  tunneling or a reverse proxy. This is acceptable because Gateway is a
+  local-development tool, not a production service.
+- **Negative:** Multi-machine agent deployments need one Gateway per host. There
+  is no centralized Gateway that manages agents across machines.
+
+## Notes
+
+Host header validation middleware is a recommended hardening measure (see issue
+backlog) to prevent DNS rebinding attacks against the localhost endpoint.

--- a/docs/adr/ADR-001-gateway-localhost-only.md
+++ b/docs/adr/ADR-001-gateway-localhost-only.md
@@ -16,7 +16,9 @@ credentials.
 
 ## Decision
 
-Gateway binds exclusively to `127.0.0.1:8765`. No LAN exposure.
+Gateway defaults to `127.0.0.1:8765`. The `--host` flag on `ax gateway start`
+and `ax gateway ui` allows an explicit override (e.g. for SSH tunnel or reverse
+proxy setups), but the default enforces localhost-only binding.
 
 ## Consequences
 

--- a/docs/adr/ADR-002-flat-proxy-allowlist.md
+++ b/docs/adr/ADR-002-flat-proxy-allowlist.md
@@ -21,12 +21,14 @@ Two approaches were considered:
 Use a flat allowlist (`_LOCAL_PROXY_METHODS` in `ax_cli/commands/gateway.py`,
 line 540). All agent sessions share the same allowed methods.
 
-Current allowlist: `whoami`, `list_spaces`, `list_agents`,
-`list_agents_availability`, `list_context`, `get_context`, `list_messages`,
-`get_message`, `search_messages`, `list_tasks`, `get_task`, `update_task`.
+Current allowlist includes both `use`-tier read operations (`whoami`,
+`list_spaces`, `list_agents`, `list_agents_availability`, `list_context`,
+`get_context`, `list_messages`, `get_message`, `search_messages`, `list_tasks`,
+`get_task`) and `admin`-tier write operations (`update_task`, `upload_file`).
 
-Write operations (`send_message`, `create_task`, `upload_file`) go through
-dedicated endpoints (`/local/send`, `/local/tasks`) with additional validation.
+`send_message` and `create_task` go through dedicated endpoints (`/local/send`,
+`/local/tasks`) with additional validation. `upload_file` is in the allowlist
+but sandboxed to the agent's workdir (see `commands/gateway.py:833-840`).
 
 ## Consequences
 
@@ -36,8 +38,8 @@ dedicated endpoints (`/local/send`, `/local/tasks`) with additional validation.
   a coding sentinel. An inbox agent can call `update_task` even if it should
   only read messages.
 - **Negative:** Adding a sensitive method to the allowlist grants it to all
-  agents. `upload_file` is intentionally excluded because an inbox agent with
-  unrestricted file upload is a trust boundary violation.
+  agents at that tier level. `upload_file` is admin-tiered and sandboxed to
+  the agent workdir, but any agent with admin tier can invoke it.
 
 ## Replacement Plan
 

--- a/docs/adr/ADR-002-flat-proxy-allowlist.md
+++ b/docs/adr/ADR-002-flat-proxy-allowlist.md
@@ -1,0 +1,47 @@
+# ADR-002: Proxy Uses a Flat Allowlist, Not Per-Agent ACLs
+
+**Status:** Accepted (Phase 4 will replace with `use`/`admin` tiers)
+
+## Context
+
+Gateway proxies API calls from local agent sessions through the `/local/proxy`
+endpoint. The proxy needs to control which `AxClient` methods an agent can
+invoke — unrestricted proxy access would let any local agent session perform
+admin operations using the operator's credentials.
+
+Two approaches were considered:
+
+1. **Per-agent ACLs** — each agent registration declares which methods it may
+   call. The proxy checks the agent's ACL before dispatching.
+2. **Flat allowlist** — a single `_LOCAL_PROXY_METHODS` dict shared by all
+   agents. Any method not in the list is rejected.
+
+## Decision
+
+Use a flat allowlist (`_LOCAL_PROXY_METHODS` in `ax_cli/commands/gateway.py`,
+line 540). All agent sessions share the same allowed methods.
+
+Current allowlist: `whoami`, `list_spaces`, `list_agents`,
+`list_agents_availability`, `list_context`, `get_context`, `list_messages`,
+`get_message`, `search_messages`, `list_tasks`, `get_task`, `update_task`.
+
+Write operations (`send_message`, `create_task`, `upload_file`) go through
+dedicated endpoints (`/local/send`, `/local/tasks`) with additional validation.
+
+## Consequences
+
+- **Positive:** Simple to understand and audit. One dict, one check.
+- **Positive:** No per-agent configuration surface to get wrong.
+- **Negative:** No granularity — an echo-test agent has the same proxy access as
+  a coding sentinel. An inbox agent can call `update_task` even if it should
+  only read messages.
+- **Negative:** Adding a sensitive method to the allowlist grants it to all
+  agents. `upload_file` is intentionally excluded because an inbox agent with
+  unrestricted file upload is a trust boundary violation.
+
+## Replacement Plan
+
+Issue #146 proposes a `use`/`admin` tier model. Each proxy method gets a tier
+annotation. Agent registrations declare their tier. The proxy checks
+`agent_tier >= method_tier` before dispatching. This preserves the simplicity
+of a central list while adding per-agent granularity.

--- a/docs/adr/ADR-003-session-tokens-per-connect.md
+++ b/docs/adr/ADR-003-session-tokens-per-connect.md
@@ -23,7 +23,8 @@ disk or reused across agent restarts.
 ## Consequences
 
 - **Positive:** A leaked session token has limited blast radius — it expires
-  and cannot be replayed after the session ends.
+  via TTL. There is no active session-end invalidation; the primary mitigation
+  is short token lifetimes.
 - **Positive:** Token compromise has a bounded window — tokens expire via TTL.
   There is no restart-based invalidation; the primary protection is short expiry.
 - **Positive:** Simpler token lifecycle — no cache invalidation, no stale token

--- a/docs/adr/ADR-003-session-tokens-per-connect.md
+++ b/docs/adr/ADR-003-session-tokens-per-connect.md
@@ -1,0 +1,35 @@
+# ADR-003: Session Tokens Are Short-Lived and Per-Connect
+
+**Status:** Accepted
+
+## Context
+
+When a local agent connects to Gateway via `/local/connect`, it receives a
+session token (`axgw_s_<payload>.<signature>`). This token authorizes subsequent
+API calls through Gateway's local endpoints (`/local/send`, `/local/inbox`,
+`/local/proxy`).
+
+The question was whether session tokens should be cached and reused across
+connections or issued fresh each time.
+
+## Decision
+
+Session tokens are short-lived and per-connect. Each `/local/connect` call
+issues a new token. Tokens are HMAC-SHA256 signed with a secret stored at
+`~/.ax/gateway/.secret` (see `issue_local_session()` in
+`ax_cli/gateway.py:1327`). Tokens are not cached on disk or reused across
+agent restarts.
+
+## Consequences
+
+- **Positive:** A leaked session token has limited blast radius — it expires
+  and cannot be replayed after the session ends.
+- **Positive:** Token compromise does not persist across agent restarts.
+  Stopping and restarting an agent invalidates all outstanding sessions.
+- **Positive:** Simpler token lifecycle — no cache invalidation, no stale token
+  bugs, no need for a revocation list.
+- **Negative:** Every agent connect requires a Gateway round-trip to obtain a
+  fresh token. This is negligible for local-machine communication.
+- **Negative:** Long-running agents that lose their session (Gateway restart,
+  secret rotation) must reconnect. The reconcile loop handles this
+  automatically for managed agents.

--- a/docs/adr/ADR-003-session-tokens-per-connect.md
+++ b/docs/adr/ADR-003-session-tokens-per-connect.md
@@ -15,17 +15,17 @@ connections or issued fresh each time.
 ## Decision
 
 Session tokens are short-lived and per-connect. Each `/local/connect` call
-issues a new token. Tokens are HMAC-SHA256 signed with a secret stored at
-`~/.ax/gateway/.secret` (see `issue_local_session()` in
-`ax_cli/gateway.py:1327`). Tokens are not cached on disk or reused across
-agent restarts.
+issues a new token. Tokens are HMAC-SHA256 signed with the secret at
+`~/.ax/gateway/local_secret.bin` (see `local_secret_path()` and
+`issue_local_session()` in `ax_cli/gateway.py`). Tokens are not cached on
+disk or reused across agent restarts.
 
 ## Consequences
 
 - **Positive:** A leaked session token has limited blast radius — it expires
   and cannot be replayed after the session ends.
-- **Positive:** Token compromise does not persist across agent restarts.
-  Stopping and restarting an agent invalidates all outstanding sessions.
+- **Positive:** Token compromise has a bounded window — tokens expire via TTL.
+  There is no restart-based invalidation; the primary protection is short expiry.
 - **Positive:** Simpler token lifecycle — no cache invalidation, no stale token
   bugs, no need for a revocation list.
 - **Negative:** Every agent connect requires a Gateway round-trip to obtain a

--- a/docs/adr/ADR-004-space-state-in-session.md
+++ b/docs/adr/ADR-004-space-state-in-session.md
@@ -1,0 +1,43 @@
+# ADR-004: Space State Lives in session.json, Not registry.json Gateway Block
+
+**Status:** Accepted (PR #172)
+
+## Context
+
+Gateway tracks which space each agent is bound to. Initially, the active space
+was stored in the `gateway` block of `registry.json` alongside static agent
+config (name, template, workdir, credentials).
+
+This caused problems:
+
+1. The reconcile loop writes `registry.json` every cycle. Space state changes
+   (operator switches space) were mixed with lifecycle state changes (agent
+   starts/stops), making it hard to reason about which writes were
+   operator-initiated vs. system-initiated.
+2. The auto-migration that strips stale `space_id`/`space_name` from the
+   gateway block could race with an operator space switch, silently reverting
+   the operator's choice.
+3. Backup and restore of `registry.json` carried space state, which is
+   ephemeral and environment-dependent — restoring a registry from staging
+   onto a prod Gateway would bind agents to the wrong space.
+
+## Decision
+
+Move active space state to `session.json`. The registry gateway block retains
+only static config (agent identity, template, workdir, credentials).
+`session.json` holds ephemeral runtime state including active space, session
+tokens, and presence information.
+
+Implemented in PR #172.
+
+## Consequences
+
+- **Positive:** Clean separation of static config (registry) vs. runtime state
+  (session). Operators can back up registry without carrying ephemeral state.
+- **Positive:** The reconcile loop no longer races with space switches — session
+  writes are independent of registry writes.
+- **Positive:** Space auto-migration only needs to touch session, not registry.
+- **Negative:** Two files to read when debugging space issues. Operators need to
+  know to check `session.json` for active space, not `registry.json`.
+- **Negative:** Gateway startup must load both files and reconcile any
+  inconsistencies between them.

--- a/docs/adr/ADR-004-space-state-in-session.md
+++ b/docs/adr/ADR-004-space-state-in-session.md
@@ -37,7 +37,9 @@ Implemented in PR #172.
 - **Positive:** The reconcile loop no longer races with space switches — session
   writes are independent of registry writes.
 - **Positive:** Space auto-migration only needs to touch session, not registry.
-- **Negative:** Two files to read when debugging space issues. Operators need to
-  know to check `session.json` for active space, not `registry.json`.
+- **Negative:** Two files to read when debugging space issues. During the
+  migration, identity bindings in `registry.json` still carry `active_space_id`
+  and `default_space_id` fields. Operators should check both `session.json` and
+  `registry.json` identity bindings until the migration is complete.
 - **Negative:** Gateway startup must load both files and reconcile any
   inconsistencies between them.

--- a/docs/adr/ADR-005-credentials-never-in-workspace.md
+++ b/docs/adr/ADR-005-credentials-never-in-workspace.md
@@ -1,0 +1,54 @@
+# ADR-005: Agent Credentials Are Brokered, Never Copied to Workspace Config
+
+**Status:** Accepted
+
+## Context
+
+When Gateway mints a managed agent credential, the credential needs to be
+available to the agent runtime. Two approaches:
+
+1. **Copy the credential** into the agent's workspace config
+   (`.ax/config.toml`) so the agent can read it directly.
+2. **Broker the credential** through Gateway — the agent authenticates with a
+   session token and Gateway attaches the real credential to proxied API calls.
+
+Copying credentials to workspace config creates multiple risks:
+
+- The credential is on disk in a file that may be committed to git, copied to
+  another machine, or read by another process in the same workspace.
+- Multiple agents sharing a workspace directory would share or overwrite each
+  other's credentials.
+- Credential rotation requires updating every workspace config file that
+  contains the old credential.
+- Logs, error messages, and diagnostic output may accidentally include the
+  credential if it's a local config value.
+
+## Decision
+
+Agent credentials are brokered by Gateway. The raw credential lives only in
+Gateway's state directory (`~/.ax/gateway/agents/{name}/token`). The agent
+runtime authenticates to Gateway with a short-lived session token and Gateway
+proxies API calls using the real credential.
+
+Credentials must not appear in:
+- `.ax/config.toml` (workspace config)
+- Log files or diagnostic output
+- Messages, PR comments, or generated docs
+- Environment variables visible to child processes (except when explicitly
+  injected by Gateway for a supervised runtime launch)
+
+## Consequences
+
+- **Positive:** Single source of truth for credentials — Gateway's state
+  directory. Rotation updates one file.
+- **Positive:** Workspace directories are safe to commit, share, and inspect.
+  No credential leakage through git, logs, or copy operations.
+- **Positive:** Multiple agents in the same workspace directory maintain
+  distinct identities — their credentials are in Gateway, not in a shared
+  `.ax/config.toml`.
+- **Negative:** Agents cannot operate independently of Gateway. If Gateway is
+  down, agents cannot authenticate. This is acceptable because Gateway is the
+  management plane — agents without their management plane are intentionally
+  non-functional.
+- **Negative:** Advanced/legacy setups that use direct token profiles bypass
+  this brokering. Those setups accept the credential-on-disk risk.

--- a/docs/adr/ADR-006-use-admin-proxy-tiers.md
+++ b/docs/adr/ADR-006-use-admin-proxy-tiers.md
@@ -1,0 +1,67 @@
+# ADR-006: `use`/`admin` Tier Model for Proxy Methods
+
+**Status:** Proposed (issue #146)
+
+## Context
+
+ADR-002 established a flat proxy allowlist. All agent sessions share the same
+set of allowed methods. This works for the current agent population but does
+not scale to mixed-trust environments where some agents should have broader
+access than others.
+
+Specific gaps:
+
+- An inbox agent that only needs `list_messages` and `get_message` currently
+  also has access to `update_task`, `list_agents`, and `search_messages`.
+- `upload_file` is excluded from the proxy entirely because granting it to all
+  agents (including untrusted inbox agents) would be a trust boundary
+  violation. But trusted coding sentinels legitimately need file upload.
+- The operator cannot express "this agent is trusted for write operations"
+  vs. "this agent only reads its inbox" without modifying the proxy source.
+
+## Decision (Proposed)
+
+Replace the flat allowlist with a two-tier model:
+
+| Tier | Access | Example Agents |
+| --- | --- | --- |
+| `use` | Read operations: `whoami`, `list_*`, `get_*`, `search_*` | Inbox agents, echo bots, monitors |
+| `admin` | Read + write operations: `update_task`, `upload_file`, `send_message` | Coding sentinels, automation agents |
+
+Each entry in `_LOCAL_PROXY_METHODS` gets a `tier` annotation:
+
+```python
+_LOCAL_PROXY_METHODS = {
+    "whoami": {"tier": "use"},
+    "list_messages": {"tier": "use", "kwargs": [...]},
+    "update_task": {"tier": "admin", "args": ["task_id"], "kwargs": [...]},
+    "upload_file": {"tier": "admin", "args": ["file_path"]},
+}
+```
+
+Agent registrations declare their tier (default: `use`). The proxy checks
+`agent_tier >= method_tier` before dispatching.
+
+## Consequences
+
+- **Positive:** Operators can grant broader access to trusted agents without
+  modifying source code.
+- **Positive:** `upload_file` and `send_message` can be added to the proxy
+  for admin-tier agents without exposing them to all agents.
+- **Positive:** The allowlist remains a single dict — easy to audit. The tier
+  annotation adds one field per entry, not a separate ACL system.
+- **Negative:** Two tiers may not be enough. Future requirements may need
+  finer granularity (per-space, per-method-argument). The two-tier model is
+  a stepping stone, not a final access control system.
+- **Negative:** Tier assignment at registration time is static. An agent
+  cannot be promoted or demoted without re-registration. This matches the
+  current "stop, modify, restart" operational model.
+
+## Implementation Notes
+
+- Add `tier` field to agent registration entries in `registry.json`.
+- Default to `use` tier for existing agents (backward compatible).
+- Add `tier` annotation to each `_LOCAL_PROXY_METHODS` entry.
+- Proxy check: `if entry_tier < method_tier: reject`.
+- Good first issue candidate: adding the `tier` annotation to existing entries
+  is a small, well-scoped change.

--- a/docs/adr/ADR-006-use-admin-proxy-tiers.md
+++ b/docs/adr/ADR-006-use-admin-proxy-tiers.md
@@ -1,6 +1,7 @@
 # ADR-006: `use`/`admin` Tier Model for Proxy Methods
 
-**Status:** Proposed (issue #146)
+**Status:** Partially implemented (tier annotations landed in PR #215; per-agent
+tier enforcement is proposed in issue #146)
 
 ## Context
 
@@ -13,9 +14,8 @@ Specific gaps:
 
 - An inbox agent that only needs `list_messages` and `get_message` currently
   also has access to `update_task`, `list_agents`, and `search_messages`.
-- `upload_file` is excluded from the proxy entirely because granting it to all
-  agents (including untrusted inbox agents) would be a trust boundary
-  violation. But trusted coding sentinels legitimately need file upload.
+- `upload_file` is now in the proxy allowlist with `tier: "admin"` and workdir
+  sandboxing, but without per-agent tier enforcement all agents can invoke it.
 - The operator cannot express "this agent is trusted for write operations"
   vs. "this agent only reads its inbox" without modifying the proxy source.
 
@@ -46,8 +46,9 @@ Agent registrations declare their tier (default: `use`). The proxy checks
 
 - **Positive:** Operators can grant broader access to trusted agents without
   modifying source code.
-- **Positive:** `upload_file` and `send_message` can be added to the proxy
-  for admin-tier agents without exposing them to all agents.
+- **Positive:** `upload_file` and `send_message` are already annotated with
+  `tier: "admin"`. Per-agent tier enforcement will restrict them to
+  admin-tier agents only.
 - **Positive:** The allowlist remains a single dict — easy to audit. The tier
   annotation adds one field per entry, not a separate ACL system.
 - **Negative:** Two tiers may not be enough. Future requirements may need
@@ -61,7 +62,6 @@ Agent registrations declare their tier (default: `use`). The proxy checks
 
 - Add `tier` field to agent registration entries in `registry.json`.
 - Default to `use` tier for existing agents (backward compatible).
-- Add `tier` annotation to each `_LOCAL_PROXY_METHODS` entry.
+- Tier annotations on `_LOCAL_PROXY_METHODS` entries are already in place
+  (PR #215). Remaining work: per-agent tier enforcement at proxy dispatch.
 - Proxy check: `if entry_tier < method_tier: reject`.
-- Good first issue candidate: adding the `tier` annotation to existing entries
-  is a small, well-scoped change.


### PR DESCRIPTION
## Summary

- Add 6 ADRs documenting key Gateway design decisions:
  - ADR-001: Gateway localhost-only binding
  - ADR-002: Flat proxy allowlist
  - ADR-003: Session tokens per-connect
  - ADR-004: Space state in session
  - ADR-005: Credentials never in workspace
  - ADR-006: Use/admin proxy tiers

Cherry-picked from #144 (closed — scope too broad). These are self-contained reference docs with no cross-dependencies.

## Validation

- [x] This is docs-only — no Python code changed
- [x] No token, profile, PAT, JWT, or agent identity behavior changed

## Test plan

- [ ] Verify ADR markdown renders correctly in GitHub
- [ ] Spot-check that ADR content matches current Gateway behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)