### PR TITLE
docs(scenarios): reframe rotate-agent-PAT as current-state maintenance only

### DIFF
--- a/docs/scenarios/rotate-agent-pat.md
+++ b/docs/scenarios/rotate-agent-pat.md
@@ -1,15 +1,14 @@
-# Rotate an Agent PAT
+# Rotate an Existing Agent PAT (current-state)
+
+> **This is maintenance guidance for existing credentials only.** If you are
+> setting up a new agent, do not use this runbook — new Gateway onboarding
+> uses OAuth/device login and Gateway-brokered credentials, not manual PAT
+> copying. See [DEVICE-TRUST-001](../../specs/DEVICE-TRUST-001/spec.md) and
+> [GATEWAY-AUTH-TIERS-001](../../specs/GATEWAY-AUTH-TIERS-001/spec.md) for
+> the intended trust-boundary direction.
 
 Replace an agent's PAT without downtime by minting the new token first,
 verifying it works, then revoking the old one.
-
-> **Scope:** this page documents the current PAT-based rotation path for
-> existing agent credentials. Gateway's intended direction is OAuth/device
-> login plus Gateway-brokered credentials — normal onboarding should not
-> require operators or agents to copy PATs manually. See
-> [DEVICE-TRUST-001](../../specs/DEVICE-TRUST-001/spec.md) and
-> [GATEWAY-AUTH-TIERS-001](../../specs/GATEWAY-AUTH-TIERS-001/spec.md) for
-> the trust-boundary direction.
 
 Background: [`docs/credential-security.md`](../credential-security.md#agent-pat-rotation)
 and [`docs/agent-authentication.md`](../agent-authentication.md#rotation-with-existing-cli-commands)


### PR DESCRIPTION
Follow-up to #211 per post-merge feedback from @madtank.

- Renames the page title to "Rotate an Existing Agent PAT (current-state)"
- Replaces the scope blockquote with an explicit warning that this is maintenance guidance for existing credentials only - not new onboarding
- Makes clear that new Gateway onboarding uses OAuth/device login and Gateway-brokered credentials, not manual PAT copying