### PR TITLE
docs: add working agreement and public roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ participating, you are expected to uphold it. Report unacceptable behavior to
 If you are joining the project for the first time:
 
 1. Read through this guide and the [Development Setup](#development-setup) section below
-2. Browse **[Good First Issues](https://github.com/ax-platform/ax-gateway/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** —
+2. Browse **[Good First Issues](https://github.com/ax-platform/ax-gateway/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** -
    small, well-scoped tasks tagged for newcomers
 
 ## Getting Started
@@ -60,11 +60,36 @@ python -m build
 Use `pipx install axctl` for normal CLI use. Use editable installs only for
 local development.
 
-## Branches
+## Branching
 
-- `main` is the integration and release branch. Branch all new work from `main`.
-- `dev/staging` is dormant as of 2026-05-07 and far behind `main`. Do not branch
-  from it — PRs cut from `dev/staging` will silently revert recent work.
+Trunk-based development. Everything branches off `main`, merges back to `main`. No long-lived branches.
+
+```
+main (protected)
+  ├── feat/FUL-42/credential-unification
+  ├── fix/FUL-55/retry-storm-backoff
+  ├── docs/scenario-rotate-pat
+  └── chore/ruff-format-precommit
+```
+
+Branch naming: `<type>/<jira-id>/<short-description>` when there is a Jira story, otherwise `<type>/<short-description>`. Types: `feat`, `fix`, `docs`, `chore`, `test`, `ci`.
+
+Feature branches should stay under a week old. If something ages past 5 days, rebase or split it.
+
+**Note:** `dev/staging` is dormant as of 2026-05-07 and far behind `main`. Do not branch from it - PRs cut from `dev/staging` will silently revert recent work.
+
+### Keeping Your Fork in Sync
+
+If you are working from a fork, pull upstream changes before starting new work:
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+Same goes for upstream dependencies like hermes-agent - pull fresh before starting work.
 
 ## Commit Style
 
@@ -92,14 +117,42 @@ Treat identity boundaries as part of the product contract:
 
 ## Pull Request Guidelines
 
-Before submitting:
+### Before Opening a PR
 
-- Code runs without errors
-- `pytest tests/ -v --tb=short` passes
-- `ruff check ax_cli/` and `ruff format --check ax_cli/` pass
-- `python -m build` succeeds
-- No sensitive data committed
-- Branch is up to date with target branch
+1. `pytest tests/ -v --tb=short` - all green
+2. `ruff check ax_cli/` - no lint errors
+3. `ruff format --check ax_cli/` - no format issues
+4. `python -m build && twine check dist/*` - package builds clean
+5. New code has unit tests
+6. Unit test coverage at 80%+ for changed files
+7. Reference any issue or bug the PR closes in the commit message
+8. No sensitive data committed
+9. Branch is up to date with target branch
+
+Use the PR template. One approving review minimum.
+
+### Merge Strategy
+
+- **Squash-and-merge** for single-commit PRs
+- **Regular merge** for multi-commit PRs where the commit history tells a useful story
+
+Delete the branch after merge.
+
+### Before Starting New Work
+
+Check outstanding issues and PRs for related or conflicting code. If your work touches the same files as an open PR, coordinate with the author to avoid painful rebases.
+
+## Definition of Done
+
+A contribution is complete when:
+
+- New code has unit tests, 80%+ coverage on changed files
+- All CI passes (tests, lint, format, build)
+- PR reviewed and approved
+- Merged to main
+- GitHub issue closed (if applicable)
+- Docs updated if the change is user-facing
+- Conventional commit message for changelog
 
 ## Release Process
 
@@ -116,7 +169,7 @@ The short version:
 ## Community & Support
 
 - **GitHub Issues**: [Report bugs or request features](https://github.com/ax-platform/ax-gateway/issues)
-- **Security Vulnerabilities**: See [SECURITY.md](./SECURITY.md) — do not open a public issue
+- **Security Vulnerabilities**: See [SECURITY.md](./SECURITY.md) - do not open a public issue
 
 ## License
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,137 @@
+# ax-gateway Roadmap
+
+> **Last updated:** May 2026
+
+## Where We Are
+
+ax-gateway is an open-source CLI and local Gateway daemon for multi-agent AI orchestration. It connects AI agents to workspaces, manages credentials, and routes messages between humans and agents through a local trust boundary.
+
+Current state:
+
+- **746+ tests passing**
+- **7 MCP tools live**
+- Hermes plugin runtime shipped - enables pluggable agent runtimes
+- Accepted to Platform One marketplace (DoD distribution channel)
+- IL2 deployment in production with free trial available
+- Active contributor community with multiple engineers across CLI, MCP, and agent capabilities
+
+---
+
+## Release Plan
+
+### 0.7.0 - Stability (May 2026)
+
+Phase 2 reliability work wrapping up. This release captures two months of hardening:
+
+- Hermes plugin runtime - pluggable agent runtime architecture
+- Host header security validation
+- Tier annotations for proxy methods
+- CLA enforcement and community standards
+- Archive/restore lifecycle fixes
+- Retry backoff for rate limiting (429 handling)
+- Corruption repair and system prompt improvements
+- 20+ PRs merged in the last week alone
+
+### 0.8.0 - Credential Unification (Q3 2026)
+
+Phase 3 - the `get_authoring_client()` refactor. Every command will route through a single credential factory, replacing ~130 call sites across 20 modules. This is the foundation for the security improvements in the next release.
+
+Also in scope:
+
+- Expanded LLM provider support through the Hermes runtime (additional providers beyond OpenAI)
+- Agent framework templates for popular orchestration libraries
+- Test coverage push toward 40%
+- Repo consolidation from earlier platform repositories
+
+### 0.9.0 - Process Attestation (Q4 2026)
+
+Phase 4 - the security long pole. Eliminates tokens stored on disk by moving to a Unix domain socket architecture with process-level attestation (`SO_PEERCRED`).
+
+Key changes:
+
+- Session handle model replaces file-based token storage
+- `use` / `admin` tier system for proxy method permissions
+- Gateway becomes the sole credential holder - agents never touch raw tokens
+- Operator approval workflows for sensitive operations
+
+### 1.0.0 GA (Q1 2027)
+
+General availability release. Feature-complete platform with:
+
+- Multi-model support (Claude, GPT-4o, Gemini, Grok, LeapfrogAI)
+- Full MCP protocol integration with remote transport
+- Process attestation hardened and production-tested
+- IL5 security posture
+- Comprehensive test coverage
+- Stable API surface
+
+---
+
+## Three Areas of Development
+
+### CLI
+
+The command-line interface and credential management layer. Includes onboarding commands, space management, key lifecycle, and the developer experience for interacting with agents.
+
+### MCP (Model Context Protocol)
+
+Protocol integration, the Hermes plugin runtime, and transport layer. This is where new LLM providers plug in and where remote vs. stdio transport decisions play out. The Hermes runtime shipped in 0.7.0 and enables community-contributed provider modules.
+
+### Skills and Agent Capabilities
+
+Agent orchestration features - inbox/messaging, task assignment, agent profiles, and the APIs that agents use to collaborate. This area grows as agents move from single-task to multi-agent coordination patterns.
+
+---
+
+## Technical Architecture
+
+```
+User / Operator
+    |
+    v
+ax CLI (commands, onboarding, key management)
+    |
+    v
+Gateway Daemon (local trust boundary)
+    |
+    +--> Hermes Plugin Runtime (LLM providers)
+    +--> MCP Protocol (tools, resources)
+    +--> Proxy Dispatcher (agent API methods)
+    |
+    v
+ax Platform (workspaces, agents, messages)
+```
+
+The Gateway daemon runs locally and acts as a trust boundary between the operator, their agents, and the platform. Agents interact through the proxy dispatcher - they never hold credentials directly (fully enforced in 0.9.0).
+
+---
+
+## Security Posture
+
+ax-gateway is designed for defense and regulated environments:
+
+- **IL2** - Current production deployment
+- **IL5** - Targeted for Q4 2026 via Defense Unicorns (Zarf/UDS for air-gapped Kubernetes)
+- **IL6** - Planned for 2027
+
+The Phase 4 process attestation model is specifically designed to meet the credential isolation requirements for higher impact levels.
+
+---
+
+## Contributing
+
+The project welcomes contributions. Infrastructure is in place:
+
+- CLA enforcement on all PRs
+- Community standards (Code of Conduct, Contributing Guide, Security Policy)
+- Good-first-issues tagged and maintained
+- PR template with checklist (tests, lint, format, build)
+
+**Quality bar for contributions:**
+
+- All PRs must pass `pytest`, `ruff check`, and `ruff format`
+- New code requires unit tests with 80%+ coverage on changed files
+- One approving review minimum
+- Conventional commit messages for changelog generation
+
+See the repository's CONTRIBUTING.md for full details.


### PR DESCRIPTION
## Summary

- Expand CONTRIBUTING.md with the team's working agreement: trunk-based branching strategy, branch naming conventions (`<type>/<jira-id>/<short-description>`), fork sync instructions, detailed PR checklist with 80% unit test coverage requirement, merge strategy (squash vs regular), and definition of done
- Add public-facing product roadmap (`docs/roadmap.md`) covering releases 0.7.0 through 1.0.0, three development areas (CLI, MCP, Skills), architecture overview, security posture, and contribution quality bar

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm no internal/sensitive information in `docs/roadmap.md`
- [ ] Review branching and PR guidelines match current team practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)