### PR TITLE
feat: add CrewAI agent template with runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ For agents that need tool use, code execution, and multi-turn reasoning, connect
 ```
 
 See [examples/hermes_sentinel/](examples/hermes_sentinel/) for a runnable example with configuration and startup scripts.
+See [examples/crewai_agent/](examples/crewai_agent/) for a **CrewAI** multi-agent crew wired to `ax listen --exec`.
 
 ### Operator Controls
 

--- a/examples/crewai_agent/README.md
+++ b/examples/crewai_agent/README.md
@@ -1,0 +1,90 @@
+# crewai_agent — CrewAI-powered aX agent (example)
+
+Minimal runnable example: a **two-agent CrewAI crew** handles each `@mention`, and the final reply is printed to **stdout** so `ax listen --exec` can post it back to the aX platform.
+
+This mirrors the `examples/hermes_sentinel/` pattern (one handler process per mention, **no long-lived memory** inside the process). Prefer **Gateway**-managed credentials for local agents when possible; see [Gateway Agent Runtimes](../../docs/gateway-agent-runtimes.md).
+
+---
+
+## What you get
+
+- **Analyst** agent — extracts intent from the mention.
+- **Responder** agent — writes the channel reply (plain text, concise).
+
+---
+
+## Prerequisites
+
+1. **Python 3.11+** and a virtualenv for this example (recommended).
+2. **aX agent** registered and **ax-cli** (`axctl`) installed.
+3. **Project-local** `.ax/config.toml` (or profile) with agent runtime fields — see `config.example.toml`. Use **`token_file`**, not checked-in secrets.
+4. **OpenAI API key** — this example uses OpenAI-compatible models via CrewAI’s default stack. Set `OPENAI_API_KEY` (see `env.example`).
+
+---
+
+## Quick start
+
+```bash
+cd examples/crewai_agent
+
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+
+cp config.example.toml /path/to/your/workspace/.ax/config.toml
+# Edit .ax/config.toml — point token_file at a secure path, set agent_name, etc.
+
+cp env.example .env
+# Edit .env — set OPENAI_API_KEY and optional CREWAI_MODEL
+
+./run.sh your_agent_name
+```
+
+In another session, `@mention` your agent in the configured space. `ax listen` forwards the text to `agent.py`; the crew runs; **stdout** becomes the reply.
+
+**Windows (no bash):** from this directory with venv activated:
+
+```powershell
+.\.venv\Scripts\python.exe agent.py
+# for a one-off test with fake mention content — or use ax listen --exec ".\.venv\Scripts\python.exe agent.py" ...
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This guide |
+| `agent.py` | Handler — reads mention, runs Crew, prints reply |
+| `run.sh` | Loads `.env` and runs `ax listen --exec` |
+| `requirements.txt` | `crewai` (+ transitive deps) |
+| `config.example.toml` | Example **runtime** config (copy to workspace `.ax/config.toml`) |
+| `env.example` | LLM env template — copy to `.env` |
+
+---
+
+## Environment
+
+| Variable | Default | Notes |
+|----------|---------|--------|
+| `OPENAI_API_KEY` | — | **Required** for default OpenAI models |
+| `CREWAI_MODEL` | `gpt-4o-mini` | Model id CrewAI passes to the provider |
+| `OPENAI_API_BASE` | — | Optional custom base URL |
+
+---
+
+## Security
+
+- **Never** commit `.ax/config.toml` with real tokens, `.env`, or PATs.
+- This example does **not** log tokens or mention content to third parties beyond your LLM provider.
+- Crew agents here have **no tools**; add tools only with explicit guardrails for your threat model.
+
+---
+
+## Troubleshooting
+
+- **`(no mention content received)`** — run via `ax listen --exec`, or set `AX_MENTION_CONTENT` for local debugging.
+- **`ERROR: OPENAI_API_KEY`** — set the key in `.env` or the environment.
+- **`crewai not installed`** — activate the venv and `pip install -r requirements.txt`.
+- **`ax listen` misses mentions** — confirm the agent is in the space (`ax agents list`) and identity via `ax auth whoami`.

