### PR TITLE
docs: clarify navigation path to Credentials tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Gateway once from a trusted terminal, then Gateway mints agent-scoped
 credentials, supervises runtimes, and gives pass-through agents a mailbox.
 Agents should use their Gateway identity, not the user's bootstrap credential.
 
-Get a user PAT from **Settings > Credentials** at [paxai.app](https://paxai.app).
+Get a user PAT by logging in to [paxai.app](https://paxai.app) going to the wheel icon, selecting **All Settings** and going to the **Credentials** tab.
 This is a high-privilege token. Treat it like a password and paste it only into
 your trusted terminal.
 


### PR DESCRIPTION
## Summary

- Updates the README instruction for obtaining a user PAT to include the specific navigation path: login → wheel icon → **All Settings** → **Credentials** tab
- Replaces the vague "Settings > Credentials" reference with step-by-step UI navigation

## Test plan

- [x] Verify the navigation path described matches the current paxai.app UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)