### PR TITLE
fix(gateway): auto-enable ax-platform plugin so hermes_plugin agents actually reply

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -43,10 +43,13 @@ from ..commands.bootstrap import (
 )
 from ..config import resolve_space_id, resolve_user_base_url, resolve_user_token
 from ..gateway import (
+    AX_PLUGIN_NAME,
     GatewayDaemon,
     _format_daemon_log_line,
+    _hermes_plugin_home,
     _is_passive_runtime,
     _is_system_agent,
+    _plugin_source_dir,
     active_gateway_pid,
     active_gateway_pids,
     active_gateway_ui_pid,
@@ -3579,6 +3582,92 @@ def _run_gateway_doctor(name: str, *, send_test: bool = False) -> dict:
             else:
                 add_check("ollama_model", "warning", "No Ollama model is selected yet.")
         add_check("launch_path", "passed", "Gateway can launch the Ollama bridge on send.")
+
+    runtime_type = str(entry.get("runtime_type") or "").strip().lower()
+    if runtime_type == "hermes_plugin":
+        # Two distinct failure modes silently break the Hermes plugin path,
+        # and each presents identically (agent shows running, no replies).
+        # Surface them as separate checks so the operator can tell which
+        # broke without source-diving.
+        try:
+            hermes_home = _hermes_plugin_home(entry)
+            plugin_link = hermes_home / "plugins" / "ax"
+            plugin_source = _plugin_source_dir()
+            if plugin_link.is_symlink() and plugin_link.resolve() == plugin_source.resolve():
+                add_check(
+                    "ax_platform_symlink",
+                    "passed",
+                    f"{plugin_link} → {plugin_source} (Hermes can load the aX adapter).",
+                )
+            elif plugin_link.exists():
+                add_check(
+                    "ax_platform_symlink",
+                    "warning",
+                    f"{plugin_link} exists but does not resolve to {plugin_source}. "
+                    f"Delete it; Gateway will re-link on the next start.",
+                )
+            else:
+                add_check(
+                    "ax_platform_symlink",
+                    "failed",
+                    f"{plugin_link} is missing. Run `ax gateway agents start {entry.get('name') or '<name>'}` "
+                    f"to trigger the scaffold.",
+                )
+        except Exception as exc:
+            add_check("ax_platform_symlink", "warning", f"Could not inspect plugin symlink: {exc}")
+
+        try:
+            hermes_home = _hermes_plugin_home(entry)
+            cfg_path = hermes_home / "config.yaml"
+            if cfg_path.exists():
+                import yaml as _yaml  # local — gateway import cost
+
+                try:
+                    loaded = _yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+                except Exception as exc:
+                    loaded = None
+                    parse_error = exc
+                else:
+                    parse_error = None
+                if not isinstance(loaded, dict):
+                    if parse_error is not None:
+                        add_check(
+                            "ax_platform_enabled",
+                            "failed",
+                            f"{cfg_path} did not parse as YAML: {parse_error}",
+                        )
+                    else:
+                        add_check(
+                            "ax_platform_enabled",
+                            "failed",
+                            f"{cfg_path} is not a YAML mapping.",
+                        )
+                else:
+                    plugins_cfg = loaded.get("plugins")
+                    enabled_list = plugins_cfg.get("enabled") if isinstance(plugins_cfg, dict) else None
+                    if isinstance(enabled_list, list) and AX_PLUGIN_NAME in enabled_list:
+                        add_check(
+                            "ax_platform_enabled",
+                            "passed",
+                            f"`plugins.enabled` contains `{AX_PLUGIN_NAME}` (Hermes will load the adapter).",
+                        )
+                    else:
+                        add_check(
+                            "ax_platform_enabled",
+                            "failed",
+                            f"`plugins.enabled` in {cfg_path} does not contain `{AX_PLUGIN_NAME}`. "
+                            f"Hermes is opt-in for user plugins; without this the runtime comes up "
+                            f"but logs `No messaging platforms enabled` and never replies.",
+                        )
+            else:
+                add_check(
+                    "ax_platform_enabled",
+                    "failed",
+                    f"{cfg_path} is missing. Run `ax gateway agents start {entry.get('name') or '<name>'}` "
+                    f"to trigger the scaffold.",
+                )
+        except Exception as exc:
+            add_check("ax_platform_enabled", "warning", f"Could not inspect per-agent config.yaml: {exc}")
 
     if str(snapshot.get("mode") or "") == "LIVE":
         if str(snapshot.get("presence") or "") == "IDLE":

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -4362,6 +4362,12 @@ def _hermes_bin(entry: dict[str, Any]) -> str:
     )
 
 
+# Canonical name of the aX platform plugin as published in ``plugin.yaml``.
+# Used by the scaffold (to enable it in per-agent ``config.yaml``) and the
+# doctor (to verify the same name shows up in ``plugins.enabled``).
+AX_PLUGIN_NAME = "ax-platform"
+
+
 def _plugin_source_dir() -> Path:
     """Resolve the aX platform plugin directory shipped with ``ax_cli``.
 
@@ -4473,12 +4479,30 @@ def _scaffold_hermes_plugin_home(entry: dict[str, Any]) -> Path:
 
 def _render_hermes_plugin_config_yaml(entry: dict[str, Any], *, home: Path, operator_home: Path) -> None:
     """Write ``$HERMES_HOME/config.yaml`` with ``terminal.cwd`` pinned to the
-    agent's workdir, seeded from the operator's ``~/.hermes/config.yaml``.
+    agent's workdir AND the aX platform plugin enabled, seeded from the
+    operator's ``~/.hermes/config.yaml``.
+
+    Hermes' plugin system is opt-in by default — discovered user plugins
+    are gated behind a ``plugins.enabled`` allowlist
+    (``hermes_cli/plugins.py``: "Plugins are opt-in by default — only
+    plugins whose name appears in this set are loaded"). Without this
+    block the runtime cleanly comes up, ``hermes plugins list`` shows
+    ``ax-platform`` as ``not enabled``, the bound platform never reaches
+    ``self.config.platforms``, and ``hermes gateway run`` logs the
+    silent-but-fatal ``No messaging platforms enabled`` — agent stays
+    silent forever with no error visible in ``gateway agents show``.
+    Pinning ``plugins.enabled`` here means every ``hermes_plugin`` agent
+    self-enables ``ax-platform`` on the next start without the operator
+    needing to learn the gate exists.
+
+    ``plugins.disabled`` (if present) is scrubbed of ``ax-platform`` so a
+    stale operator-level disable can't override our enable. Other plugin
+    names in both lists are left untouched.
 
     Writes via a temp file + atomic replace so a partial write can't leave
-    Hermes booting against a half-yaml. Any non-mapping ``terminal`` value
-    in the operator config is replaced with a fresh mapping so we never
-    silently keep a bogus structure.
+    Hermes booting against a half-yaml. Any non-mapping ``terminal`` or
+    ``plugins`` value in the operator config is replaced with a fresh
+    mapping so we never silently keep a bogus structure.
     """
     workdir = _hermes_plugin_workdir(entry)
     target = home / "config.yaml"
@@ -4498,6 +4522,20 @@ def _render_hermes_plugin_config_yaml(entry: dict[str, Any], *, home: Path, oper
         terminal_cfg = {}
     terminal_cfg["cwd"] = str(workdir)
     cfg["terminal"] = terminal_cfg
+
+    plugins_cfg = cfg.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        plugins_cfg = {}
+    enabled = plugins_cfg.get("enabled")
+    if not isinstance(enabled, list):
+        enabled = []
+    if AX_PLUGIN_NAME not in enabled:
+        enabled.append(AX_PLUGIN_NAME)
+    plugins_cfg["enabled"] = enabled
+    disabled = plugins_cfg.get("disabled")
+    if isinstance(disabled, list) and AX_PLUGIN_NAME in disabled:
+        plugins_cfg["disabled"] = [name for name in disabled if name != AX_PLUGIN_NAME]
+    cfg["plugins"] = plugins_cfg
     try:
         import yaml
 

--- a/ax_cli/gateway_runtime_types.py
+++ b/ax_cli/gateway_runtime_types.py
@@ -149,9 +149,11 @@ def runtime_type_catalog() -> dict[str, dict[str, Any]]:
             "description": (
                 "Gateway-supervised long-running Hermes process using the native "
                 "aX platform plugin at ax_cli/plugins/platforms/ax/. Gateway scaffolds the "
-                "agent's HERMES_HOME (plugin symlink + non-secret identity .env) "
-                "and spawns `hermes gateway run`; AX_TOKEN is injected at start from "
-                "the Gateway-owned token file and is never written to the workspace."
+                "agent's HERMES_HOME (plugin symlink + non-secret identity .env + per-agent "
+                "config.yaml with `plugins.enabled: [ax-platform]` so Hermes' opt-in plugin "
+                "gate doesn't silently drop the adapter) and spawns `hermes gateway run`; "
+                "AX_TOKEN is injected at start from the Gateway-owned token file and is "
+                "never written to the workspace."
             ),
             "kind": "supervised_process",
             "passive": False,

--- a/docs/SETUP-HERMES.md
+++ b/docs/SETUP-HERMES.md
@@ -251,6 +251,25 @@ disconnect, and posts a shutdown notice to the home channel.
 
 ## Troubleshooting
 
+**`No messaging platforms enabled` in `~/.hermes/logs/gateway.log` and the
+agent stays silent forever (Plugin opt-in gate)**
+→ Hermes' plugin system is opt-in by default — discovered user plugins are
+gated behind a `plugins.enabled` allowlist in `~/.hermes/config.yaml`. The
+runtime cleanly comes up, `hermes plugins list` shows `ax-platform` as
+`not enabled`, and `gateway agents show <name>` reports the runtime as
+running, but no replies ever land.
+
+Gateway-supervised `hermes_plugin` agents self-enable `ax-platform` in
+their per-agent `$HERMES_HOME/config.yaml` automatically — `gateway agents
+show <name>` exposes this via the `ax_platform_enabled` doctor check.
+If you're running `hermes gateway run` manually against `~/.hermes/`, add
+the entry yourself:
+```yaml
+plugins:
+  enabled:
+    - ax-platform
+```
+
 **`Plugin 'ax-platform' has no register() function`**
 → The plugin's `__init__.py` must re-export `register` from `adapter`:
 ```python

--- a/tests/test_gateway_hermes_plugin.py
+++ b/tests/test_gateway_hermes_plugin.py
@@ -209,7 +209,105 @@ def test_scaffold_renders_minimal_config_when_operator_has_none(tmp_path, monkey
 
     assert cfg_path.is_file() and not cfg_path.is_symlink()
     rendered = yaml.safe_load(cfg_path.read_text())
-    assert rendered == {"terminal": {"cwd": str(tmp_path / "wiki")}}
+    # Scaffold always pins terminal.cwd and enables the ax-platform plugin —
+    # without the latter Hermes' opt-in gate silently drops the adapter.
+    assert rendered == {
+        "terminal": {"cwd": str(tmp_path / "wiki")},
+        "plugins": {"enabled": [gateway_core.AX_PLUGIN_NAME]},
+    }
+
+
+def test_scaffold_enables_ax_platform_when_operator_config_has_no_plugins_key(tmp_path, monkeypatch):
+    """Operator config without a `plugins` section gets one created with
+    `enabled: [ax-platform]`. Otherwise fresh setups would hit Hermes'
+    silent `No messaging platforms enabled` failure mode.
+    """
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    (operator_hermes / "config.yaml").write_text(yaml.safe_dump({"model": "gpt-5.5"}))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    rendered = yaml.safe_load((home / "config.yaml").read_text())
+    assert rendered["plugins"]["enabled"] == [gateway_core.AX_PLUGIN_NAME]
+    assert rendered["model"] == "gpt-5.5"
+
+
+def test_scaffold_appends_ax_platform_alongside_existing_enabled_plugins(tmp_path, monkeypatch):
+    """Operator already has other plugins enabled — scaffold must append
+    ax-platform without dropping the existing entries.
+    """
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    (operator_hermes / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["disk-cleanup", "spotify"]}})
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    rendered = yaml.safe_load((home / "config.yaml").read_text())
+    assert set(rendered["plugins"]["enabled"]) == {
+        "disk-cleanup",
+        "spotify",
+        gateway_core.AX_PLUGIN_NAME,
+    }
+
+
+def test_scaffold_does_not_duplicate_ax_platform_when_already_enabled(tmp_path, monkeypatch):
+    """Idempotent: running the scaffold twice (or against a config that
+    already enables ax-platform) does not produce duplicate entries.
+    """
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    (operator_hermes / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": [gateway_core.AX_PLUGIN_NAME]}})
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    gateway_core._scaffold_hermes_plugin_home(entry)
+    # Second scaffold against the previously-rendered per-agent config.
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    rendered = yaml.safe_load((home / "config.yaml").read_text())
+    assert rendered["plugins"]["enabled"].count(gateway_core.AX_PLUGIN_NAME) == 1
+
+
+def test_scaffold_scrubs_stale_disable_of_ax_platform(tmp_path, monkeypatch):
+    """If the operator's `plugins.disabled` lists ax-platform, the
+    scaffold removes it — a stale disable would override the enable and
+    re-create the silent-drop failure mode.
+    """
+    yaml = pytest.importorskip("yaml")
+    fake_home = tmp_path / "operator-home"
+    operator_hermes = fake_home / ".hermes"
+    operator_hermes.mkdir(parents=True)
+    (operator_hermes / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": ["disk-cleanup"],
+                    "disabled": [gateway_core.AX_PLUGIN_NAME, "google_meet"],
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    entry = _base_entry(tmp_path)
+    home = gateway_core._scaffold_hermes_plugin_home(entry)
+    rendered = yaml.safe_load((home / "config.yaml").read_text())
+    assert gateway_core.AX_PLUGIN_NAME in rendered["plugins"]["enabled"]
+    assert gateway_core.AX_PLUGIN_NAME not in rendered["plugins"].get("disabled", [])
+    # Unrelated disables stay put.
+    assert "google_meet" in rendered["plugins"]["disabled"]
 
 
 def test_hermes_setup_status_does_not_gate_plugin_runtime(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fresh `axctl gateway agents add <name> --type hermes_plugin` setups silently fail to reply because Hermes' plugin system is **opt-in by default** — discovered user plugins are gated behind a `plugins.enabled` allowlist in `~/.hermes/config.yaml` (citation: `hermes_cli/plugins.py:199` "Plugins are opt-in by default — only plugins whose name appears in this set are loaded"). Our scaffold writes the `.env` and creates the plugin symlink but never touched `plugins.enabled`.

Failure mode on a clean operator host:
- `axctl gateway agents add` succeeds
- `axctl gateway agents show <name>` reports the runtime as **running**
- `~/.hermes/plugins/ax` symlink resolves correctly
- `hermes plugins list` shows `ax-platform` with status **not enabled**
- `hermes gateway run` logs the silent-but-fatal:
  ```
  WARNING gateway.run: No messaging platforms enabled.
  INFO    gateway.run: Channel directory built: 0 target(s)
  ```
- Agent stays silent forever, **no error visible to the operator**

Reproduced tonight on EC2 after a clean rebuild of the local hermes-agent venv — took ~30 minutes of source-diving to find. @madtank's pre-existing setups all had manual `plugins.enabled: [ax-platform]` carried over from prior tinkering, which is why this bit fresh setups but not existing ones.

## Changes (per @cli_god's spec)

- **`AX_PLUGIN_NAME = "ax-platform"`** constant next to `_plugin_source_dir()` — one source of truth for the scaffold and the doctor checks.
- **`_render_hermes_plugin_config_yaml`** now ensures `plugins.enabled` contains `AX_PLUGIN_NAME` and scrubs it from `plugins.disabled` if a stale operator-level disable exists. Idempotent; preserves other plugin names in both lists.
- **`_run_gateway_doctor`** adds two checks for `runtime_type == "hermes_plugin"`:
  - `ax_platform_symlink` — `\$HERMES_HOME/plugins/ax` resolves to `_plugin_source_dir()`
  - `ax_platform_enabled` — per-agent `\$HERMES_HOME/config.yaml` has `ax-platform` in `plugins.enabled`
  
  Surfaced as separate doctor lines so operators can tell which broke without source-diving.
- **`gateway_runtime_types.py`** `hermes_plugin` description updated so `ax gateway runtime-types` advertises the self-enable behavior.
- **`docs/SETUP-HERMES.md`** troubleshooting: leading entry now explains the opt-in gate, the silent failure mode, and the manual recovery recipe for anyone running `hermes gateway run` outside Gateway supervision.

## Test plan

- [x] 4 new scaffold tests covering: fresh config gets enabled, pre-existing other plugins preserved, idempotent re-render no duplicates, stale `plugins.disabled: [ax-platform]` is scrubbed
- [x] Existing `test_scaffold_renders_minimal_config_when_operator_has_none` updated to assert the new shape
- [x] `pytest tests/test_gateway_hermes_plugin.py` — 23/23 passing
- [x] Broader sweep `pytest tests/ -k 'doctor or hermes or plugin'` — 68 passed, 1 skipped (adapter-activity skip is hermes-agent-not-on-test-venv, unchanged)
- [x] Full pre-commit suite green (ruff check, ruff format, CI tests, coverage, build, twine)
- [x] Manually reproduced silent failure pre-fix; manually verified scaffold + new doctor checks light up post-fix

Closes the chain of three PRs from tonight's hermes_plugin debugging marathon:
- #226 (Retry-After backoff)
- #227 (test-channel env isolation)
- #229 (Hermes plugin packaging — ships the plugin in the wheel)
- **this** — actually wires the bundled plugin into Hermes' opt-in gate so it works end-to-end without operator intervention

Per @cli_god — "ship it once it's clean and CI is green; I'll review in-session."

🤖 Generated with [Claude Code](https://claude.com/claude-code)