### PR TITLE
test(channel): isolate setup-docker test from real ~/.claude/

### DIFF
--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1422,6 +1422,7 @@ def test_channel_setup_uses_gateway_registry_defaults(monkeypatch, tmp_path):
 def test_channel_setup_can_generate_docker_mcp_command(tmp_path):
     token_file = tmp_path / "token"
     token_file.write_text("axp_a_agent.secret\n")
+    env_path = tmp_path / "orion.env"
 
     result = runner.invoke(
         channel_mod.app,
@@ -1438,6 +1439,8 @@ def test_channel_setup_can_generate_docker_mcp_command(tmp_path):
             "docker",
             "--container-image",
             "ax-channel:demo",
+            "--env-path",
+            str(env_path),
             "--json",
         ],
     )
@@ -1449,3 +1452,4 @@ def test_channel_setup_can_generate_docker_mcp_command(tmp_path):
     assert "ax-channel:demo" in server["args"]
     assert "-i" in server["args"]
     assert "axctl" in server["args"]
+    assert env_path.exists()


### PR DESCRIPTION
## Summary

- `tests/test_channel.py::test_channel_setup_can_generate_docker_mcp_command` passes `--workdir tmp_path` but **does not** pass `--env-path`, so `channel setup` falls back to its default `Path.home() / .claude / channels / ax-channel / {agent_name}.env`.
- That path is **the real operator file** an attached Claude Code session reads at startup. Running the test (including in pre-commit hooks) silently overwrites the operator's `~/.claude/channels/ax-channel/orion.env` with the fixture values (`AX_TOKEN_FILE=/tmp/pytest-.../token`, `AX_SPACE_ID="space-123"`), after which `/mcp` cannot connect to the channel.
- Fix mirrors the three sibling tests at `tests/test_channel.py:1010 / 1317 / 1392` that already isolate by passing `--env-path tmp_path / "..."`. Adds an `env_path.exists()` assertion so a future test regressing this pattern surfaces as a failure instead of operator breakage.

## Reproduction

```
$ git push                         # triggers full pre-commit suite (ruff + pytest + coverage + build + twine)
$ /mcp                             # in Claude Code → fails to connect
$ cat ~/.claude/channels/ax-channel/orion.env
AX_TOKEN_FILE="/tmp/pytest-of-ax-agent/pytest-4/test_channel_setup_can_generat0/token"
AX_SPACE_ID="space-123"
AX_AGENT_NAME="orion"
```

Recovery: `axctl gateway agents attach orion` regenerates the correct file. With this PR, the test no longer touches the operator's home dir.

## Test plan

- [x] `pytest tests/test_channel.py::test_channel_setup_can_generate_docker_mcp_command` — passes
- [x] Full pre-commit suite green (ruff, ruff format, CI tests, coverage, build, twine)
- [x] Confirmed `~/.claude/channels/ax-channel/orion.env` is not modified by the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)