### PR TITLE
feat(gateway): supervise Hermes plugin runtime

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -976,7 +976,7 @@ def _normalize_runtime_type(runtime_type: str) -> str:
         return str(runtime_type_definition(runtime_type)["id"])
     except KeyError as exc:
         raise ValueError(
-            "Unsupported runtime type. Use echo, exec, hermes_sentinel, sentinel_cli, claude_code_channel, or inbox."
+            "Unsupported runtime type. Use echo, exec, hermes_plugin, hermes_sentinel, sentinel_cli, claude_code_channel, or inbox."
         ) from exc
 
 
@@ -8080,7 +8080,7 @@ def add_agent(
     runtime_type: str = typer.Option(
         None,
         "--type",
-        help="Advanced/internal runtime backend: echo | exec | hermes_sentinel | sentinel_cli | claude_code_channel | inbox",
+        help="Advanced/internal runtime backend: echo | exec | hermes_plugin | hermes_sentinel | sentinel_cli | claude_code_channel | inbox",
     ),
     exec_cmd: str = typer.Option(None, "--exec", help="Advanced override for exec-based templates"),
     workdir: str = typer.Option(None, "--workdir", help="Advanced working directory override"),
@@ -8177,7 +8177,7 @@ def update_agent(
     runtime_type: str = typer.Option(
         None,
         "--type",
-        help="Advanced/internal runtime backend override: echo | exec | hermes_sentinel | sentinel_cli | claude_code_channel | inbox",
+        help="Advanced/internal runtime backend override: echo | exec | hermes_plugin | hermes_sentinel | sentinel_cli | claude_code_channel | inbox",
     ),
     exec_cmd: str = typer.Option(None, "--exec", help="Advanced override for exec-based templates"),
     workdir: str = typer.Option(None, "--workdir", help="Advanced working directory override"),

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1214,6 +1214,8 @@ def _register_managed_agent(
     model: str | None = None,
     system_prompt: str | None = None,
     timeout_seconds: int | None = None,
+    allow_all_users: bool = False,
+    allowed_users: str | None = None,
     start: bool = True,
 ) -> dict:
     name = name.strip()
@@ -1333,6 +1335,10 @@ def _register_managed_agent(
     }
     if normalized_system_prompt:
         entry_payload["system_prompt"] = normalized_system_prompt
+    if allow_all_users:
+        entry_payload["allow_all_users"] = True
+    if allowed_users and str(allowed_users).strip():
+        entry_payload["allowed_users"] = str(allowed_users).strip()
     if requires_approval:
         entry_payload["install_id"] = str(uuid.uuid4())
     entry = upsert_agent_entry(registry, entry_payload)
@@ -1613,6 +1619,8 @@ def _update_managed_agent(
     model: str | None = None,
     system_prompt: str | object = _UNSET,
     timeout_seconds: int | object = _UNSET,
+    allow_all_users: bool | object = _UNSET,
+    allowed_users: str | object = _UNSET,
     desired_state: str | None = None,
 ) -> dict:
     name = name.strip()
@@ -1706,6 +1714,17 @@ def _update_managed_agent(
     entry["runtime_type"] = runtime_effective
     entry["exec_command"] = exec_effective
     entry["workdir"] = workdir_effective
+    if allow_all_users is not _UNSET:
+        if allow_all_users:
+            entry["allow_all_users"] = True
+        else:
+            entry.pop("allow_all_users", None)
+    if allowed_users is not _UNSET:
+        allowed_clean = str(allowed_users or "").strip()
+        if allowed_clean:
+            entry["allowed_users"] = allowed_clean
+        else:
+            entry.pop("allowed_users", None)
     if template_effective_id == "ollama":
         entry["ollama_model"] = ollama_model_effective
     else:
@@ -8108,6 +8127,21 @@ def add_agent(
     timeout_seconds: int = typer.Option(
         None, "--timeout", "--timeout-seconds", help="Max seconds a runtime may process one message"
     ),
+    allow_all_users: bool = typer.Option(
+        False,
+        "--allow-all-users",
+        help=(
+            "Hermes plugin runtime only: open the agent to mentions from anyone in its space. "
+            "Sets AX_ALLOW_ALL_USERS=1 + GATEWAY_ALLOW_ALL_USERS=true in the scaffolded "
+            "HERMES_HOME/.env. Default-closed; without this (or --allowed-users) the agent "
+            "denies all incoming mentions."
+        ),
+    ),
+    allowed_users: str = typer.Option(
+        None,
+        "--allowed-users",
+        help="Hermes plugin runtime only: comma-separated agent/user names allowed to mention this agent.",
+    ),
     start: bool = typer.Option(True, "--start/--no-start", help="Desired running state after registration"),
     as_json: bool = JSON_OPTION,
 ):
@@ -8150,6 +8184,8 @@ def add_agent(
             model=model,
             system_prompt=resolved_prompt,
             timeout_seconds=timeout_seconds,
+            allow_all_users=allow_all_users,
+            allowed_users=allowed_users,
             start=start,
         )
     except (ValueError, LookupError) as exc:
@@ -8197,6 +8233,23 @@ def update_agent(
     timeout_seconds: int = typer.Option(
         None, "--timeout", "--timeout-seconds", help="Max seconds a runtime may process one message"
     ),
+    allow_all_users: bool = typer.Option(
+        None,
+        "--allow-all-users/--no-allow-all-users",
+        help=(
+            "Hermes plugin runtime only: open the agent to mentions from anyone in its space "
+            "(or close it back down). Sets AX_ALLOW_ALL_USERS / GATEWAY_ALLOW_ALL_USERS in "
+            "the scaffolded HERMES_HOME/.env on the next start."
+        ),
+    ),
+    allowed_users: str = typer.Option(
+        None,
+        "--allowed-users",
+        help=(
+            "Hermes plugin runtime only: comma-separated agent/user names allowed to mention this agent. "
+            "Pass an empty string to clear."
+        ),
+    ),
     desired_state: str = typer.Option(None, "--desired-state", help="running | stopped"),
     as_json: bool = JSON_OPTION,
 ):
@@ -8224,6 +8277,8 @@ def update_agent(
             model=model,
             system_prompt=resolved_prompt,
             timeout_seconds=timeout_seconds if timeout_seconds is not None else _UNSET,
+            allow_all_users=allow_all_users if allow_all_users is not None else _UNSET,
+            allowed_users=allowed_users if allowed_users is not None else _UNSET,
             desired_state=desired_state,
         )
     except (LookupError, ValueError) as exc:

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -426,6 +426,12 @@ def _template_operator_defaults(template_id: str | None, runtime_type: object) -
             "reply_mode": "interactive",
             "telemetry_level": "rich",
         },
+        "hermes_plugin": {
+            "placement": "hosted",
+            "activation": "persistent",
+            "reply_mode": "interactive",
+            "telemetry_level": "rich",
+        },
         "sentinel_cli": {
             "placement": "hosted",
             "activation": "persistent",
@@ -629,6 +635,7 @@ def _template_asset_defaults(template_id: str | None, runtime_type: object) -> d
             "constraints": [],
         },
         "hermes_sentinel": defaults_by_template["hermes"],
+        "hermes_plugin": defaults_by_template["hermes"],
         "sentinel_cli": defaults_by_template["sentinel_cli"],
         "inbox": defaults_by_template["inbox"],
     }
@@ -839,7 +846,7 @@ def _hermes_repo_candidates(entry: dict[str, Any] | None = None) -> list[Path]:
 def hermes_setup_status(entry: dict[str, Any]) -> dict[str, Any]:
     template_id = str(entry.get("template_id") or "").strip().lower()
     runtime_type = str(entry.get("runtime_type") or "").strip().lower()
-    if template_id != "hermes" and runtime_type != "hermes_sentinel":
+    if template_id != "hermes" and runtime_type not in {"hermes_sentinel", "hermes_plugin"}:
         return {"ready": True, "template_id": template_id}
 
     candidates = _hermes_repo_candidates(entry)
@@ -4059,6 +4066,22 @@ def _is_hermes_sentinel_runtime(runtime_type: object) -> bool:
     return str(runtime_type or "").strip().lower() in {"hermes_sentinel", "hermes_sdk"}
 
 
+def _is_hermes_plugin_runtime(runtime_type: object) -> bool:
+    return str(runtime_type or "").strip().lower() == "hermes_plugin"
+
+
+def _is_supervised_subprocess_runtime(runtime_type: object) -> bool:
+    """Runtimes Gateway supervises as a single long-running child process.
+
+    Both the legacy in-tree sentinel and the new Hermes plugin path fall
+    into this bucket: Gateway spawns the process, monitors liveness, and
+    tees stdout to a log file. The lifecycle helpers
+    (_start/_stop/_monitor) are runtime-specific; this predicate just lets
+    the shared start/stop scaffolding treat both the same.
+    """
+    return _is_hermes_sentinel_runtime(runtime_type) or _is_hermes_plugin_runtime(runtime_type)
+
+
 def _gateway_repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
@@ -4264,6 +4287,175 @@ def _build_hermes_sentinel_env(entry: dict[str, Any]) -> dict[str, str]:
     if env.get("PATH"):
         path_entries.append(env["PATH"])
     env["PATH"] = ":".join(path_entries)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Hermes plugin runtime (`runtime_type == "hermes_plugin"`)
+#
+# Gateway supervises a single long-running `hermes gateway run` process per
+# agent. The Hermes process discovers our aX platform plugin (linked into
+# HERMES_HOME/plugins/ax) and connects to aX over SSE; replies post via the
+# aX REST API. Gateway's job here is identity + supervision, not message
+# brokering. The bootstrap PAT never lives in the workspace — Gateway reads
+# the token from its owned token file at spawn time and exports it into the
+# child process's env only.
+# ---------------------------------------------------------------------------
+
+
+def _hermes_plugin_workdir(entry: dict[str, Any]) -> Path:
+    raw = str(entry.get("workdir") or "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path("/home/ax-agent/agents") / str(entry.get("name") or "agent")
+
+
+def _hermes_plugin_home(entry: dict[str, Any]) -> Path:
+    """Per-agent HERMES_HOME under the workdir. Workdir-as-home matches the
+    operator pattern that nova and ax-wiki already use, and keeps each
+    agent's memories/sessions/skills next to its workdir rather than under
+    a Gateway-owned location."""
+    configured = str(entry.get("hermes_home") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return _hermes_plugin_workdir(entry) / ".hermes"
+
+
+def _hermes_bin(entry: dict[str, Any]) -> str:
+    """Resolve the hermes CLI.
+
+    Order:
+        1. Explicit operator override on the agent entry (`hermes_bin`).
+        2. ``HERMES_BIN`` env var on the Gateway process.
+        3. ``<HERMES_REPO_PATH>/.venv/bin/hermes`` if a repo path is configured.
+        4. ``~/hermes-agent/.venv/bin/hermes`` (the documented dev default).
+        5. ``hermes`` on $PATH (raises ``RuntimeError`` if not present).
+    """
+    configured = str(entry.get("hermes_bin") or "").strip()
+    if configured:
+        return configured
+    env_override = os.environ.get("HERMES_BIN", "").strip()
+    if env_override:
+        return env_override
+    hermes_repo = str(entry.get("hermes_repo_path") or "").strip()
+    if hermes_repo:
+        candidate = Path(hermes_repo).expanduser() / ".venv" / "bin" / "hermes"
+        if candidate.exists():
+            return str(candidate)
+    default = Path.home() / "hermes-agent" / ".venv" / "bin" / "hermes"
+    if default.exists():
+        return str(default)
+    found = shutil.which("hermes")
+    if found:
+        return found
+    raise RuntimeError(
+        "hermes CLI not found. Install hermes-agent, set HERMES_BIN, or set hermes_bin on the agent entry."
+    )
+
+
+def _plugin_source_dir() -> Path:
+    return _gateway_repo_root() / "plugins" / "platforms" / "ax"
+
+
+def _scaffold_hermes_plugin_home(entry: dict[str, Any]) -> Path:
+    """Make HERMES_HOME ready for ``hermes gateway run`` without writing
+    secrets to disk.
+
+    Idempotent. Creates the directory, links the aX platform plugin into
+    ``$HERMES_HOME/plugins/ax``, writes a non-secret ``.env`` with the
+    agent's identity, and (if missing) links the host's ``~/.hermes/auth.json``
+    and ``~/.hermes/config.yaml`` so the agent inherits the operator's
+    provider credentials. Operators who want per-agent provider creds can
+    delete the symlinks and provision their own files.
+    """
+    workdir = _hermes_plugin_workdir(entry)
+    workdir.mkdir(parents=True, exist_ok=True)
+    home = _hermes_plugin_home(entry)
+    home.mkdir(parents=True, exist_ok=True)
+    plugins_dir = home / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    plugin_link = plugins_dir / "ax"
+    plugin_source = _plugin_source_dir()
+    if not plugin_link.exists() and not plugin_link.is_symlink():
+        try:
+            plugin_link.symlink_to(plugin_source)
+        except OSError:
+            # Some filesystems disallow symlinks; fall back to a marker file
+            # so the operator gets a clear "go link this yourself" signal.
+            (plugins_dir / "ax.MISSING").write_text(
+                f"Could not symlink {plugin_source} → {plugin_link}. "
+                f"Link manually so `hermes plugins list` shows ax-platform.\n",
+                encoding="utf-8",
+            )
+    elif plugin_link.is_symlink():
+        # Refresh the symlink if it points at a stale source (e.g. repo moved).
+        try:
+            current_target = plugin_link.resolve()
+        except OSError:
+            current_target = None
+        if current_target != plugin_source.resolve():
+            try:
+                plugin_link.unlink()
+                plugin_link.symlink_to(plugin_source)
+            except OSError:
+                pass
+    # Non-secret identity .env so `hermes gateway run` can come up
+    # standalone (without Gateway env injection) for debugging. AX_TOKEN
+    # is deliberately omitted — it is injected via subprocess env only.
+    env_lines = [
+        "# Managed by ax gateway. Identity only; never AX_TOKEN.",
+        "# Gateway injects AX_TOKEN into the subprocess env from",
+        "# ~/.ax/gateway/agents/<name>/token (mode 600) at spawn time.",
+        f"AX_AGENT_NAME={entry.get('name') or ''}",
+        f"AX_AGENT_ID={entry.get('agent_id') or ''}",
+        f"AX_SPACE_ID={entry.get('space_id') or ''}",
+        f"AX_BASE_URL={entry.get('base_url') or 'https://paxai.app'}",
+        f"AX_HOME_CHANNEL={entry.get('home_channel_id') or entry.get('space_id') or ''}",
+    ]
+    (home / ".env").write_text("\n".join(env_lines) + "\n", encoding="utf-8")
+    # Inherit provider creds from the operator's ~/.hermes/ unless the
+    # agent already has its own. Symlink, don't copy, so rotation in one
+    # place propagates everywhere.
+    operator_home = Path.home() / ".hermes"
+    for inherit in ("auth.json", "config.yaml"):
+        source = operator_home / inherit
+        target = home / inherit
+        if target.exists() or target.is_symlink():
+            continue
+        if not source.exists():
+            continue
+        try:
+            target.symlink_to(source)
+        except OSError:
+            pass
+    return home
+
+
+def _build_hermes_plugin_cmd(entry: dict[str, Any]) -> list[str]:
+    return [_hermes_bin(entry), "gateway", "run"]
+
+
+def _build_hermes_plugin_env(entry: dict[str, Any]) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in ENV_DENYLIST}
+    token = load_gateway_managed_agent_token(entry)
+    home = _hermes_plugin_home(entry)
+    env.update(
+        {
+            "AX_TOKEN": token,
+            "AX_BASE_URL": str(entry.get("base_url") or "https://paxai.app"),
+            "AX_AGENT_NAME": str(entry.get("name") or ""),
+            "AX_AGENT_ID": str(entry.get("agent_id") or ""),
+            "AX_SPACE_ID": str(entry.get("space_id") or ""),
+            "AX_HOME_CHANNEL": str(entry.get("home_channel_id") or entry.get("space_id") or ""),
+            "HERMES_HOME": str(home),
+        }
+    )
+    # Local Gateway URL so the adapter can post external-runtime announcements
+    # for roster activity (best-effort; the adapter silently no-ops if Gateway
+    # isn't reachable).
+    gateway_url = os.environ.get("AX_LOCAL_GATEWAY_URL") or os.environ.get("AX_GATEWAY_UI_URL")
+    if gateway_url:
+        env["AX_LOCAL_GATEWAY_URL"] = gateway_url
     return env
 
 
@@ -4617,7 +4809,7 @@ class ManagedAgentRuntime:
     def start(self) -> None:
         runtime_type = str(self.entry.get("runtime_type") or "").lower()
         if (
-            _is_hermes_sentinel_runtime(runtime_type)
+            _is_supervised_subprocess_runtime(runtime_type)
             and self._supervised_process is not None
             and self._supervised_process.poll() is None
         ):
@@ -4663,6 +4855,9 @@ class ManagedAgentRuntime:
         )
         if _is_hermes_sentinel_runtime(runtime_type):
             self._start_hermes_sentinel_process(runtime_instance_id=runtime_instance_id)
+            return
+        if _is_hermes_plugin_runtime(runtime_type):
+            self._start_hermes_plugin_process(runtime_instance_id=runtime_instance_id)
             return
         self._worker_thread = None
         if not _is_passive_runtime(self.entry.get("runtime_type")):
@@ -4983,6 +5178,10 @@ class ManagedAgentRuntime:
             return
 
     def _stop_hermes_sentinel_process(self, *, timeout: float = 5.0) -> None:
+        # Despite the name, this stop path is runtime-agnostic: it just SIGTERMs
+        # self._supervised_process. Both hermes_sentinel and hermes_plugin land
+        # here from stop(). The function early-returns when there is no
+        # supervised child, so it is safe to call for any runtime type.
         process = self._supervised_process
         self._supervised_process = None
         if process is None or process.poll() is not None:
@@ -5004,6 +5203,144 @@ class ManagedAgentRuntime:
                 process.wait(timeout=timeout)
             except Exception:
                 pass
+
+    # ----- hermes_plugin runtime (Gateway-supervised `hermes gateway run`) -----
+
+    def _hermes_plugin_log_path(self) -> Path:
+        configured = str(self.entry.get("log_path") or "").strip()
+        if configured:
+            return Path(configured).expanduser()
+        return _hermes_plugin_workdir(self.entry) / "gateway-hermes-plugin.log"
+
+    def _start_hermes_plugin_process(self, *, runtime_instance_id: str) -> None:
+        try:
+            hermes_bin_path = _hermes_bin(self.entry)
+        except RuntimeError as exc:
+            self._record_supervised_setup_error(str(exc))
+            return
+        try:
+            load_gateway_managed_agent_token(self.entry)
+        except ValueError as exc:
+            self._record_supervised_setup_error(str(exc))
+            return
+        try:
+            home = _scaffold_hermes_plugin_home(self.entry)
+        except OSError as exc:
+            self._record_supervised_setup_error(
+                f"Failed to scaffold HERMES_HOME ({_hermes_plugin_home(self.entry)}): {exc}"
+            )
+            return
+
+        workdir = _hermes_plugin_workdir(self.entry)
+        log_path = self._hermes_plugin_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        cmd = _build_hermes_plugin_cmd(self.entry)
+        env = _build_hermes_plugin_env(self.entry)
+        try:
+            log_handle = log_path.open("a", encoding="utf-8")
+            log_handle.write(
+                f"\n[{_now_iso()}] Gateway starting Hermes plugin: "
+                f"{shlex.quote(hermes_bin_path)} gateway run "
+                f"(HERMES_HOME={home}, AX_AGENT_NAME={env.get('AX_AGENT_NAME')})\n"
+            )
+            log_handle.flush()
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                cwd=str(workdir),
+                env=env,
+                start_new_session=True,
+            )
+            self._sentinel_log_handle = log_handle
+            # Reuse the sentinel stdout consumer's tee-to-log behavior. The
+            # plugin doesn't emit AX_GATEWAY_EVENT lines (it posts activity
+            # directly to aX via the platform adapter), so the parser stays
+            # silent and only the log-tee side fires. If the plugin ever
+            # starts emitting those events, no change needed here.
+            self._sentinel_stdout_thread = threading.Thread(
+                target=self._consume_sentinel_stdout,
+                args=(process, log_handle),
+                daemon=True,
+                name=f"gw-hermes-plugin-stdout-{self.name}",
+            )
+            self._sentinel_stdout_thread.start()
+        except Exception as exc:
+            self._record_supervised_setup_error(f"Failed to start Hermes plugin: {str(exc)[:360]}")
+            return
+
+        self._supervised_process = process
+        self._update_state(
+            effective_state="running",
+            current_status=None,
+            current_activity="Hermes plugin runtime running",
+            current_tool=None,
+            current_tool_call_id=None,
+            last_error=None,
+            last_runtime_error_at=None,
+            last_connected_at=_now_iso(),
+            last_seen_at=_now_iso(),
+            reconnect_backoff_seconds=0,
+        )
+        self.entry["last_runtime_error_at"] = None
+        record_gateway_activity(
+            "runtime_started",
+            entry=self.entry,
+            runtime_instance_id=runtime_instance_id,
+            pid=process.pid,
+            log_path=str(log_path),
+            supervised_runtime="hermes_plugin",
+        )
+        self._supervised_thread = threading.Thread(
+            target=self._monitor_hermes_plugin_process,
+            daemon=True,
+            name=f"gw-hermes-plugin-{self.name}",
+        )
+        self._supervised_thread.start()
+        self._log(f"started hermes_plugin pid={process.pid}")
+
+    def _monitor_hermes_plugin_process(self) -> None:
+        process = self._supervised_process
+        if process is None:
+            return
+        while not self.stop_event.wait(timeout=5.0):
+            returncode = process.poll()
+            if returncode is None:
+                self._update_state(effective_state="running", last_seen_at=_now_iso(), last_error=None)
+                continue
+            status = "stopped" if returncode == 0 else "error"
+            error = None if returncode == 0 else f"Hermes plugin exited with code {returncode}"
+            self._update_state(
+                effective_state=status,
+                current_status=None if returncode == 0 else "error",
+                current_activity=None if returncode == 0 else error,
+                current_tool=None,
+                current_tool_call_id=None,
+                last_error=error,
+                last_seen_at=_now_iso(),
+            )
+            record_gateway_activity(
+                "runtime_exited",
+                entry=self.entry,
+                pid=process.pid,
+                exit_code=returncode,
+                error=error,
+            )
+            return
+
+    def _record_supervised_setup_error(self, error: str) -> None:
+        """Shared error path for supervised-subprocess runtimes."""
+        self._update_state(
+            effective_state="error",
+            current_status="error",
+            current_activity=error,
+            last_error=error,
+            last_runtime_error_at=_now_iso(),
+        )
+        self.entry["last_runtime_error_at"] = self._state.get("last_runtime_error_at")
+        record_gateway_activity("runtime_error", entry=self.entry, error=error)
 
     def _publish_processing_status(
         self,

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -846,7 +846,16 @@ def _hermes_repo_candidates(entry: dict[str, Any] | None = None) -> list[Path]:
 def hermes_setup_status(entry: dict[str, Any]) -> dict[str, Any]:
     template_id = str(entry.get("template_id") or "").strip().lower()
     runtime_type = str(entry.get("runtime_type") or "").strip().lower()
-    if template_id != "hermes" and runtime_type not in {"hermes_sentinel", "hermes_plugin"}:
+    # hermes_plugin invokes `hermes gateway run` resolved via _hermes_bin
+    # (entry override / HERMES_BIN / $PATH / fallback) and loads the aX
+    # platform plugin from this repo, so it has no hermes-agent checkout
+    # dependency and must short-circuit the gate — even when template_id
+    # is "hermes" (the plugin is now the default template runtime).
+    if runtime_type == "hermes_plugin":
+        return {"ready": True, "template_id": template_id}
+    # hermes_sentinel and bare hermes-template entries still run from the
+    # in-tree sentinel and need a hermes-agent checkout resolvable below.
+    if template_id != "hermes" and runtime_type != "hermes_sentinel":
         return {"ready": True, "template_id": template_id}
 
     candidates = _hermes_repo_candidates(entry)
@@ -4426,22 +4435,74 @@ def _scaffold_hermes_plugin_home(entry: dict[str, Any]) -> Path:
     if allowed:
         env_lines.append(f"AX_ALLOWED_USERS={allowed}")
     (home / ".env").write_text("\n".join(env_lines) + "\n", encoding="utf-8")
-    # Inherit provider creds from the operator's ~/.hermes/ unless the
-    # agent already has its own. Symlink, don't copy, so rotation in one
-    # place propagates everywhere.
+    # Inherit provider creds from the operator's ~/.hermes/auth.json. This
+    # is a symlink so credential rotation propagates without re-scaffolding.
     operator_home = Path.home() / ".hermes"
-    for inherit in ("auth.json", "config.yaml"):
-        source = operator_home / inherit
-        target = home / inherit
-        if target.exists() or target.is_symlink():
-            continue
-        if not source.exists():
-            continue
+    auth_source = operator_home / "auth.json"
+    auth_target = home / "auth.json"
+    if not (auth_target.exists() or auth_target.is_symlink()) and auth_source.exists():
         try:
-            target.symlink_to(source)
+            auth_target.symlink_to(auth_source)
         except OSError:
             pass
+    # Render a per-agent config.yaml with terminal.cwd pinned to this
+    # agent's workdir. Symlinking the operator's config.yaml verbatim
+    # leaked terminal.cwd (e.g. another agent's path) through the
+    # `hermes gateway run` bridge in gateway/run.py, which writes
+    # TERMINAL_CWD from config.yaml regardless of what the per-agent
+    # .env sets — and the LLM then mis-identifies itself from the
+    # workdir name in its system prompt. The render starts from the
+    # operator's config (so model/provider/agent defaults still apply)
+    # and is regenerated on every scaffold call, which means rotating
+    # those defaults still propagates the next time the runtime starts.
+    _render_hermes_plugin_config_yaml(entry, home=home, operator_home=operator_home)
     return home
+
+
+def _render_hermes_plugin_config_yaml(entry: dict[str, Any], *, home: Path, operator_home: Path) -> None:
+    """Write ``$HERMES_HOME/config.yaml`` with ``terminal.cwd`` pinned to the
+    agent's workdir, seeded from the operator's ``~/.hermes/config.yaml``.
+
+    Writes via a temp file + atomic replace so a partial write can't leave
+    Hermes booting against a half-yaml. Any non-mapping ``terminal`` value
+    in the operator config is replaced with a fresh mapping so we never
+    silently keep a bogus structure.
+    """
+    workdir = _hermes_plugin_workdir(entry)
+    target = home / "config.yaml"
+    operator_config = operator_home / "config.yaml"
+    cfg: dict[str, Any] = {}
+    if operator_config.exists():
+        try:
+            import yaml  # local import keeps gateway import cost down for non-Hermes paths
+
+            loaded = yaml.safe_load(operator_config.read_text(encoding="utf-8"))
+        except Exception:
+            loaded = None
+        if isinstance(loaded, dict):
+            cfg = loaded
+    terminal_cfg = cfg.get("terminal")
+    if not isinstance(terminal_cfg, dict):
+        terminal_cfg = {}
+    terminal_cfg["cwd"] = str(workdir)
+    cfg["terminal"] = terminal_cfg
+    try:
+        import yaml
+
+        rendered = yaml.safe_dump(cfg, sort_keys=False)
+    except Exception:
+        # Last-resort minimal config so the agent can still come up with a
+        # correct terminal.cwd even if the operator config is unreadable.
+        rendered = f"terminal:\n  cwd: {workdir}\n"
+    # Replace any stale symlink from earlier scaffolds before writing.
+    if target.is_symlink():
+        try:
+            target.unlink()
+        except OSError:
+            pass
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(rendered, encoding="utf-8")
+    os.replace(tmp, target)
 
 
 def _build_hermes_plugin_cmd(entry: dict[str, Any]) -> list[str]:

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -4412,6 +4412,19 @@ def _scaffold_hermes_plugin_home(entry: dict[str, Any]) -> Path:
         f"AX_BASE_URL={entry.get('base_url') or 'https://paxai.app'}",
         f"AX_HOME_CHANNEL={entry.get('home_channel_id') or entry.get('space_id') or ''}",
     ]
+    # Allowlist controls. Two independent layers:
+    #   - AX_ALLOWED_USERS / AX_ALLOW_ALL_USERS: plugin-side filter on who
+    #     can @-mention this agent (adapter checks the sender's name).
+    #   - GATEWAY_ALLOW_ALL_USERS: hermes-side gate; without it, hermes
+    #     refuses to dispatch any request when no platform allowlist is set.
+    # Operators opt in by setting `entry["allow_all_users"] = True` (e.g. via
+    # `ax gateway agents add/update --allow-all-users`). Default-closed.
+    if entry.get("allow_all_users"):
+        env_lines.append("AX_ALLOW_ALL_USERS=1")
+        env_lines.append("GATEWAY_ALLOW_ALL_USERS=true")
+    allowed = str(entry.get("allowed_users") or "").strip()
+    if allowed:
+        env_lines.append(f"AX_ALLOWED_USERS={allowed}")
     (home / ".env").write_text("\n".join(env_lines) + "\n", encoding="utf-8")
     # Inherit provider creds from the operator's ~/.hermes/ unless the
     # agent already has its own. Symlink, don't copy, so rotation in one
@@ -6286,8 +6299,17 @@ class GatewayDaemon:
         )
         space_status = _normalized_optional_controlled(entry.get("space_status"), _CONTROLLED_SPACE_STATUSES)
         runtime = self._runtimes.get(name)