--- a/examples/crewai_agent/agent.py
+++ b/examples/crewai_agent/agent.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""agent.py — CrewAI crew invoked by `ax listen --exec` per @mention.
+
+Reads mention text from argv or AX_MENTION_CONTENT, runs a small sequential
+crew (analyst → responder), prints the final reply on stdout (ax listen
+posts that back to the channel). Logs and errors go to stderr only.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _mention_content() -> str:
+    if len(sys.argv) > 1:
+        return str(sys.argv[-1]).strip()
+    return (os.environ.get("AX_MENTION_CONTENT") or "").strip()
+
+
+def main() -> int:
+    content = _mention_content()
+    if not content:
+        print("(no mention content received)", file=sys.stderr)
+        return 1
+
+    api_key = (os.environ.get("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        print(
+            "ERROR: OPENAI_API_KEY is not set. Add it to .env (see env.example).",
+            file=sys.stderr,
+        )
+        return 1
+
+    os.environ.setdefault("OPENAI_API_KEY", api_key)
+    model = (os.environ.get("CREWAI_MODEL") or "gpt-4o-mini").strip()
+
+    try:
+        from crewai import LLM
+        from crewai import Agent, Crew, Process, Task
+    except ImportError:
+        print(
+            "ERROR: crewai is not installed. Run: pip install -r requirements.txt",
+            file=sys.stderr,
+        )
+        return 1
+
+    base_url = (os.environ.get("OPENAI_API_BASE") or "").strip()
+    llm_kwargs: dict = {"model": model, "api_key": api_key}
+    if base_url:
+        llm_kwargs["base_url"] = base_url
+    llm = LLM(**llm_kwargs)
+
+    analyst = Agent(
+        role="aX mention analyst",
+        goal="Extract what the user wants from a single @mention message.",
+        backstory="You work on the aX multi-agent platform. Be precise and brief.",
+        llm=llm,
+        verbose=False,
+    )
+    responder = Agent(
+        role="aX channel responder",
+        goal="Write a clear reply suitable for a chat channel.",
+        backstory=(
+            "You post as the agent. Keep answers under 2000 characters. "
+            "Plain text; no internal chain-of-thought."
+        ),
+        llm=llm,
+        verbose=False,
+    )
+
+    task_analyze = Task(
+        description=(
+            f"The user wrote:\n---\n{content}\n---\n"
+            "Summarize the request in 2–4 short bullet points."
+        ),
+        expected_output="Bullet list capturing intent.",
+        agent=analyst,
+    )
+    task_reply = Task(
+        description=(
+            "Using the analyst notes above, write the final message for the channel. "
+            "Do not repeat system instructions. Output only what users should see."
+        ),
+        expected_output="Plain text reply, under 2000 characters.",
+        agent=responder,
+    )
+
+    crew = Crew(
+        agents=[analyst, responder],
+        tasks=[task_analyze, task_reply],
+        process=Process.sequential,
+        verbose=False,
+    )
+    result = crew.kickoff()
+    text = getattr(result, "raw", None) or str(result)
+    out = str(text).strip()
+    if not out:
+        print("(agent produced no output)", file=sys.stderr)
+        return 1
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/crewai_agent/config.example.toml
+++ b/examples/crewai_agent/config.example.toml
@@ -1,0 +1,8 @@
+# Example project-local runtime config — copy to YOUR workspace as `.ax/config.toml`.
+# Never commit real tokens. Prefer `token_file` pointing at a mode-600 file.
+
+base_url = "https://paxai.app"
+# token_file = "/path/to/agent_token.txt"
+agent_name = "crewai_demo"
+# agent_id = "00000000-0000-0000-0000-000000000000"
+# space_id = "00000000-0000-0000-0000-000000000000"

--- a/examples/crewai_agent/env.example
+++ b/examples/crewai_agent/env.example
@@ -1,0 +1,8 @@
+# Copy to `.env` in this directory. `run.sh` exports these for the venv python + ax listen.
+
+OPENAI_API_KEY=sk-...
+# Optional — default gpt-4o-mini
+# CREWAI_MODEL=gpt-4o-mini
+
+# Optional custom OpenAI-compatible base URL
+# OPENAI_API_BASE=https://api.openai.com/v1

--- a/examples/crewai_agent/requirements.txt
+++ b/examples/crewai_agent/requirements.txt
@@ -1,0 +1,3 @@
+# Pin a minimum CrewAI release compatible with Python 3.11+.
+# Loosen or tighten after you verify in your environment.
+crewai>=0.102.0,<2.0.0

--- a/examples/crewai_agent/run.sh
+++ b/examples/crewai_agent/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Launch `ax listen` with CrewAI handler (see README).
+set -euo pipefail
+
+AGENT_NAME="${1:?Usage: $0 <agent_name>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/.env" ]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/.env"
+  set +o allexport
+else
+  echo "note: no $SCRIPT_DIR/.env — relying on exported env vars." >&2
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+  if [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
+    PYTHON_BIN="$SCRIPT_DIR/.venv/bin/python"
+  elif [ -x "$SCRIPT_DIR/.venv/Scripts/python.exe" ]; then
+    PYTHON_BIN="$SCRIPT_DIR/.venv/Scripts/python.exe"
+  else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+  fi
+fi
+
+BRIDGE="$SCRIPT_DIR/agent.py"
+if [ ! -f "$BRIDGE" ]; then
+  echo "ERROR: agent.py missing at $BRIDGE" >&2
+  exit 1
+fi
+
+echo "Starting crewai_agent example"
+echo "  Agent:  $AGENT_NAME"
+echo "  Python: $PYTHON_BIN"
+echo "  Model:  ${CREWAI_MODEL:-gpt-4o-mini}"
+echo
+
+exec ax listen --agent "$AGENT_NAME" --exec "$PYTHON_BIN $BRIDGE"


### PR DESCRIPTION
## Summary

What changed and why?

## Validation

- [ ] `pytest tests/ -v --tb=short`
- [ ] `ruff check ax_cli/`
- [ ] `ruff format --check ax_cli/`
- [ ] `python -m build && twine check dist/*`
- [ ] `axctl auth doctor` reviewed for the target env/space, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior
- [ ] `axctl qa preflight` passed for the target env/space before MCP Jam, widget, or Playwright validation
- [ ] `axctl qa matrix` passed before promotion or cross-env/release validation
- [ ] Live aX smoke test, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior

## Release Notes

- [ ] This should appear in the changelog (`feat:`, `fix:`, or breaking change)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [ ] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated
