### PR TITLE
fix(gateway): honor Retry-After on upstream 429 backoff

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -229,14 +229,25 @@ class UpstreamRateLimitedError(RuntimeError):
         super().__init__(f"Upstream rate-limited after {retries_attempted} retries")
 
 
-def _with_upstream_429_retry(call, *, max_retries: int, base_wait: float = 1.0):
-    """Run ``call`` and retry on httpx 429 with exponential backoff.
+def _with_upstream_429_retry(
+    call,
+    *,
+    max_retries: int,
+    base_wait: float = 1.0,
+    max_wait: float = 120.0,
+):
+    """Run ``call`` and retry on httpx 429, honoring ``Retry-After`` when present.
 
-    Waits ``base_wait * 2**attempt`` between attempts. Other httpx
-    exceptions (4xx/5xx that aren't 429, network errors) propagate
+    Per-attempt wait = ``max(base_wait * 2**attempt, retry_after_seconds)``,
+    capped at ``max_wait``. paxai.app sends ``Retry-After: <seconds>`` on its
+    per-user rate-limit responses; ignoring it and falling back to a 1s/2s
+    exponential backoff exhausts the retry budget far below the server's
+    cooldown and surfaces as a spurious ``UpstreamRateLimitedError``.
+
+    Other httpx exceptions (4xx/5xx that aren't 429, network errors) propagate
     immediately. After the configured retry budget is exhausted on a
     persistent 429, raises ``UpstreamRateLimitedError`` carrying the
-    final exception and any Retry-After hint.
+    final exception.
     """
     attempts = 0
     while True:
@@ -247,7 +258,13 @@ def _with_upstream_429_retry(call, *, max_retries: int, base_wait: float = 1.0):
                 raise
             if attempts >= max_retries:
                 raise UpstreamRateLimitedError(exc, attempts) from exc
-            wait = base_wait * (2**attempts)
+            retry_after_raw = exc.response.headers.get("retry-after")
+            try:
+                hint = float(retry_after_raw) if retry_after_raw is not None else 0.0
+            except (TypeError, ValueError):
+                hint = 0.0
+            exp = base_wait * (2**attempts)
+            wait = min(max(exp, hint), max_wait)
             time.sleep(wait)
             attempts += 1
 

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -7291,7 +7291,13 @@ def _make_429_error() -> httpx.HTTPStatusError:
 
 
 def test_with_upstream_429_retry_succeeds_on_second_attempt(monkeypatch):
-    """Helper retries on 429 and returns the success result of the next call."""
+    """Helper retries on 429 and returns the success result of the next call.
+
+    Wait honors ``Retry-After: 12`` from the server response rather than the
+    1s exponential-backoff default — paxai.app's per-user bucket needs the
+    full server-advertised cooldown before the retry has any chance of
+    succeeding.
+    """
     sleeps: list[float] = []
     monkeypatch.setattr(gateway_cmd.time, "sleep", lambda s: sleeps.append(s))
     calls = {"n": 0}
@@ -7305,7 +7311,7 @@ def test_with_upstream_429_retry_succeeds_on_second_attempt(monkeypatch):
     result = gateway_cmd._with_upstream_429_retry(call, max_retries=2, base_wait=1.0)
     assert result == {"agent": "ok"}
     assert calls["n"] == 2
-    assert sleeps == [1.0]  # one backoff before the successful retry
+    assert sleeps == [12.0]  # max(exp=1.0, retry_after=12)
 
 
 def test_with_upstream_429_retry_exhausts_then_raises(monkeypatch):
@@ -7322,8 +7328,54 @@ def test_with_upstream_429_retry_exhausts_then_raises(monkeypatch):
         gateway_cmd._with_upstream_429_retry(call, max_retries=2, base_wait=1.0)
     assert exc_info.value.retries_attempted == 2
     assert exc_info.value.retry_after_seconds == 12  # parsed from header
-    # 2 retries × exponential = 1s + 2s.
-    assert sleeps == [1.0, 2.0]
+    # Both retries honor Retry-After: 12 (max of exp backoff 1s/2s and 12s hint).
+    assert sleeps == [12.0, 12.0]
+
+
+def test_with_upstream_429_retry_falls_back_to_exp_backoff_without_retry_after(monkeypatch):
+    """If the server omits Retry-After, fall back to the exponential
+    backoff schedule. Preserves prior behavior for non-conforming responses.
+    """
+    sleeps: list[float] = []
+    monkeypatch.setattr(gateway_cmd.time, "sleep", lambda s: sleeps.append(s))
+
+    request = httpx.Request("POST", "https://paxai.app/api/v1/agents")
+    no_hint = httpx.HTTPStatusError(
+        "429",
+        request=request,
+        response=httpx.Response(429, request=request),  # no Retry-After header
+    )
+
+    def call():
+        raise no_hint
+
+    with pytest.raises(gateway_cmd.UpstreamRateLimitedError):
+        gateway_cmd._with_upstream_429_retry(call, max_retries=2, base_wait=1.0)
+    assert sleeps == [1.0, 2.0]  # exp backoff: 1*2^0, 1*2^1
+
+
+def test_with_upstream_429_retry_caps_wait_at_max(monkeypatch):
+    """Pathological Retry-After values are capped at ``max_wait`` so a
+    misbehaving server can't hang the CLI for hours.
+    """
+    sleeps: list[float] = []
+    monkeypatch.setattr(gateway_cmd.time, "sleep", lambda s: sleeps.append(s))
+
+    request = httpx.Request("POST", "https://paxai.app/api/v1/agents")
+    insane = httpx.HTTPStatusError(
+        "429",
+        request=request,
+        response=httpx.Response(429, headers={"retry-after": "999999"}, request=request),
+    )
+
+    def call():
+        raise insane
+
+    with pytest.raises(gateway_cmd.UpstreamRateLimitedError):
+        gateway_cmd._with_upstream_429_retry(
+            call, max_retries=2, base_wait=1.0, max_wait=30.0
+        )
+    assert sleeps == [30.0, 30.0]  # both capped at max_wait
 
 
 def test_with_upstream_429_retry_propagates_other_errors(monkeypatch):


### PR DESCRIPTION
## Summary

- `_with_upstream_429_retry` was ignoring the server's `Retry-After` header and using a 1.0s exponential backoff (1s, 2s).
- paxai.app sends `Retry-After: <seconds>` on per-user 429s (`x-ratelimit-key: api:user:user:<id>`) — typically 30-90s on `/api/v1/agents`.
- With a 2-retry budget and 1s base, the CLI exhausted retries in ~3s — orders of magnitude under the server's advertised cooldown — and surfaced as a spurious `UpstreamRateLimitedError` on routine `gateway agents add` / `attach` / `status` calls.
- New per-attempt wait: `min(max(exp_backoff, retry_after), max_wait)`, default cap 120s.
- Fallback to original exponential schedule when the server omits the header (preserves prior behavior for non-conforming responses).

## Reproduction

```
$ axctl gateway agents add orion --template claude_code_channel --workdir /home/ax-agent
# pre-fix: fails ~3s later with UpstreamRateLimitedError, despite server sending Retry-After: 87
# post-fix: sleeps 87s, retries once, succeeds
```

## Test plan

- [x] `pytest tests/test_gateway_commands.py -k 429` — 6/6 passing
- [x] Existing tests updated for new wait timing (sleeps now honor `retry-after: 12` from the test fixture instead of falling back to exp backoff)
- [x] New test: `test_with_upstream_429_retry_falls_back_to_exp_backoff_without_retry_after` — preserves old behavior when header absent
- [x] New test: `test_with_upstream_429_retry_caps_wait_at_max` — pathological `Retry-After: 999999` is capped at `max_wait`
- [x] Full pre-commit suite (ruff, ruff format, CI tests, coverage, build, twine) — passed locally
- [x] Manually verified against prod with `axctl gateway agents add orion ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)