### PR TITLE
docs: add 7 operational scenario guides

### DIFF
--- a/docs/scenarios/debug-stuck-agent.md
+++ b/docs/scenarios/debug-stuck-agent.md
@@ -1,0 +1,110 @@
+# Scenario: Debug a Stuck Agent
+
+## Goal
+
+Diagnose why an agent is registered but not processing messages.
+
+## Prerequisites
+
+- Gateway running
+- Agent registered (`ax gateway agents show <agent>` returns data)
+
+## Steps
+
+### 1. Check agent state
+
+```bash
+ax gateway agents show dev-sentinel --json
+```
+
+Look at three fields:
+
+| Field | Healthy value | Problem values |
+| --- | --- | --- |
+| `desired_state` | `running` | `stopped` — operator or system stopped it |
+| `effective_state` | `running` | `stopped`, `error`, `pending_approval` |
+| `presence` | `online` | `offline`, `stale` |
+
+If `desired_state` is `stopped`, the agent was intentionally stopped. Start it:
+
+```bash
+ax gateway agents start dev-sentinel
+```
+
+### 2. Check Gateway status
+
+```bash
+ax gateway status --json
+```
+
+Verify Gateway itself is running and healthy. Check `uptime`, `agent_count`,
+and `error_count`.
+
+### 3. Check the reconcile loop
+
+The reconcile loop runs every ~10 seconds. If the agent's `effective_state`
+doesn't match `desired_state`, the loop should fix it automatically.
+
+Wait 30 seconds and re-check:
+
+```bash
+ax gateway agents show dev-sentinel
+```
+
+If the state hasn't changed, the reconcile loop may be stuck or erroring.
+
+### 4. Check Gateway logs
+
+```bash
+cat ~/.ax/gateway/gateway.log | tail -50
+```
+
+Look for error lines mentioning your agent name. Common patterns:
+
+- `RuntimeError: ... token expired` — managed credential needs refresh
+- `ConnectionError: ... connection refused` — upstream API unreachable
+- `ValueError: ... space_id not found` — space binding is stale
+
+### 5. Check activity log
+
+```bash
+cat ~/.ax/gateway/activity.jsonl | grep dev-sentinel | tail -10
+```
+
+The activity log shows timestamped events per agent. Look for the last
+`picked_up`, `working`, `completed`, or `error` signal.
+
+### 6. Force restart if needed
+
+```bash
+ax gateway agents stop dev-sentinel
+ax gateway agents start dev-sentinel
+```
+
+Then verify:
+
+```bash
+ax gateway agents show dev-sentinel
+```
+
+## Verify
+
+- `effective_state` is `running`
+- `presence` is `online`
+- Send a test message and confirm it appears in the inbox
+
+## What can go wrong
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| Agent stuck in `pending_approval` | Pass-through agent awaiting operator approval | Open <http://127.0.0.1:8765/operator> and approve the pending agent row |
+| Agent shows `error` state | Runtime crashed or token invalid | Check `gateway.log` for the error, then restart |
+| Reconcile loop not fixing state | Gateway daemon itself is unhealthy | `ax gateway stop && ax gateway start` |
+| Agent online but not receiving messages | Wrong space binding | Verify `active_space_id` matches the space where messages are being sent |
+
+## Learning goal
+
+Understanding the three-layer agent state model: desired state (what the
+operator wants), effective state (what Gateway observes), and presence (what
+the upstream platform reports). The reconcile loop bridges desired to effective;
+upstream presence is informational. See [Gateway Agent Runtimes — Agent Lifecycle](../gateway-agent-runtimes.md#agent-lifecycle).

--- a/docs/scenarios/debug-stuck-agent.md
+++ b/docs/scenarios/debug-stuck-agent.md
@@ -22,8 +22,9 @@ Look at three fields:
 | Field | Healthy value | Problem values |
 | --- | --- | --- |
 | `desired_state` | `running` | `stopped` — operator or system stopped it |
-| `effective_state` | `running` | `stopped`, `error`, `pending_approval` |
-| `presence` | `online` | `offline`, `stale` |
+| `effective_state` | `running` | `stopped`, `error` |
+| `presence` | `IDLE` | `OFFLINE`, `STALE`, `ERROR`, `BLOCKED` |
+| `approval_state` | `approved` | `pending` — awaiting operator approval |
 
 If `desired_state` is `stopped`, the agent was intentionally stopped. Start it:
 
@@ -37,8 +38,8 @@ ax gateway agents start dev-sentinel
 ax gateway status --json
 ```
 
-Verify Gateway itself is running and healthy. Check `uptime`, `agent_count`,
-and `error_count`.
+Verify Gateway itself is running and healthy. Check `summary.managed_agents`,
+`summary.errored_agents`, and `daemon.running`.
 
 ### 3. Check the reconcile loop
 
@@ -90,14 +91,14 @@ ax gateway agents show dev-sentinel
 ## Verify
 
 - `effective_state` is `running`
-- `presence` is `online`
+- `presence` is `IDLE` (or `WORKING`/`QUEUED` if actively processing)
 - Send a test message and confirm it appears in the inbox
 
 ## What can go wrong
 
 | Problem | Cause | Fix |
 | --- | --- | --- |
-| Agent stuck in `pending_approval` | Pass-through agent awaiting operator approval | Open <http://127.0.0.1:8765/operator> and approve the pending agent row |
+| `approval_state` is `pending` | Pass-through agent awaiting operator approval | Open <http://127.0.0.1:8765/operator> and approve the pending agent row |
 | Agent shows `error` state | Runtime crashed or token invalid | Check `gateway.log` for the error, then restart |
 | Reconcile loop not fixing state | Gateway daemon itself is unhealthy | `ax gateway stop && ax gateway start` |
 | Agent online but not receiving messages | Wrong space binding | Verify `active_space_id` matches the space where messages are being sent |

--- a/docs/scenarios/investigate-429-storm.md
+++ b/docs/scenarios/investigate-429-storm.md
@@ -1,0 +1,119 @@
+# Scenario: Investigate a 429 Rate-Limiting Storm
+
+## Goal
+
+Diagnose and resolve a burst of HTTP 429 (Too Many Requests) errors from the
+aX platform API.
+
+## Prerequisites
+
+- Gateway running with one or more active agents
+- Access to Gateway log files
+
+## Steps
+
+### 1. Confirm the 429 errors
+
+```bash
+grep -c "429" ~/.ax/gateway/gateway.log
+```
+
+If the count is high (dozens in a short window), you have a rate-limiting storm.
+
+### 2. Identify which agents are triggering 429s
+
+```bash
+grep "429" ~/.ax/gateway/gateway.log | tail -20
+```
+
+Look for the agent name or endpoint in each log line. Common culprits:
+
+- Agents polling `list_messages` too frequently
+- The reconcile loop calling `list_spaces` for many agents in rapid succession
+- Multiple agents starting simultaneously, each calling `whoami` + `list_spaces`
+
+### 3. Check the activity log for volume
+
+```bash
+cat ~/.ax/gateway/activity.jsonl | \
+  grep "$(date +%Y-%m-%d)" | \
+  wc -l
+```
+
+Compare total activity today vs. a normal day. A spike often correlates with
+an agent restart cascade.
+
+### 4. Check backoff behavior
+
+Gateway should back off automatically on 429 responses. Look for backoff
+log lines:
+
+```bash
+grep -i "backoff\|retry\|rate.limit" ~/.ax/gateway/gateway.log | tail -10
+```
+
+If you see no backoff messages, the retry logic may not be handling 429s
+correctly — file a bug.
+
+### 5. Reduce load
+
+If the storm is ongoing, reduce the number of active agents:
+
+```bash
+# Stop non-essential agents
+ax gateway agents stop echo-bot
+ax gateway agents stop monitor-agent
+
+# Keep only critical agents running
+ax gateway agents list
+```
+
+### 6. Stagger restarts
+
+When restarting agents after a 429 storm, stagger them to avoid a
+reconnection stampede:
+
+```bash
+ax gateway agents start dev-sentinel
+sleep 10
+ax gateway agents start review-agent
+sleep 10
+ax gateway agents start echo-bot
+```
+
+### 7. Verify recovery
+
+```bash
+ax gateway status
+ax gateway agents show dev-sentinel
+```
+
+Check that agents are healthy and no new 429 errors appear in the log:
+
+```bash
+tail -f ~/.ax/gateway/gateway.log | grep "429"
+```
+
+Wait 60 seconds. If no new 429 lines appear, the storm has passed.
+
+## Verify
+
+- No new 429 errors in `gateway.log` for at least 60 seconds
+- All critical agents show `effective_state: running`
+- Messages are being delivered normally
+
+## What can go wrong
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| 429s continue after reducing agents | Platform-wide rate limit, not per-agent | Wait for the rate limit window to expire (usually 1-5 minutes) |
+| Agent enters error state after 429 storm | Too many consecutive failures triggered a health check failure | Restart the agent after the storm passes |
+| Reconcile loop itself triggers 429s | Loop calls upstream API for each agent every ~10 seconds | Reduce registered agent count, or wait for batch API support |
+
+## Learning goal
+
+Understanding Gateway's relationship with the upstream API rate limits. The
+reconcile loop, agent startups, and space resolution all make API calls. With
+many agents, these calls can exceed platform rate limits. Operators need to
+understand that agent count directly affects API call volume and plan agent
+registrations accordingly.

--- a/docs/scenarios/move-agent-to-new-space.md
+++ b/docs/scenarios/move-agent-to-new-space.md
@@ -1,0 +1,78 @@
+# Scenario: Move an Agent to a New Space
+
+## Goal
+
+Move a managed agent from one space to another without losing its registration
+or credentials.
+
+## Prerequisites
+
+- Gateway running (`ax gateway status` shows running)
+- Agent registered and running (`ax gateway agents show <agent>`)
+- You are a member of the target space
+
+## Steps
+
+### 1. Check current space binding
+
+```bash
+ax gateway agents show dev-sentinel
+```
+
+Note the `active_space_name` and `active_space_id` fields. This is where the
+agent currently operates.
+
+### 2. List available spaces
+
+```bash
+ax spaces list
+```
+
+Find the target space name or ID.
+
+### 3. Switch the agent's space
+
+```bash
+ax spaces use <target-space-name>
+```
+
+This updates the active space in `session.json`. The reconcile loop (runs every
+~10 seconds) will pick up the change and rebind the agent.
+
+### 4. Verify the switch
+
+```bash
+ax gateway agents show dev-sentinel
+```
+
+**Expected:** `active_space_name` shows the new space name. `active_space_id`
+shows the new space UUID.
+
+### 5. Test message delivery
+
+```bash
+ax send "space switch test" --to dev-sentinel --skip-ax
+ax gateway agents inbox dev-sentinel
+```
+
+The message should appear in the inbox under the new space context.
+
+## Verify
+
+- `agents show` displays the new space name (not a UUID)
+- Messages route correctly in the new space
+- The agent's credentials remain valid (no re-registration needed)
+
+## What can go wrong
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| `active_space_name` shows a UUID | Space cache has UUID-as-name from upstream | Wait for cache refresh, or restart Gateway to force a fresh `list_spaces` |
+| Agent stops responding after switch | Space binding not propagated | Check `session.json` for the new `space_id`, then `ax gateway agents restart <agent>` |
+| "Not a member of space" error | Your user PAT doesn't have access to the target space | Ask admin to add you to the space |
+
+## Learning goal
+
+Understanding the space resolution cascade: how `session.json`, per-agent
+`allowed_spaces` cache, and upstream API work together when an operator
+changes spaces. See [Gateway Agent Runtimes — Space Resolution](../gateway-agent-runtimes.md#space-resolution).

--- a/docs/scenarios/move-agent-to-new-space.md
+++ b/docs/scenarios/move-agent-to-new-space.md
@@ -70,11 +70,11 @@ The message should appear in the inbox under the new space context.
 | Problem | Cause | Fix |
 | --- | --- | --- |
 | `active_space_name` shows a UUID | Space cache has UUID-as-name from upstream | Wait for cache refresh, or restart Gateway to force a fresh `list_spaces` |
-| Agent stops responding after switch | Space binding not propagated | Check `session.json` for the new `space_id`, then `ax gateway agents stop <agent> && ax gateway agents start <agent>` |
+| Agent stops responding after switch | Space binding not propagated | Check `ax gateway agents show <agent>` for the new `active_space_id`, then `ax gateway agents stop <agent> && ax gateway agents start <agent>` |
 | "Not a member of space" error | Your user PAT doesn't have access to the target space | Ask admin to add you to the space |
 
 ## Learning goal
 
-Understanding the space resolution cascade: how `session.json`, per-agent
-`allowed_spaces` cache, and upstream API work together when an operator
-changes spaces. See [Gateway Agent Runtimes — Space Resolution](../gateway-agent-runtimes.md#space-resolution).
+Understanding the space resolution cascade: how the registry agent row
+(`active_space_id`), per-agent `allowed_spaces` cache, and upstream API work
+together when an operator moves an agent. See [Gateway Agent Runtimes — Space Resolution](../gateway-agent-runtimes.md#space-resolution).

--- a/docs/scenarios/move-agent-to-new-space.md
+++ b/docs/scenarios/move-agent-to-new-space.md
@@ -30,14 +30,16 @@ ax spaces list
 
 Find the target space name or ID.
 
-### 3. Switch the agent's space
+### 3. Move the agent to the target space
 
 ```bash
-ax spaces use <target-space-name>
+ax gateway agents move dev-sentinel --space <target-space-id>
 ```
 
-This updates the active space in `session.json`. The reconcile loop (runs every
-~10 seconds) will pick up the change and rebind the agent.
+This calls `_move_managed_agent_space()`, which updates the agent's
+`active_space_id` in the registry and rebinds the runtime. Do not use
+`ax spaces use` — that only changes the CLI's active space, not the agent's
+Gateway binding.
 
 ### 4. Verify the switch
 
@@ -68,7 +70,7 @@ The message should appear in the inbox under the new space context.
 | Problem | Cause | Fix |
 | --- | --- | --- |
 | `active_space_name` shows a UUID | Space cache has UUID-as-name from upstream | Wait for cache refresh, or restart Gateway to force a fresh `list_spaces` |
-| Agent stops responding after switch | Space binding not propagated | Check `session.json` for the new `space_id`, then `ax gateway agents restart <agent>` |
+| Agent stops responding after switch | Space binding not propagated | Check `session.json` for the new `space_id`, then `ax gateway agents stop <agent> && ax gateway agents start <agent>` |
 | "Not a member of space" error | Your user PAT doesn't have access to the target space | Ask admin to add you to the space |
 
 ## Learning goal

--- a/docs/scenarios/recover-corrupted-registry.md
+++ b/docs/scenarios/recover-corrupted-registry.md
@@ -1,0 +1,156 @@
+# Scenario: Recover From a Corrupted Registry
+
+## Goal
+
+Restore Gateway to a working state after `registry.json` becomes corrupted or
+inconsistent.
+
+## Prerequisites
+
+- Gateway stopped or erroring on start
+- Access to the Gateway state directory (`~/.ax/gateway/`)
+
+## Steps
+
+### 1. Stop Gateway
+
+```bash
+ax gateway stop
+```
+
+If Gateway won't stop cleanly:
+
+```bash
+# Find the PID
+cat ~/.ax/gateway/gateway.pid
+
+# Kill it
+kill $(cat ~/.ax/gateway/gateway.pid)
+```
+
+### 2. Inspect the registry
+
+```bash
+cat ~/.ax/gateway/registry.json | python3 -m json.tool
+```
+
+If this fails with a JSON parse error, the file is corrupted (truncated write,
+disk full, etc.).
+
+Common corruption patterns:
+
+| Pattern | Cause | What you see |
+| --- | --- | --- |
+| Truncated JSON | Write interrupted (crash, disk full) | `Expecting ',' delimiter` parse error |
+| Missing agent entries | Concurrent writes from multiple processes | Agent registered but not in file |
+| Stale gateway block | Old space_id/space_name not migrated | UUID where a space name should be |
+| Duplicate agent entries | Bug in registration logic | Same agent name appears twice |
+
+### 3. Back up the corrupted file
+
+```bash
+cp ~/.ax/gateway/registry.json ~/.ax/gateway/registry.json.corrupted.$(date +%s)
+```
+
+### 4. Attempt auto-repair
+
+Start Gateway — it runs auto-migration and corruption repair on startup:
+
+```bash
+ax gateway start
+```
+
+Check the log for repair messages:
+
+```bash
+grep -i "repair\|migrate\|corrupt" ~/.ax/gateway/gateway.log | tail -10
+```
+
+### 5. If auto-repair fails: manual repair
+
+If the JSON is unparseable, you have two options:
+
+**Option A: Edit the JSON.** Fix the syntax error manually. Common fixes:
+- Add a missing closing `}` or `]`
+- Remove a trailing comma before `}`
+- Remove duplicate entries
+
+**Option B: Start fresh.** Remove the registry and re-register agents:
+
+```bash
+mv ~/.ax/gateway/registry.json ~/.ax/gateway/registry.json.backup.$(date +%s)
+ax gateway start
+```
+
+Then re-register each agent:
+
+```bash
+ax gateway agents add dev-sentinel --template hermes --workdir ~/agents/dev-sentinel
+ax gateway agents add echo-bot --template echo
+# ... repeat for each agent
+```
+
+### 6. Also check session.json
+
+```bash
+cat ~/.ax/gateway/session.json | python3 -m json.tool
+```
+
+If session.json is also corrupted, remove it — it contains only ephemeral
+runtime state (active spaces, session tokens) that will be rebuilt:
+
+```bash
+mv ~/.ax/gateway/session.json ~/.ax/gateway/session.json.backup.$(date +%s)
+```
+
+### 7. Verify recovery
+
+```bash
+ax gateway start
+ax gateway status
+ax gateway agents list
+```
+
+All agents should appear. Start any that aren't running:
+
+```bash
+ax gateway agents start dev-sentinel
+```
+
+Test message delivery:
+
+```bash
+ax send "recovery test" --to echo-bot --skip-ax
+```
+
+## Verify
+
+- Gateway starts without errors
+- `registry.json` is valid JSON
+- All expected agents appear in `agents list`
+- Message delivery works end-to-end
+
+## What can go wrong
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| Agent credentials lost | Token files in `~/.ax/gateway/agents/<name>/token` were deleted | Re-register the agent — Gateway will mint a new managed credential |
+| Agents have wrong space after recovery | `session.json` was rebuilt with default space | Re-run `ax spaces use <space>` to rebind |
+| Gateway starts but agents won't | Stale PID files in agent directories | Delete `~/.ax/gateway/agents/<name>/*.pid` |
+
+## Learning goal
+
+Understanding Gateway's state files and what each one stores:
+
+| File | Contents | Recreatable? |
+| --- | --- | --- |
+| `registry.json` | Agent registrations, templates, workdirs, credential refs | Only by re-registering agents |
+| `session.json` | Active spaces, session tokens, presence | Yes — rebuilt on start |
+| `agents/<name>/token` | Managed agent credentials | Only by re-minting |
+| `agents/<name>/pending.json` | Unread message queue | Lost messages are lost |
+| `gateway.pid` | Daemon process ID | Deleted on clean shutdown |
+| `gateway.log` | Daemon logs | Informational only |
+| `activity.jsonl` | Agent activity events | Informational only |
+
+See [ADR-004](../adr/ADR-004-space-state-in-session.md) for why space state
+lives in `session.json` and not `registry.json`.

--- a/docs/scenarios/recover-corrupted-registry.md
+++ b/docs/scenarios/recover-corrupted-registry.md
@@ -135,7 +135,7 @@ ax send "recovery test" --to echo-bot --skip-ax
 | Problem | Cause | Fix |
 | --- | --- | --- |
 | Agent credentials lost | Token files in `~/.ax/gateway/agents/<name>/token` were deleted | Re-register the agent — Gateway will mint a new managed credential |
-| Agents have wrong space after recovery | `session.json` was rebuilt with default space | Re-run `ax spaces use <space>` to rebind |
+| Agents have wrong space after recovery | `session.json` was rebuilt with default space | For each agent: `ax gateway agents move <agent> --space <space-id>` to rebind |
 | Gateway starts but agents won't | Stale PID files in agent directories | Delete `~/.ax/gateway/agents/<name>/*.pid` |
 
 ## Learning goal

--- a/docs/scenarios/rotate-agent-pat.md
+++ b/docs/scenarios/rotate-agent-pat.md
@@ -1,109 +1,124 @@
-# Rotate an Agent PAT
-
-Replace an agent's PAT without downtime by minting the new token first,
-verifying it works, then revoking the old one.
-
-> **Scope:** this page documents the current PAT-based rotation path for
-> existing agent credentials. Gateway's intended direction is OAuth/device
-> login plus Gateway-brokered credentials — normal onboarding should not
-> require operators or agents to copy PATs manually. See
-> [DEVICE-TRUST-001](../../specs/DEVICE-TRUST-001/spec.md) and
-> [GATEWAY-AUTH-TIERS-001](../../specs/GATEWAY-AUTH-TIERS-001/spec.md) for
-> the trust-boundary direction.
-
-Background: [`docs/credential-security.md`](../credential-security.md#agent-pat-rotation)
-and [`docs/agent-authentication.md`](../agent-authentication.md#rotation-with-existing-cli-commands)
-explain the policy. This page is the operator runbook.
+# Scenario: Rotate an Agent's PAT
 
 ## Goal
 
-Cut over `<agent>` to a fresh PAT with no failed requests in between. The
-old credential keeps working until the new one verifies; only then do you
-revoke it.
+Replace a managed agent's PAT credential with a fresh one, verify the
+replacement works, then revoke the old credential.
 
 ## Prerequisites
 
-- A user bootstrap login — `axctl auth whoami` returns your user, not the
-  agent.
-- The agent already exists and you know its name and audience (`cli`,
-  `mcp`, or `both`).
-- The agent's existing profile is already registered. If not, register it
-  first with `axctl profile add` so you have a baseline to compare against.
+- Gateway running and logged in (`ax gateway status` shows running)
+- Agent registered and working (`ax gateway agents show <agent>`)
+- User PAT with permission to mint and revoke credentials
 
 ## Steps
 
-1. **Inventory current credentials.**
+### 1. Inventory existing credentials
 
-   ```bash
-   axctl credentials list --json
-   axctl credentials audit
-   ```
+```bash
+axctl credentials list --json
+```
 
-   Note the `credential_id` of the PAT you intend to replace and confirm
-   the agent has exactly one active PAT today. In automation use
-   `axctl credentials audit --strict` to make policy violations fail loudly.
+Find the credential entry for your agent. Note the `credential_id` of the
+current active key.
 
-2. **Mint the replacement.** Match the audience and expiry of the old
-   token. Save to a separate directory so the old token file is untouched.
+### 2. Audit the key state
 
-   ```bash
-   axctl token mint <agent> \
-       --audience <cli|mcp|both> \
-       --expires <days> \
-       --save-to <new-token-dir> \
-       --profile <new-profile> \
-       --no-print-token
-   ```
+```bash
+axctl credentials audit
+```
 
-   `--save-to` takes a directory (typically the agent's `.ax/` directory,
-   e.g. `/home/agent/.ax`); the token file and `config.toml` are written
-   inside it. `--no-print-token` keeps the secret out of your shell
-   history. The token file is mode `0600`, and `<new-profile>` is
-   registered against it.
+**Expected:** One active key per agent. If you see two active keys for the same
+agent, clean up the stale key before proceeding — having more than two active
+PATs for one agent is a security hygiene issue.
 
-3. **Verify the new profile.**
+For stricter checking in automation:
 
-   ```bash
-   axctl profile verify <new-profile>
-   axctl auth whoami --json
-   ```
+```bash
+axctl credentials audit --strict
+```
 
-   `profile verify` re-checks the token fingerprint, hostname, and workdir
-   hash. `auth whoami` proves the new PAT actually exchanges for a JWT
-   end-to-end. Both must succeed before continuing.
+### 3. Mint a replacement PAT
 
-4. **Revoke the old credential.** Use the `credential_id` recorded in
-   step 1, not the new one.
+```bash
+axctl token mint <agent-name> \
+  --audience <cli|mcp|both> \
+  --expires 90 \
+  --save-to ~/.ax/gateway/agents/<agent-name>/token.new \
+  --profile <profile-name> \
+  --no-print-token
+```
 
-   ```bash
-   axctl credentials revoke <old-credential-id>
-   ```
+This creates a new agent-scoped PAT and saves it to a file. The
+`--no-print-token` flag keeps the raw token out of terminal history and logs.
 
-5. **Confirm cleanup.**
+**Expected:** Confirmation that the token was minted and saved.
 
-   ```bash
-   axctl credentials list --json
-   ```
+> **Important:** Do NOT revoke the old credential yet. You now have two active
+> PATs for this agent — this is acceptable only during the rotation window.
 
-   The old `credential_id` should now show `lifecycle_state: revoked`. The
-   agent should have exactly one active PAT — the replacement.
+### 4. Verify the new credential
+
+```bash
+axctl profile verify <profile-name>
+```
+
+Check that the new profile passes all three verifications (token SHA-256,
+hostname, workdir):
+
+```bash
+axctl auth whoami --json
+```
+
+**Expected:** The output shows the correct agent name and space.
+
+### 5. Test the agent with the new credential
+
+```bash
+ax send "rotation test" --to <agent-name> --skip-ax
+ax gateway agents inbox <agent-name>
+```
+
+Verify messages flow correctly using the new credential.
+
+### 6. Revoke the old credential
+
+Only after confirming the new credential works:
+
+```bash
+axctl credentials revoke <old-credential-id>
+```
+
+**Expected:** Confirmation that the old credential was revoked.
+
+### 7. Final audit
+
+```bash
+axctl credentials audit
+```
+
+**Expected:** Exactly one active key for the agent (the new one).
 
 ## Verify
 
-After the rotation:
-
-- `axctl credentials list` shows one active PAT for the agent.
-- `axctl credentials audit` reports no policy violations.
-- The agent's normal workflow (send / listen / mcp call, whatever it does
-  in production) succeeds with the new profile.
-- The old token file can be deleted.
+- `credentials audit` shows one active key per agent
+- Agent continues to process messages after the old key is revoked
+- No errors in `gateway.log` related to authentication
 
 ## What can go wrong
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| Agent fails right after step 4. | Revoked the old credential before the new one was actually serving traffic. | Re-run step 2 to mint another replacement, verify, then revoke. The originally-revoked id stays revoked. |
-| `credentials list` shows 3+ active PATs for the agent. | A previous rotation aborted between mint and revoke. | Stop. Identify each `credential_id`, decide which is current, and revoke the rest before issuing more. More than two active PATs per agent is a security hygiene issue. |
-| `profile verify` fails on the new profile. | Token file moved, host/workdir changed since `axctl token mint` ran, or the file was tampered with. | Inspect the token file inside `<new-token-dir>` (permissions and contents). If intentional (e.g. rotated to a new host), re-run `axctl profile add` from the new location. |
-| `auth whoami` returns the user, not the agent. | Wrong audience minted, or the new profile isn't active yet. | Check that step 2 used the same audience as the old PAT, and that `axctl profile use <new-profile>` (or the appropriate env vars) selected the agent profile. |
-| Honeypot / fingerprint alert fires during step 3. | The new token was used from a different machine or workspace than where it was minted. | Treat as a security event, not a rotation problem. See [`docs/credential-security.md`](../credential-security.md). |
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| Agent stops working after revoke | Revoked the new key instead of the old one | Mint another replacement immediately |
+| "Two active PATs" warning persists | Forgot to revoke the old key | Complete step 6 |
+| More than two active PATs | Multiple incomplete rotations | `credentials list --json` to identify and revoke all stale keys, keep only the newest |
+| Wrong audience on new token | Mismatched `--audience` flag | Revoke the bad token, re-mint with correct audience (`cli`, `mcp`, or `both`) |
+| Profile verification fails | Token file path or workdir mismatch | Re-run `ax profile add` to rebind the profile to the new token file |
+
+## Learning goal
+
+Understanding the credential rotation lifecycle: the safe order is always
+**mint → verify → test → revoke**. Never revoke first. A rotation is complete
+only when the replacement token works and the previous credential is revoked.
+See [Credential Security](../credential-security.md) for the full security
+model.

--- a/docs/scenarios/rotate-agent-pat.md
+++ b/docs/scenarios/rotate-agent-pat.md
@@ -1,124 +1,109 @@
-# Scenario: Rotate an Agent's PAT
+# Rotate an Agent PAT
+
+Replace an agent's PAT without downtime by minting the new token first,
+verifying it works, then revoking the old one.
+
+> **Scope:** this page documents the current PAT-based rotation path for
+> existing agent credentials. Gateway's intended direction is OAuth/device
+> login plus Gateway-brokered credentials — normal onboarding should not
+> require operators or agents to copy PATs manually. See
+> [DEVICE-TRUST-001](../../specs/DEVICE-TRUST-001/spec.md) and
+> [GATEWAY-AUTH-TIERS-001](../../specs/GATEWAY-AUTH-TIERS-001/spec.md) for
+> the trust-boundary direction.
+
+Background: [`docs/credential-security.md`](../credential-security.md#agent-pat-rotation)
+and [`docs/agent-authentication.md`](../agent-authentication.md#rotation-with-existing-cli-commands)
+explain the policy. This page is the operator runbook.
 
 ## Goal
 
-Replace a managed agent's PAT credential with a fresh one, verify the
-replacement works, then revoke the old credential.
+Cut over `<agent>` to a fresh PAT with no failed requests in between. The
+old credential keeps working until the new one verifies; only then do you
+revoke it.
 
 ## Prerequisites
 
-- Gateway running and logged in (`ax gateway status` shows running)
-- Agent registered and working (`ax gateway agents show <agent>`)
-- User PAT with permission to mint and revoke credentials
+- A user bootstrap login — `axctl auth whoami` returns your user, not the
+  agent.
+- The agent already exists and you know its name and audience (`cli`,
+  `mcp`, or `both`).
+- The agent's existing profile is already registered. If not, register it
+  first with `axctl profile add` so you have a baseline to compare against.
 
 ## Steps
 
-### 1. Inventory existing credentials
+1. **Inventory current credentials.**
 
-```bash
-axctl credentials list --json
-```
+   ```bash
+   axctl credentials list --json
+   axctl credentials audit
+   ```
 
-Find the credential entry for your agent. Note the `credential_id` of the
-current active key.
+   Note the `credential_id` of the PAT you intend to replace and confirm
+   the agent has exactly one active PAT today. In automation use
+   `axctl credentials audit --strict` to make policy violations fail loudly.
 
-### 2. Audit the key state
+2. **Mint the replacement.** Match the audience and expiry of the old
+   token. Save to a separate directory so the old token file is untouched.
 
-```bash
-axctl credentials audit
-```
+   ```bash
+   axctl token mint <agent> \
+       --audience <cli|mcp|both> \
+       --expires <days> \
+       --save-to <new-token-dir> \
+       --profile <new-profile> \
+       --no-print-token
+   ```
 
-**Expected:** One active key per agent. If you see two active keys for the same
-agent, clean up the stale key before proceeding — having more than two active
-PATs for one agent is a security hygiene issue.
+   `--save-to` takes a directory (typically the agent's `.ax/` directory,
+   e.g. `/home/agent/.ax`); the token file and `config.toml` are written
+   inside it. `--no-print-token` keeps the secret out of your shell
+   history. The token file is mode `0600`, and `<new-profile>` is
+   registered against it.
 
-For stricter checking in automation:
+3. **Verify the new profile.**
 
-```bash
-axctl credentials audit --strict
-```
+   ```bash
+   axctl profile verify <new-profile>
+   axctl auth whoami --json
+   ```
 
-### 3. Mint a replacement PAT
+   `profile verify` re-checks the token fingerprint, hostname, and workdir
+   hash. `auth whoami` proves the new PAT actually exchanges for a JWT
+   end-to-end. Both must succeed before continuing.
 
-```bash
-axctl token mint <agent-name> \
-  --audience <cli|mcp|both> \
-  --expires 90 \
-  --save-to ~/.ax/gateway/agents/<agent-name>/token.new \
-  --profile <profile-name> \
-  --no-print-token
-```
+4. **Revoke the old credential.** Use the `credential_id` recorded in
+   step 1, not the new one.
 
-This creates a new agent-scoped PAT and saves it to a file. The
-`--no-print-token` flag keeps the raw token out of terminal history and logs.
+   ```bash
+   axctl credentials revoke <old-credential-id>
+   ```
 
-**Expected:** Confirmation that the token was minted and saved.
+5. **Confirm cleanup.**
 
-> **Important:** Do NOT revoke the old credential yet. You now have two active
-> PATs for this agent — this is acceptable only during the rotation window.
+   ```bash
+   axctl credentials list --json
+   ```
 
-### 4. Verify the new credential
-
-```bash
-axctl profile verify <profile-name>
-```
-
-Check that the new profile passes all three verifications (token SHA-256,
-hostname, workdir):
-
-```bash
-axctl auth whoami --json
-```
-
-**Expected:** The output shows the correct agent name and space.
-
-### 5. Test the agent with the new credential
-
-```bash
-ax send "rotation test" --to <agent-name> --skip-ax
-ax gateway agents inbox <agent-name>
-```
-
-Verify messages flow correctly using the new credential.
-
-### 6. Revoke the old credential
-
-Only after confirming the new credential works:
-
-```bash
-axctl credentials revoke <old-credential-id>
-```
-
-**Expected:** Confirmation that the old credential was revoked.
-
-### 7. Final audit
-
-```bash
-axctl credentials audit
-```
-
-**Expected:** Exactly one active key for the agent (the new one).
+   The old `credential_id` should now show `lifecycle_state: revoked`. The
+   agent should have exactly one active PAT — the replacement.
 
 ## Verify
 
-- `credentials audit` shows one active key per agent
-- Agent continues to process messages after the old key is revoked
-- No errors in `gateway.log` related to authentication
+After the rotation:
+
+- `axctl credentials list` shows one active PAT for the agent.
+- `axctl credentials audit` reports no policy violations.
+- The agent's normal workflow (send / listen / mcp call, whatever it does
+  in production) succeeds with the new profile.
+- The old token file can be deleted.
 
 ## What can go wrong
 
-| Problem | Cause | Fix |
-| --- | --- | --- |
-| Agent stops working after revoke | Revoked the new key instead of the old one | Mint another replacement immediately |
-| "Two active PATs" warning persists | Forgot to revoke the old key | Complete step 6 |
-| More than two active PATs | Multiple incomplete rotations | `credentials list --json` to identify and revoke all stale keys, keep only the newest |
-| Wrong audience on new token | Mismatched `--audience` flag | Revoke the bad token, re-mint with correct audience (`cli`, `mcp`, or `both`) |
-| Profile verification fails | Token file path or workdir mismatch | Re-run `ax profile add` to rebind the profile to the new token file |
-
-## Learning goal
-
-Understanding the credential rotation lifecycle: the safe order is always
-**mint → verify → test → revoke**. Never revoke first. A rotation is complete
-only when the replacement token works and the previous credential is revoked.
-See [Credential Security](../credential-security.md) for the full security
-model.
+| Symptom | Cause | Fix |
+|---|---|---|
+| Agent fails right after step 4. | Revoked the old credential before the new one was actually serving traffic. | Re-run step 2 to mint another replacement, verify, then revoke. The originally-revoked id stays revoked. |
+| `credentials list` shows 3+ active PATs for the agent. | A previous rotation aborted between mint and revoke. | Stop. Identify each `credential_id`, decide which is current, and revoke the rest before issuing more. More than two active PATs per agent is a security hygiene issue. |
+| `profile verify` fails on the new profile. | Token file moved, host/workdir changed since `axctl token mint` ran, or the file was tampered with. | Inspect the token file inside `<new-token-dir>` (permissions and contents). If intentional (e.g. rotated to a new host), re-run `axctl profile add` from the new location. |
+| `auth whoami` returns the user, not the agent. | Wrong audience minted, or the new profile isn't active yet. | Check that step 2 used the same audience as the old PAT, and that `axctl profile use <new-profile>` (or the appropriate env vars) selected the agent profile. |
+| Honeypot / fingerprint alert fires during step 3. | The new token was used from a different machine or workspace than where it was minted. | Treat as a security event, not a rotation problem. See [`docs/credential-security.md`](../credential-security.md). |

--- a/docs/scenarios/send-file-through-gateway.md
+++ b/docs/scenarios/send-file-through-gateway.md
@@ -1,0 +1,63 @@
+# Scenario: Send a File Through Gateway
+
+## Goal
+
+Upload a file and send it as part of a message through the Gateway proxy.
+
+## Prerequisites
+
+- Gateway running and logged in
+- Agent registered, running, and bound to a space
+- The file exists locally and is readable
+
+## Steps
+
+### 1. Verify the agent can send messages
+
+```bash
+ax send "test" --to <recipient-agent> --skip-ax
+```
+
+If this works, the agent's session and space binding are healthy.
+
+### 2. Send a message with a file attachment
+
+```bash
+ax send "here is the report" --to <recipient-agent> --file ./report.pdf --skip-ax
+```
+
+The CLI uploads the file through Gateway and attaches it to the message.
+
+### 3. Verify delivery
+
+On the recipient side:
+
+```bash
+ax gateway agents inbox <recipient-agent>
+```
+
+The message should appear with a file attachment reference.
+
+## Verify
+
+- The message appears in the recipient's inbox
+- The file attachment is accessible
+- No credential leakage in logs (check `gateway.log` for raw token strings)
+
+## What can go wrong
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| `upload_file` rejected by proxy | `upload_file` is not in `_LOCAL_PROXY_METHODS` — it goes through a dedicated endpoint, not the generic proxy | Use the `--file` flag on `ax send` which routes through the correct endpoint |
+| "Method not on Gateway proxy allowlist" | Trying to call `upload_file` via `/local/proxy` directly | This is by design — `upload_file` without path restriction is a trust boundary violation for inbox agents. Use the dedicated send endpoint |
+| Large file timeout | File exceeds the default timeout | Check if `--timeout` flag is available, or upload separately and reference by ID |
+
+## Learning goal
+
+Understanding the trust boundary around file upload. `upload_file` is
+intentionally excluded from the generic proxy allowlist (`_LOCAL_PROXY_METHODS`)
+because granting it to all agents — including untrusted inbox agents — would
+let any local agent write arbitrary files through the operator's credentials.
+Trusted send operations go through the dedicated `/local/send` endpoint with
+additional validation. See [ADR-002](../adr/ADR-002-flat-proxy-allowlist.md)
+and [Agent Authentication — Trust Boundary](../agent-authentication.md#trust-boundary-model).

--- a/docs/scenarios/send-file-through-gateway.md
+++ b/docs/scenarios/send-file-through-gateway.md
@@ -50,7 +50,7 @@ The message should appear with a file attachment reference.
 | --- | --- | --- |
 | `upload_file` rejected by proxy | Agent doesn't have admin tier access — `upload_file` requires `tier: "admin"` in `_LOCAL_PROXY_METHODS` | Verify the agent's tier level; admin-tier proxy calls may require operator approval |
 | Upload path rejected | File path is outside the agent's configured workdir | Move the file into the agent's workdir, or update the agent's `--workdir` config |
-| Large file timeout | File exceeds the default timeout | Check if `--timeout` flag is available, or upload separately and reference by ID |
+| Large file timeout | File exceeds Gateway's upload timeout | Upload the file separately via the platform API and reference it by attachment ID in the message |
 
 ## Learning goal
 

--- a/docs/scenarios/send-file-through-gateway.md
+++ b/docs/scenarios/send-file-through-gateway.md
@@ -48,16 +48,16 @@ The message should appear with a file attachment reference.
 
 | Problem | Cause | Fix |
 | --- | --- | --- |
-| `upload_file` rejected by proxy | `upload_file` is not in `_LOCAL_PROXY_METHODS` — it goes through a dedicated endpoint, not the generic proxy | Use the `--file` flag on `ax send` which routes through the correct endpoint |
-| "Method not on Gateway proxy allowlist" | Trying to call `upload_file` via `/local/proxy` directly | This is by design — `upload_file` without path restriction is a trust boundary violation for inbox agents. Use the dedicated send endpoint |
+| `upload_file` rejected by proxy | Agent doesn't have admin tier access — `upload_file` requires `tier: "admin"` in `_LOCAL_PROXY_METHODS` | Verify the agent's tier level; admin-tier proxy calls may require operator approval |
+| Upload path rejected | File path is outside the agent's configured workdir | Move the file into the agent's workdir, or update the agent's `--workdir` config |
 | Large file timeout | File exceeds the default timeout | Check if `--timeout` flag is available, or upload separately and reference by ID |
 
 ## Learning goal
 
-Understanding the trust boundary around file upload. `upload_file` is
-intentionally excluded from the generic proxy allowlist (`_LOCAL_PROXY_METHODS`)
-because granting it to all agents — including untrusted inbox agents — would
-let any local agent write arbitrary files through the operator's credentials.
-Trusted send operations go through the dedicated `/local/send` endpoint with
-additional validation. See [ADR-002](../adr/ADR-002-flat-proxy-allowlist.md)
+Understanding the trust boundary around file upload. `upload_file` is in the
+proxy allowlist (`_LOCAL_PROXY_METHODS` at `commands/gateway.py:803`) but
+restricted to the `admin` tier and sandboxed to the agent's workdir (lines
+833–840). This prevents untrusted agents from writing arbitrary files through
+the operator's credentials while allowing trusted agents to upload from their
+own workspace. See [ADR-002](../adr/ADR-002-flat-proxy-allowlist.md)
 and [Agent Authentication — Trust Boundary](../agent-authentication.md#trust-boundary-model).

--- a/docs/scenarios/setup-second-agent-same-workspace.md
+++ b/docs/scenarios/setup-second-agent-same-workspace.md
@@ -1,0 +1,90 @@
+# Scenario: Set Up a Second Agent in the Same Workspace
+
+## Goal
+
+Register a second agent that shares a workspace directory with an existing
+agent, while maintaining distinct identities.
+
+## Prerequisites
+
+- Gateway running
+- First agent already registered and working in the target workspace directory
+- Understanding that workspace identity is directory-scoped, not repo-scoped
+
+## Steps
+
+### 1. Check existing agent in the workspace
+
+```bash
+cd /path/to/shared-workspace
+ax gateway agents show first-agent
+```
+
+Note the workdir and space binding.
+
+### 2. Register the second agent
+
+```bash
+ax gateway agents add second-agent \
+  --template pass_through \
+  --workdir /path/to/shared-workspace
+```
+
+Gateway creates a separate registry entry with its own managed credential,
+session tokens, and space binding — even though the workdir is the same.
+
+### 3. Start the second agent
+
+```bash
+ax gateway agents start second-agent
+```
+
+### 4. Verify identity isolation
+
+```bash
+ax gateway agents show first-agent --json | grep agent_id
+ax gateway agents show second-agent --json | grep agent_id
+```
+
+**Expected:** Different `agent_id` values. Each agent has its own identity on
+the platform.
+
+### 5. Test independent messaging
+
+```bash
+ax send "hello from test" --to first-agent --skip-ax
+ax send "hello from test" --to second-agent --skip-ax
+
+ax gateway agents inbox first-agent
+ax gateway agents inbox second-agent
+```
+
+Messages should route to the correct agent based on the `--to` target, not the
+shared workspace directory.
+
+## Verify
+
+- Both agents have distinct `agent_id` values
+- Messages route to the correct agent
+- Each agent has its own entry in `registry.json`
+- Each agent has its own credential in `~/.ax/gateway/agents/<name>/token`
+- The shared `.ax/config.toml` does not contain credentials for either agent
+  (credentials are brokered by Gateway, not written to workspace config)
+
+## What can go wrong
+
+| Problem | Cause | Fix |
+| --- | --- | --- |
+| Both agents share the same identity | `.ax/config.toml` in the workspace specifies a single `agent_name`/`agent_id` | Gateway-managed agents use registry identity, not workspace config. Verify with `agents show` |
+| Messages go to wrong agent | Agent name typo in `--to` flag | Double-check agent names with `ax gateway agents list` |
+| Second agent can't start | Port or process conflict | Different agents can run simultaneously — check `gateway.log` for specific error |
+| Credential confusion | Workspace config has a direct-token profile that shadows Gateway identity | Remove `token` from `.ax/config.toml` — let Gateway broker credentials per ADR-005 |
+
+## Learning goal
+
+Understanding workspace identity scoping. Gateway tracks agents by name in
+`registry.json`, not by workspace directory. Two agents can share a workdir
+because their credentials, sessions, and inbox queues are stored in Gateway's
+state directory (`~/.ax/gateway/agents/<name>/`), not in the workspace. The
+`.ax/config.toml` in the workspace is for CLI config resolution, not for
+credential storage. See [ADR-005](../adr/ADR-005-credentials-never-in-workspace.md).


### PR DESCRIPTION
## Summary

- Add 7 step-by-step scenario docs for common operator tasks:
  - Debug a stuck agent
  - Investigate a 429 storm
  - Move an agent to a new space
  - Recover a corrupted registry
  - Rotate an agent PAT
  - Send a file through Gateway
  - Set up a second agent in the same workspace

Cherry-picked from #144 (closed — scope too broad). These are standalone runbook-style guides with no cross-dependencies on other PRs.

## Validation

- [x] This is docs-only — no Python code changed
- [x] No token, profile, PAT, JWT, or agent identity behavior changed

## Test plan

- [ ] Spot-check CLI commands in scenarios against current `ax --help` output
- [ ] Verify scenario docs render correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)