### PR TITLE
feat: add ax spaces join command to redeem space invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ returned messages have actually been handled.
 | `ax agents list` | List agents in the space |
 | `ax spaces list` | List spaces you belong to |
 | `ax spaces create NAME` | Create a new space (`--visibility private/invite_only/public`) |
+| `ax spaces join CODE` | Redeem a space invite (`--use` sets current space) |
 | `ax keys list` | List API keys |
 | `ax profile list` | List named profiles |
 | `ax agents ping orion --timeout 30` | Probe whether an agent is listening now |

--- a/ax_cli/client.py
+++ b/ax_cli/client.py
@@ -420,6 +420,12 @@ class AxClient:
         r.raise_for_status()
         return self._parse_json(r)
 
+    def join_space_with_invite(self, invite_code: str) -> dict:
+        """POST /api/spaces/join — redeem a space invite and become a member."""
+        r = self._http.post("/api/spaces/join", json={"invite_code": invite_code.strip()})
+        r.raise_for_status()
+        return self._parse_json(r)
+
     # --- Messages ---
 
     def send_heartbeat(

--- a/ax_cli/commands/spaces.py
+++ b/ax_cli/commands/spaces.py
@@ -1,4 +1,4 @@
-"""ax spaces — list, create, and manage spaces."""
+"""ax spaces — list, create, join via invite, and manage spaces."""
 
 from typing import Optional
 
@@ -106,6 +106,70 @@ def create(
         console.print(
             f"[green]Created:[/green] {space.get('name')} (id={str(space.get('id', ''))[:8]}…, visibility={space.get('visibility')})"
         )
+
+
+@app.command("join")
+def join_space(
+    invite_code: str = typer.Argument(..., help="Space invite code from the inviter"),
+    use: bool = typer.Option(False, "--use", help="Set joined space as the CLI current space"),
+    global_config: bool = typer.Option(
+        False, "--global", help="With --use: save default space to global config instead of local .ax/config.toml"
+    ),
+    as_json: bool = JSON_OPTION,
+):
+    """Redeem a space invite and join that space."""
+    code = invite_code.strip()
+    if not code:
+        console.print("[red]Invite code cannot be empty.[/red]")
+        raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        result = client.join_space_with_invite(code)
+    except httpx.HTTPStatusError as e:
+        handle_error(e)
+
+    raw_space = result.get("space") if isinstance(result.get("space"), dict) else None
+    space = raw_space if raw_space is not None else (result if isinstance(result, dict) else {})
+    sid = str(space.get("id") or space.get("space_id") or result.get("space_id") or "")
+    label = _space_label(space, sid) if space else sid
+
+    allowed: bool | None = None
+    agent_name: str | None = None
+    if use and sid:
+        save_space_id(sid, local=not global_config)
+        allowed, agent_name = _bound_agent_allows_space(client, sid)
+
+    payload = {
+        "invite_code": code,
+        "space_id": sid or None,
+        "space_slug": space.get("slug") if space else None,
+        "space_name": space.get("name") if space else None,
+        "visibility": space.get("visibility") if space else None,
+        "used_as_current": use,
+        "scope": ("global" if global_config else "local") if use else None,
+        "bound_agent": agent_name,
+        "bound_agent_allowed": allowed,
+    }
+    if as_json:
+        print_json(payload)
+        return
+
+    if sid:
+        console.print(f"[green]Joined space:[/green] {label} (id={sid})")
+    else:
+        console.print("[green]Invite redeemed.[/green]")
+    if use and sid:
+        console.print(
+            f"[dim]Saved current space to {'global config' if global_config else 'local .ax/config.toml'}.[/dim]"
+        )
+        if allowed is False and agent_name:
+            console.print(
+                f"[yellow]Warning:[/yellow] @{agent_name} is not attached to this space; agent-authored writes may be rejected."
+            )
+    console.print(
+        "[dim]If `ax spaces list` does not show the new space yet, cached JWT claims may be stale — try again shortly or re-exchange your PAT.[/dim]"
+    )
 
 
 @app.command("use")

--- a/ax_cli/commands/spaces.py
+++ b/ax_cli/commands/spaces.py
@@ -134,6 +134,23 @@ def join_space(
     sid = str(space.get("id") or space.get("space_id") or result.get("space_id") or "")
     label = _space_label(space, sid) if space else sid
 
+    if use and not sid:
+        msg = (
+            "Join succeeded but the response had no space id; cannot apply --use. "
+            "Run `ax spaces list`, then `ax spaces use` with the new space when it appears."
+        )
+        if as_json:
+            print_json(
+                {
+                    "error": "join_missing_space_id",
+                    "message": msg,
+                    "used_as_current": False,
+                }
+            )
+        else:
+            console.print(f"[red]{msg}[/red]")
+        raise typer.Exit(1)
+
     allowed: bool | None = None
     agent_name: str | None = None
     if use and sid:
@@ -141,7 +158,6 @@ def join_space(
         allowed, agent_name = _bound_agent_allows_space(client, sid)
 
     payload = {
-        "invite_code": code,
         "space_id": sid or None,
         "space_slug": space.get("slug") if space else None,
         "space_name": space.get("name") if space else None,

--- a/tests/test_spaces_commands.py
+++ b/tests/test_spaces_commands.py
@@ -94,7 +94,7 @@ def test_spaces_join_redeems_invite_json(monkeypatch):
     assert payload["space_id"] == "space-invited"
     assert payload["space_slug"] == "qa-lab"
     assert payload["space_name"] == "QA Lab"
-    assert payload["invite_code"] == "9UZ8ZEPRTNHG"
+    assert "invite_code" not in payload
     assert payload["used_as_current"] is False
 
 
@@ -126,3 +126,30 @@ def test_spaces_join_rejects_blank_invite():
     result = runner.invoke(app, ["spaces", "join", "   "])
     assert result.exit_code == 1
     assert "empty" in result.output.lower()
+
+
+def test_spaces_join_use_fails_when_response_has_no_space_id(monkeypatch):
+    class FakeClient:
+        def join_space_with_invite(self, code):
+            return {"status": "ok"}
+
+    monkeypatch.setattr("ax_cli.commands.spaces.get_client", lambda: FakeClient())
+
+    result = runner.invoke(app, ["spaces", "join", "CODE", "--use", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload.get("error") == "join_missing_space_id"
+    assert payload.get("used_as_current") is False
+    assert "space id" in (payload.get("message") or "").lower()
+
+
+def test_spaces_join_use_fails_human_when_response_has_no_space_id(monkeypatch):
+    class FakeClient:
+        def join_space_with_invite(self, code):
+            return {"ok": True}
+
+    monkeypatch.setattr("ax_cli.commands.spaces.get_client", lambda: FakeClient())
+
+    result = runner.invoke(app, ["spaces", "join", "CODE", "--use"])
+    assert result.exit_code == 1
+    assert "space id" in result.output.lower()

--- a/tests/test_spaces_commands.py
+++ b/tests/test_spaces_commands.py
@@ -68,3 +68,61 @@ def test_spaces_use_global_saves_global_config(monkeypatch):
     assert result.exit_code == 0, result.output
     assert saved == {"space_id": "team-space", "local": False}
     assert json.loads(result.output)["scope"] == "global"
+
+
+def test_spaces_join_redeems_invite_json(monkeypatch):
+    calls = {}
+
+    class FakeClient:
+        def join_space_with_invite(self, code):
+            calls["code"] = code
+            return {
+                "space": {
+                    "id": "space-invited",
+                    "slug": "qa-lab",
+                    "name": "QA Lab",
+                    "visibility": "invite_only",
+                }
+            }
+
+    monkeypatch.setattr("ax_cli.commands.spaces.get_client", lambda: FakeClient())
+
+    result = runner.invoke(app, ["spaces", "join", " 9UZ8ZEPRTNHG ", "--json"])
+    assert result.exit_code == 0, result.output
+    assert calls["code"] == "9UZ8ZEPRTNHG"
+    payload = json.loads(result.output)
+    assert payload["space_id"] == "space-invited"
+    assert payload["space_slug"] == "qa-lab"
+    assert payload["space_name"] == "QA Lab"
+    assert payload["invite_code"] == "9UZ8ZEPRTNHG"
+    assert payload["used_as_current"] is False
+
+
+def test_spaces_join_use_saves_local_space(monkeypatch):
+    saved = {}
+
+    class FakeClient:
+        def join_space_with_invite(self, code):
+            return {"space": {"id": "new-space", "slug": "joined", "name": "Joined"}}
+
+        def whoami(self):
+            return {}
+
+    def fake_save_space_id(space_id, *, local=True):
+        saved["space_id"] = space_id
+        saved["local"] = local
+
+    monkeypatch.setattr("ax_cli.commands.spaces.get_client", lambda: FakeClient())
+    monkeypatch.setattr("ax_cli.commands.spaces.save_space_id", fake_save_space_id)
+
+    result = runner.invoke(app, ["spaces", "join", "CODE", "--use", "--json"])
+    assert result.exit_code == 0, result.output
+    assert saved == {"space_id": "new-space", "local": True}
+    assert json.loads(result.output)["used_as_current"] is True
+    assert json.loads(result.output)["scope"] == "local"
+
+
+def test_spaces_join_rejects_blank_invite():
+    result = runner.invoke(app, ["spaces", "join", "   "])
+    assert result.exit_code == 1
+    assert "empty" in result.output.lower()


### PR DESCRIPTION
## Summary

What changed and why?

## Validation

- [ ] `pytest tests/ -v --tb=short`
- [ ] `ruff check ax_cli/`
- [ ] `ruff format --check ax_cli/`
- [ ] `python -m build && twine check dist/*`
- [ ] `axctl auth doctor` reviewed for the target env/space, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior
- [ ] `axctl qa preflight` passed for the target env/space before MCP Jam, widget, or Playwright validation
- [ ] `axctl qa matrix` passed before promotion or cross-env/release validation
- [ ] Live aX smoke test, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior

## Release Notes

- [ ] This should appear in the changelog (`feat:`, `fix:`, or breaking change)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [ ] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated
