### PR TITLE
feat(cli): add --version flag and display version in web UI

### DIFF
--- a/ax_cli/__init__.py
+++ b/ax_cli/__init__.py
@@ -1,3 +1,8 @@
 """aX Platform CLI."""
 
-__version__ = "0.3.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("axctl")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -5070,7 +5070,7 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
     <section class="panel">
       <div class="panel-body footer-note">
         <span>Local status API: <code>/api/status</code> and <code>/api/agents/&lt;name&gt;</code></span>
-        <span>Setup skill: <code>skills/gateway-agent-setup/SKILL.md</code> · Terminal parity: <code>uv run ax gateway watch</code></span>
+        <span>Setup skill: <code>skills/gateway-agent-setup/SKILL.md</code> · Terminal parity: <code>uv run ax gateway watch</code> · axctl <code>__VERSION__</code></span>
       </div>
     </section>
   </main>
@@ -5713,7 +5713,8 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
 </body>
 </html>
 """
-    return template.replace("__REFRESH_MS__", str(refresh_ms))
+    from ax_cli import __version__
+    return template.replace("__REFRESH_MS__", str(refresh_ms)).replace("__VERSION__", __version__)
 
 
 _DEMO_HTML_PATH = Path(__file__).resolve().parent.parent / "static" / "demo.html"
@@ -5743,8 +5744,12 @@ _GATEWAY_FAVICON_SVG = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4
 
 
 def _render_gateway_demo_page(*, refresh_ms: int) -> str:
+    from ax_cli import __version__
     body = _DEMO_HTML_PATH.read_text(encoding="utf-8")
-    inject = f"<script>window.__GATEWAY_DEMO_REFRESH_MS__ = {int(refresh_ms)};</script></head>"
+    inject = (
+        f"<script>window.__GATEWAY_DEMO_REFRESH_MS__ = {int(refresh_ms)};"
+        f"window.__AXCTL_VERSION__ = {__version__!r};</script></head>"
+    )
     return body.replace("</head>", inject, 1)
 
 

--- a/ax_cli/main.py
+++ b/ax_cli/main.py
@@ -63,7 +63,21 @@ from .commands import (  # noqa: E402
     watch,
 )
 
+def _version_callback(value: bool) -> None:
+    if value:
+        from ax_cli import __version__
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
 app = typer.Typer(name="ax", help="aX Platform CLI", no_args_is_help=True)
+
+
+@app.callback()
+def _main(
+    version: bool = typer.Option(False, "--version", "-V", callback=_version_callback, is_eager=True, help="Show version and exit"),
+) -> None:
+    pass
 app.add_typer(auth.app, name="auth")
 app.add_typer(keys.app, name="keys")
 app.add_typer(credentials.app, name="credentials")

--- a/ax_cli/static/demo.html
+++ b/ax_cli/static/demo.html
@@ -357,6 +357,8 @@
       .type-mark svg { width: 18px; height: 18px; }
       .row-agent { gap: 9px; }
     }
+    .page-footer { border-top: 1px solid var(--line, #1d3342); margin-top: 24px; padding: 12px 0 24px; text-align: right; font-size: 12px; color: var(--muted, #93afbf); }
+    .page-footer code { font-family: monospace; }
   </style>
 </head>
 <body>
@@ -432,6 +434,7 @@
       </div>
       <div id="agent-region"></div>
     </section>
+    <footer class="page-footer">axctl <code id="axctl-version"></code></footer>
   </div>
 
   <!-- Drawer -->
@@ -2866,6 +2869,8 @@
     }
 
     boot();
+    const versionEl = document.getElementById("axctl-version");
+    if (versionEl && window.__AXCTL_VERSION__) versionEl.textContent = window.__AXCTL_VERSION__;
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds `ax --version` (and `ax -V`) to print the installed version and exit
- `ax_cli/__init__.py` derives `__version__` from `importlib.metadata`, staying in sync with `pyproject.toml` automatically
- Displays the version in the operator view (`/operator`) footer
- Displays the version in the quick view (`/`) footer, right-aligned with a top border separator

## Test plan

- [x] `ax --version` prints the current version string
- [x] `ax -V` works as shorthand
- [x] Gateway quick view (`/`) shows version in footer
- [x] Gateway operator view (`/operator`) shows version in footer
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)