### PR TITLE
feat(auth): surface OAuth roadmap notice after PAT login

### DIFF
--- a/ax_cli/commands/auth.py
+++ b/ax_cli/commands/auth.py
@@ -154,6 +154,10 @@ def login_user(
         console.print(f"  {k} = {v}")
 
     console.print("\n[cyan]You're ready.[/cyan] Try: ax auth whoami")
+    console.print(
+        "[dim]Note: PAT-based login is the current bootstrap path. "
+        "Gateway-brokered OAuth login is on the roadmap as the preferred alternative.[/dim]"
+    )
 
 
 def _probe_credential(effective: dict) -> dict:


### PR DESCRIPTION
Closes #— (no issue — follows up on @madtank's comment in #240)

Adds a one-line informational notice after successful PAT-based login letting operators know that Gateway-brokered OAuth login is on the roadmap as the preferred alternative. Non-blocking, purely informational.

Directly addresses the direction noted in PR #240:
> "Reminder we are going to need to move away from bootstrapping PAT
> for the gateway to sign in with OAuth."