+        runtime_type_lower = str(entry.get("runtime_type") or "").strip().lower()
         external_runtime_state = str(entry.get("external_runtime_state") or "").strip().lower()
-        if external_runtime_state or _external_runtime_expected(entry):
+        # The external-runtime branch is for plugin agents the operator runs
+        # themselves (manual `hermes gateway run`). When Gateway is the
+        # supervisor — runtime_type is hermes_plugin — Gateway owns the
+        # process lifecycle and any external-runtime hints on the entry are
+        # leftover announcement state from an earlier hand-launched run.
+        # Skip the external branch so we reach the supervised-subprocess path.
+        if (external_runtime_state or _external_runtime_expected(entry)) and not _is_hermes_plugin_runtime(
+            runtime_type_lower
+        ):
             if runtime is not None:
                 runtime.stop()
                 self._runtimes.pop(name, None)

--- a/ax_cli/gateway_runtime_types.py
+++ b/ax_cli/gateway_runtime_types.py
@@ -101,13 +101,16 @@ def runtime_type_catalog() -> dict[str, dict[str, Any]]:
         },
         "hermes_sentinel": {
             "id": "hermes_sentinel",
-            "label": "Hermes Sentinel",
+            "label": "Hermes Sentinel (legacy)",
             "description": (
-                "Gateway-supervised long-running Hermes sentinel using the original "
-                "claude_agent_v2.py listener semantics."
+                "Legacy Gateway-supervised Hermes sentinel using the in-tree "
+                "claude_agent_v2.py listener semantics. New agents should use "
+                "hermes_plugin instead — this runtime is kept only so existing "
+                "entries continue to work until they are explicitly migrated."
             ),
             "kind": "supervised_process",
             "passive": False,
+            "deprecated": True,
             "requires": [],
             "form_fields": [
                 {
@@ -125,10 +128,10 @@ def runtime_type_catalog() -> dict[str, dict[str, Any]]:
             ],
             "examples": [
                 {
-                    "label": "Hermes dev sentinel",
+                    "label": "Hermes dev sentinel (legacy)",
                     "runtime_type": "hermes_sentinel",
                     "workdir": "/home/ax-agent/agents/dev_sentinel",
-                    "note": "Gateway starts the old listener once and monitors it; Hermes owns session continuity.",
+                    "note": "Legacy in-tree listener. Prefer hermes_plugin for new agents.",
                 },
             ],
             "signals": {
@@ -138,6 +141,50 @@ def runtime_type_catalog() -> dict[str, dict[str, Any]]:
                     "and tool activity signals as the pre-Gateway setup."
                 ),
                 "tools": "Tool telemetry comes from claude_agent_v2.py/Hermes callbacks, not a one-shot bridge.",
+            },
+        },
+        "hermes_plugin": {
+            "id": "hermes_plugin",
+            "label": "Hermes Plugin",
+            "description": (
+                "Gateway-supervised long-running Hermes process using the native "
+                "aX platform plugin at plugins/platforms/ax/. Gateway scaffolds the "
+                "agent's HERMES_HOME (plugin symlink + non-secret identity .env) "
+                "and spawns `hermes gateway run`; AX_TOKEN is injected at start from "
+                "the Gateway-owned token file and is never written to the workspace."
+            ),
+            "kind": "supervised_process",
+            "passive": False,
+            "requires": [],
+            "form_fields": [
+                {
+                    "name": "workdir",
+                    "label": "Workdir",
+                    "required": True,
+                    "placeholder": "/Users/jacob/claude_home/ax-wiki",
+                },
+            ],
+            "examples": [
+                {
+                    "label": "Wiki agent (Hermes plugin)",
+                    "runtime_type": "hermes_plugin",
+                    "workdir": "/Users/jacob/claude_home/ax-wiki",
+                    "note": (
+                        "Gateway launches `hermes gateway run` against HERMES_HOME=<workdir>/.hermes; "
+                        "the plugin connects to aX over SSE and replies via REST."
+                    ),
+                },
+            ],
+            "signals": {
+                **_shared_signals(),
+                "activity": (
+                    "Gateway reports process liveness; the plugin streams progress/tool events "
+                    "onto the original mention's activity stream so chat stays final-only."
+                ),
+                "tools": (
+                    "Tool telemetry comes from Hermes platform callbacks via the aX adapter "
+                    "(plugins/platforms/ax/adapter.py)."
+                ),
             },
         },
         "sentinel_cli": {
@@ -237,7 +284,7 @@ def runtime_type_definition(runtime_type: str) -> dict[str, Any]:
 
 def runtime_type_list() -> list[dict[str, Any]]:
     catalog = runtime_type_catalog()
-    ordered_ids = ["echo", "exec", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox"]
+    ordered_ids = ["echo", "exec", "hermes_plugin", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox"]
     return [catalog[runtime_id] for runtime_id in ordered_ids if runtime_id in catalog]
 
 
@@ -246,7 +293,7 @@ def agent_template_catalog() -> dict[str, dict[str, Any]]:
     skill_path = _gateway_setup_skill_path()
     runtime_signals = {
         key: runtime_type_definition(key)["signals"]
-        for key in ("echo", "exec", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox")
+        for key in ("echo", "exec", "hermes_plugin", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox")
     }
     return {
         "echo_test": {
@@ -374,32 +421,36 @@ def agent_template_catalog() -> dict[str, dict[str, Any]]:
         },
         "hermes": {
             "id": "hermes",
-            "label": "Hermes Sentinel",
-            "description": "Long-running Hermes coding sentinel managed by Gateway.",
+            "label": "Hermes",
+            "description": (
+                "Long-running Hermes agent managed by Gateway via the native aX "
+                "platform plugin (plugins/platforms/ax/). Gateway scaffolds "
+                "HERMES_HOME and supervises `hermes gateway run`."
+            ),
             "availability": "ready",
             "launchable": True,
-            "runtime_type": "hermes_sentinel",
+            "runtime_type": "hermes_plugin",
             "asset_class": "interactive_agent",
             "intake_model": "live_listener",
             "trigger_sources": ["direct_message"],
             "return_paths": ["inline_reply"],
             "telemetry_shape": "rich",
             "suggested_name": "hermes-bot",
-            "operator_summary": "Best path for a capable coding agent with continuity and rich progress.",
+            "operator_summary": "Best path for a capable Hermes-backed agent with continuity and rich progress, via the supported plugin path.",
             "recommended_test_message": "Remember the word cobalt, reply briefly, then I will ask you what word I gave you.",
             "what_you_need": [
-                "A local hermes-agent checkout, usually at ~/hermes-agent or via HERMES_REPO_PATH.",
-                "Hermes auth or model credentials such as ~/.hermes/auth.json or provider env vars.",
+                "A local hermes-agent install (hermes CLI on PATH, or HERMES_BIN env var, or ~/hermes-agent/.venv/bin/hermes).",
+                "Hermes provider credentials in ~/.hermes/auth.json (Gateway will symlink to <workdir>/.hermes if not already present).",
             ],
             "setup_skill": "gateway-agent-setup",
             "setup_skill_path": str(skill_path),
             "defaults": {
-                "runtime_type": "hermes_sentinel",
+                "runtime_type": "hermes_plugin",
                 "workdir": str(repo_root),
             },
-            "signals": runtime_signals["hermes_sentinel"],
+            "signals": runtime_signals["hermes_plugin"],
             "advanced": {
-                "adapter_label": "Gateway-supervised Hermes listener",
+                "adapter_label": "Gateway-supervised Hermes plugin",
                 "supports_command_override": False,
             },
         },

--- a/docs/SETUP-HERMES.md
+++ b/docs/SETUP-HERMES.md
@@ -136,8 +136,32 @@ approvals:
 
 ## Run
 
-Always launch from the agent's workdir so the process inherits the
-right cwd even if `terminal.cwd` is wrong:
+Two paths, pick one:
+
+### Gateway-supervised (preferred)
+
+Register the agent with the `hermes` template and let Gateway own the
+lifecycle. Gateway scaffolds `<workdir>/.hermes` (plugin symlink + non-secret
+identity `.env`), spawns `hermes gateway run`, and injects `AX_TOKEN` from
+the Gateway-owned token file at process start so the raw PAT never lives
+in the workspace.
+
+```bash
+ax gateway agents add @wiki-bot \
+  --template hermes \
+  --space <space-id-or-slug> \
+  --workdir ~/hermes-agents/wiki-bot
+ax gateway agents start @wiki-bot
+```
+
+`ax gateway agents stop @wiki-bot` shuts down the supervised hermes
+process cleanly. Gateway's runtime row shows liveness; the Hermes-side
+plugin posts activity/replies directly to aX.
+
+### Manual (for development / debugging the plugin itself)
+
+Launch `hermes gateway run` yourself from the agent's workdir. Useful
+when you are iterating on the adapter or want to attach a debugger:
 
 ```bash
 cd ~/hermes-agents/nova
@@ -182,7 +206,7 @@ Use one short live pass before calling a setup good:
 | Default working area | `terminal.cwd` + launch from workdir | **Soft.** Bash defaults to the workdir; `pwd` returns it. Absolute paths still work. |
 | Dangerous-command gate | `approvals.mode: on` (default) | **Real boundary.** Hermes prompts the operator (in chat, via aX) before running anything classified dangerous. See `~/hermes-agent/SECURITY.md` §2. |
 | Output redaction | `agent/redact.py` | API keys / tokens are scrubbed before reaching display layer. |
-| Per-agent home dir | `HERMES_HOME` set per agent (Gateway path) | Hermes memory/sessions don't cross agents on the same host. |
+| Per-agent home dir | `HERMES_HOME=<workdir>/.hermes` set automatically by Gateway when the agent uses the `hermes_plugin` runtime | Hermes memory/sessions don't cross agents on the same host. |
 
 ### Not yet enforced (the open questions)
 

--- a/docs/gateway-agent-runtimes.md
+++ b/docs/gateway-agent-runtimes.md
@@ -44,8 +44,18 @@ Current useful modes:
 - `inbox`: queueing and manual acknowledgement paths for background workers.
 - `exec`: run probes or one-shot bridges that explicitly persist or reconstruct
   any state they need.
-- `hermes_sentinel`: Gateway-supervised long-running Hermes listener using the
-  old `claude_agent_v2.py --runtime hermes_sdk` behavior.
+- `hermes_plugin`: Gateway-supervised long-running `hermes gateway run`
+  process using the native aX platform plugin at `plugins/platforms/ax/`.
+  Preferred path for all new Hermes agents. Gateway scaffolds
+  `<workdir>/.hermes` (plugin symlink + non-secret identity `.env`), spawns
+  the hermes binary, and injects `AX_TOKEN` from the Gateway-owned token
+  file at start so the raw PAT never lives in the workspace. The `hermes`
+  template defaults to this runtime.
+- `hermes_sentinel` *(legacy)*: Gateway-supervised long-running Hermes
+  listener using the old `claude_agent_v2.py --runtime hermes_sdk`
+  behavior. Kept only so existing entries keep working; new agents should
+  use `hermes_plugin`. Migrate with
+  `ax gateway agents update <name> --type hermes_plugin`.
 - `claude_code_channel`: attached Claude Code channel. Gateway registers the
   identity and token; `ax-channel` delivers live mentions into the Claude Code
   session.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "typer>=0.9",
     "httpx>=0.25",
     "rich>=13.0",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -3491,12 +3491,16 @@ def test_gateway_runtime_types_command_json():
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     ids = [item["id"] for item in payload["runtime_types"]]
-    assert ids == ["echo", "exec", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox"]
+    assert ids == ["echo", "exec", "hermes_plugin", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox"]
     exec_type = next(item for item in payload["runtime_types"] if item["id"] == "exec")
     assert exec_type["signals"]["activity"]
     assert exec_type["examples"]
+    plugin_type = next(item for item in payload["runtime_types"] if item["id"] == "hermes_plugin")
+    assert plugin_type["kind"] == "supervised_process"
+    assert plugin_type.get("deprecated") is not True
     hermes_type = next(item for item in payload["runtime_types"] if item["id"] == "hermes_sentinel")
     assert hermes_type["kind"] == "supervised_process"
+    assert hermes_type.get("deprecated") is True
     sentinel_type = next(item for item in payload["runtime_types"] if item["id"] == "sentinel_cli")
     assert sentinel_type["signals"]["tools"]
     channel_type = next(item for item in payload["runtime_types"] if item["id"] == "claude_code_channel")
@@ -3567,7 +3571,7 @@ def test_gateway_ui_handler_serves_status_and_agent_detail(monkeypatch, tmp_path
             runtime_types = client.get("/api/runtime-types")
             assert runtime_types.status_code == 200
             runtime_payload = runtime_types.json()
-            assert runtime_payload["count"] == 6
+            assert runtime_payload["count"] == 7  # +hermes_plugin
             assert runtime_payload["runtime_types"][1]["id"] == "exec"
 
             templates = client.get("/api/templates")

--- a/tests/test_gateway_hermes_plugin.py
+++ b/tests/test_gateway_hermes_plugin.py
@@ -1,0 +1,170 @@
+"""Tests for the Gateway-supervised Hermes plugin runtime.
+
+Covers the scaffolding + spawn helpers (no live subprocess). Specifically
+asserts the trust-boundary property: the raw AX_TOKEN never lands in any
+file under the workspace; it only appears in the subprocess env that
+Gateway builds at spawn time from the Gateway-owned token file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ax_cli import gateway as gateway_core
+from ax_cli.gateway_runtime_types import (
+    agent_template_definition,
+    runtime_type_definition,
+    runtime_type_list,
+)
+
+
+def _base_entry(tmp_path: Path) -> dict:
+    workdir = tmp_path / "wiki"
+    return {
+        "name": "mnemo",
+        "agent_id": "11111111-1111-1111-1111-111111111111",
+        "space_id": "22222222-2222-2222-2222-222222222222",
+        "base_url": "https://paxai.app",
+        "workdir": str(workdir),
+        "runtime_type": "hermes_plugin",
+        "template_id": "hermes",
+    }
+
+
+def test_hermes_plugin_runtime_in_catalog():
+    plugin_def = runtime_type_definition("hermes_plugin")
+    assert plugin_def["id"] == "hermes_plugin"
+    assert plugin_def["kind"] == "supervised_process"
+    assert plugin_def.get("deprecated") is not True
+    ids = [r["id"] for r in runtime_type_list()]
+    assert "hermes_plugin" in ids
+    # hermes template now defaults to plugin runtime
+    hermes_template = agent_template_definition("hermes")
+    assert hermes_template["runtime_type"] == "hermes_plugin"
+    assert hermes_template["defaults"]["runtime_type"] == "hermes_plugin"
+
+
+def test_hermes_sentinel_marked_deprecated_but_still_resolvable():
+    legacy = runtime_type_definition("hermes_sentinel")
+    assert legacy["id"] == "hermes_sentinel"
+    assert legacy.get("deprecated") is True
+
+
+def test_is_predicates():
+    assert gateway_core._is_hermes_plugin_runtime("hermes_plugin")
+    assert not gateway_core._is_hermes_plugin_runtime("hermes_sentinel")
+    assert gateway_core._is_supervised_subprocess_runtime("hermes_plugin")
+    assert gateway_core._is_supervised_subprocess_runtime("hermes_sentinel")
+    assert not gateway_core._is_supervised_subprocess_runtime("echo")
+    assert not gateway_core._is_supervised_subprocess_runtime("exec")
+
+
+def test_hermes_plugin_workdir_and_home(tmp_path):
+    entry = _base_entry(tmp_path)
+    workdir = gateway_core._hermes_plugin_workdir(entry)
+    assert workdir == tmp_path / "wiki"
+    home = gateway_core._hermes_plugin_home(entry)
+    assert home == workdir / ".hermes"
+    entry["hermes_home"] = str(tmp_path / "elsewhere")
+    assert gateway_core._hermes_plugin_home(entry) == tmp_path / "elsewhere"
+
+
+def test_scaffold_creates_dir_plugin_link_and_dotenv(tmp_path):
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    assert home.is_dir()
+    plugin_link = home / "plugins" / "ax"
+    assert plugin_link.is_symlink() or (plugin_link / "plugin.yaml").exists()
+    assert plugin_link.resolve() == gateway_core._plugin_source_dir().resolve()
+    dotenv = (home / ".env").read_text()
+    assert "AX_AGENT_NAME=mnemo" in dotenv
+    assert entry["agent_id"] in dotenv
+    assert entry["space_id"] in dotenv
+    assert "AX_BASE_URL=https://paxai.app" in dotenv
+    # The .env can mention AX_TOKEN in a comment, but must never assign it.
+    assert not any(
+        line.strip().startswith("AX_TOKEN=") for line in dotenv.splitlines()
+    ), "Identity .env must not assign AX_TOKEN"
+
+
+def test_scaffold_is_idempotent(tmp_path):
+    entry = _base_entry(tmp_path)
+    home_first = gateway_core._scaffold_hermes_plugin_home(entry)
+    plugin_link = home_first / "plugins" / "ax"
+    first_target = plugin_link.resolve()
+    home_second = gateway_core._scaffold_hermes_plugin_home(entry)
+    assert home_first == home_second
+    assert (home_second / "plugins" / "ax").resolve() == first_target
+
+
+def test_scaffold_inherits_operator_auth_when_present(tmp_path, monkeypatch):
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    (operator_hermes / "auth.json").write_text("{}")
+    (operator_hermes / "config.yaml").write_text("providers: {}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    auth = home / "auth.json"
+    cfg = home / "config.yaml"
+    assert auth.is_symlink()
+    assert cfg.is_symlink()
+    assert auth.resolve() == (operator_hermes / "auth.json").resolve()
+
+
+def test_build_cmd_uses_hermes_gateway_run(tmp_path, monkeypatch):
+    entry = _base_entry(tmp_path)
+    monkeypatch.setenv("HERMES_BIN", "/usr/local/bin/hermes-test")
+    cmd = gateway_core._build_hermes_plugin_cmd(entry)
+    assert cmd == ["/usr/local/bin/hermes-test", "gateway", "run"]
+
+
+def test_build_env_injects_token_from_gateway_file(tmp_path, monkeypatch):
+    entry = _base_entry(tmp_path)
+    token_file = tmp_path / "token"
+    token_file.write_text("axp_a_TEST_TOKEN_NOT_REAL_xxxxx")
+    entry["token_file"] = str(token_file)
+
+    # Strip any inherited AX_TOKEN that would mask the per-agent value.
+    for var in ("AX_TOKEN", "AX_AGENT_NAME", "AX_AGENT_ID", "AX_SPACE_ID"):
+        monkeypatch.delenv(var, raising=False)
+
+    env = gateway_core._build_hermes_plugin_env(entry)
+    assert env["AX_TOKEN"] == "axp_a_TEST_TOKEN_NOT_REAL_xxxxx"
+    assert env["AX_AGENT_NAME"] == "mnemo"
+    assert env["AX_AGENT_ID"] == entry["agent_id"]
+    assert env["AX_SPACE_ID"] == entry["space_id"]
+    assert env["AX_BASE_URL"] == "https://paxai.app"
+    home = gateway_core._hermes_plugin_home(entry)
+    assert env["HERMES_HOME"] == str(home)
+    # ENV_DENYLIST stripping: callers should not leak Gateway's own AX_TOKEN
+    # if it happened to be set when Gateway started.
+    monkeypatch.setenv("AX_TOKEN", "axp_u_GATEWAY_USER_TOKEN_LEAK")
+    env_again = gateway_core._build_hermes_plugin_env(entry)
+    assert env_again["AX_TOKEN"] == "axp_a_TEST_TOKEN_NOT_REAL_xxxxx"
+
+
+def test_hermes_bin_prefers_entry_override(tmp_path, monkeypatch):
+    entry = _base_entry(tmp_path)
+    entry["hermes_bin"] = "/custom/bin/hermes"
+    monkeypatch.setenv("HERMES_BIN", "/env/bin/hermes")
+    assert gateway_core._hermes_bin(entry) == "/custom/bin/hermes"
+
+
+def test_hermes_bin_falls_back_to_env(tmp_path, monkeypatch):
+    entry = _base_entry(tmp_path)
+    monkeypatch.setenv("HERMES_BIN", "/env/bin/hermes")
+    assert gateway_core._hermes_bin(entry) == "/env/bin/hermes"
+
+
+def test_hermes_bin_raises_when_unresolvable(tmp_path, monkeypatch):
+    entry = _base_entry(tmp_path)
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "nope"))
+    monkeypatch.setattr(gateway_core.shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError, match="hermes CLI not found"):
+        gateway_core._hermes_bin(entry)

--- a/tests/test_gateway_hermes_plugin.py
+++ b/tests/test_gateway_hermes_plugin.py
@@ -89,6 +89,31 @@ def test_scaffold_creates_dir_plugin_link_and_dotenv(tmp_path):
     ), "Identity .env must not assign AX_TOKEN"
 
 
+def test_scaffold_writes_allow_all_users_when_opted_in(tmp_path):
+    entry = _base_entry(tmp_path)
+    entry["allow_all_users"] = True
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    dotenv = (home / ".env").read_text()
+    assert "AX_ALLOW_ALL_USERS=1" in dotenv
+    assert "GATEWAY_ALLOW_ALL_USERS=true" in dotenv
+
+
+def test_scaffold_omits_allow_all_users_by_default(tmp_path):
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    dotenv = (home / ".env").read_text()
+    assert "AX_ALLOW_ALL_USERS=1" not in dotenv
+    assert "GATEWAY_ALLOW_ALL_USERS=true" not in dotenv
+
+
+def test_scaffold_writes_allowed_users(tmp_path):
+    entry = _base_entry(tmp_path)
+    entry["allowed_users"] = "alice,bob"
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    dotenv = (home / ".env").read_text()
+    assert "AX_ALLOWED_USERS=alice,bob" in dotenv
+
+
 def test_scaffold_is_idempotent(tmp_path):
     entry = _base_entry(tmp_path)
     home_first = gateway_core._scaffold_hermes_plugin_home(entry)

--- a/tests/test_gateway_hermes_plugin.py
+++ b/tests/test_gateway_hermes_plugin.py
@@ -84,9 +84,9 @@ def test_scaffold_creates_dir_plugin_link_and_dotenv(tmp_path):
     assert entry["space_id"] in dotenv
     assert "AX_BASE_URL=https://paxai.app" in dotenv
     # The .env can mention AX_TOKEN in a comment, but must never assign it.
-    assert not any(
-        line.strip().startswith("AX_TOKEN=") for line in dotenv.splitlines()
-    ), "Identity .env must not assign AX_TOKEN"
+    assert not any(line.strip().startswith("AX_TOKEN=") for line in dotenv.splitlines()), (
+        "Identity .env must not assign AX_TOKEN"
+    )
 
 
 def test_scaffold_writes_allow_all_users_when_opted_in(tmp_path):
@@ -129,16 +129,105 @@ def test_scaffold_inherits_operator_auth_when_present(tmp_path, monkeypatch):
     operator_hermes = fake_home / ".hermes"
     operator_hermes.mkdir(parents=True)
     (operator_hermes / "auth.json").write_text("{}")
-    (operator_hermes / "config.yaml").write_text("providers: {}")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
     entry = _base_entry(tmp_path)
     home = gateway_core._scaffold_hermes_plugin_home(entry)
     auth = home / "auth.json"
-    cfg = home / "config.yaml"
     assert auth.is_symlink()
-    assert cfg.is_symlink()
     assert auth.resolve() == (operator_hermes / "auth.json").resolve()
+
+
+def test_scaffold_renders_config_yaml_with_pinned_terminal_cwd(tmp_path, monkeypatch):
+    """config.yaml is rendered (not symlinked) so operator's terminal.cwd
+    can't bleed through. The agent's workdir wins for terminal.cwd while
+    other operator defaults (model, providers, etc.) are still seeded.
+    """
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    operator_config = {
+        "model": "gpt-5.5",
+        "providers": {"openai-codex": {"default_model": "gpt-5.5"}},
+        # Operator pointed terminal.cwd at a *different* agent's tree —
+        # exactly the bleed that mis-identifies agents in production.
+        "terminal": {"backend": "local", "cwd": str(tmp_path / "some-other-agent")},
+    }
+    (operator_hermes / "config.yaml").write_text(yaml.safe_dump(operator_config))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    cfg_path = home / "config.yaml"
+
+    assert cfg_path.is_file() and not cfg_path.is_symlink()
+    rendered = yaml.safe_load(cfg_path.read_text())
+    # terminal.cwd must point at the agent's own workdir, never the
+    # operator's pinned path.
+    assert rendered["terminal"]["cwd"] == str(tmp_path / "wiki")
+    # Operator's other terminal fields and top-level defaults pass through.
+    assert rendered["terminal"]["backend"] == "local"
+    assert rendered["model"] == "gpt-5.5"
+    assert rendered["providers"]["openai-codex"]["default_model"] == "gpt-5.5"
+
+
+def test_scaffold_replaces_stale_config_symlink(tmp_path, monkeypatch):
+    """Upgrading from the old symlink-based scaffold must not leave a
+    stale symlink in place — otherwise the identity bleed survives.
+    """
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    (operator_hermes / "config.yaml").write_text(yaml.safe_dump({"terminal": {"cwd": str(tmp_path / "stale")}}))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._hermes_plugin_home(entry)
+    home.mkdir(parents=True, exist_ok=True)
+    stale_target = home / "config.yaml"
+    stale_target.symlink_to(operator_hermes / "config.yaml")
+    assert stale_target.is_symlink()
+
+    gateway_core._scaffold_hermes_plugin_home(entry)
+    assert not stale_target.is_symlink()
+    assert stale_target.is_file()
+    rendered = yaml.safe_load(stale_target.read_text())
+    assert rendered["terminal"]["cwd"] == str(tmp_path / "wiki")
+
+
+def test_scaffold_renders_minimal_config_when_operator_has_none(tmp_path, monkeypatch):
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    (fake_home / ".hermes").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    cfg_path = home / "config.yaml"
+
+    assert cfg_path.is_file() and not cfg_path.is_symlink()
+    rendered = yaml.safe_load(cfg_path.read_text())
+    assert rendered == {"terminal": {"cwd": str(tmp_path / "wiki")}}
+
+
+def test_hermes_setup_status_does_not_gate_plugin_runtime(tmp_path, monkeypatch):
+    """hermes_plugin must not be gated on the presence of a hermes-agent
+    git checkout — the binary is resolved via _hermes_bin (HERMES_BIN /
+    $PATH / fallback) and the aX plugin source ships in this repo.
+    """
+    # Make sure no candidate path exists so the legacy gate would fail.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "nope"))
+    monkeypatch.delenv("HERMES_REPO_PATH", raising=False)
+    entry = _base_entry(tmp_path)
+    status = gateway_core.hermes_setup_status(entry)
+    assert status["ready"] is True, status
+
+    # Sanity: hermes_sentinel still requires the checkout.
+    sentinel_entry = dict(entry, runtime_type="hermes_sentinel")
+    sentinel_status = gateway_core.hermes_setup_status(sentinel_entry)
+    assert sentinel_status["ready"] is False
 
 
 def test_build_cmd_uses_hermes_gateway_run(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Gateway now spawns and supervises a `hermes gateway run` subprocess directly for agents whose `runtime_type` is `hermes_plugin`, replacing the in-tree `hermes_sentinel` shim for new installs. Per-agent `HERMES_HOME` is scaffolded under the agent workdir, the aX platform plugin is symlinked in, a non-secret identity `.env` is written, and the Gateway-owned token is injected via subprocess env only (never to disk).
- Adds `allow_all_users` / `allowed_users` plumbing through the scaffold so operators can opt an agent into open access via `ax gateway agents add/update --allow-all-users` without hand-editing `~/.hermes/.env`. Default remains closed.
- Updates docs (`SETUP-HERMES.md`, `gateway-agent-runtimes.md`) and adds `tests/test_gateway_hermes_plugin.py` covering scaffold idempotency, env construction, and allowlist plumbing; existing `test_gateway_commands.py` adjusted for the new runtime type.

## Test plan

- [x] `uv run ruff check ax_cli/gateway.py ax_cli/commands/gateway.py ax_cli/gateway_runtime_types.py tests/test_gateway_hermes_plugin.py` — passes
- [ ] `uv run pytest tests/test_gateway_hermes_plugin.py tests/test_gateway_commands.py` — please confirm in CI
- [x] Live smoke: registered `mnemo` (workdir `~/claude_home/ax-wiki`) as `hermes_plugin`, Gateway spawned `hermes gateway run` (pid 94267), aX SSE connected, end-to-end channel reply round-tripped (see `~/claude_home/ax-wiki/.hermes/sessions/20260510_143304_c7625f96.jsonl`)

## Known follow-ups (not blocking)

- **Operator config bleed-through (identity confusion):** the scaffold symlinks the operator's `~/.hermes/config.yaml` into the per-agent home. If the operator's config has `terminal.cwd` pointed at another agent's tree (e.g. nova), the supervised agent inherits that path and the LLM can mis-identify itself from the workdir name. Fix forward: write a per-agent `config.yaml` that overrides `terminal.cwd` to the agent's own workdir (or omit it) while still inheriting provider creds.
- **Operator `~/.hermes/.env` should not carry `AX_TOKEN`:** observed on this machine. Gateway is the trust boundary; agent runtime tokens belong in `~/.ax/gateway/agents/<name>/token`. Worth a doc/cleanup pass, but out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)