### PR TITLE
feat: add LangGraph agent template with runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ For agents that need tool use, code execution, and multi-turn reasoning, connect
 ```
 
 See [examples/hermes_sentinel/](examples/hermes_sentinel/) for a runnable example with configuration and startup scripts.
+See [examples/langgraph_agent/](examples/langgraph_agent/) for a **LangGraph** graph wired to `ax listen --exec` (OpenAI-compatible chat).
 
 ### Operator Controls
 

--- a/examples/langgraph_agent/README.md
+++ b/examples/langgraph_agent/README.md
@@ -1,0 +1,71 @@
+# langgraph_agent — LangGraph aX agent (example)
+
+Runnable example: a **small LangGraph** (`analyze` → `respond`) handles each `@mention`. The final reply is printed on **stdout** for `ax listen --exec`.
+
+This follows the same shape as [examples/hermes_sentinel/](../hermes_sentinel/) and complements [examples/gateway_langgraph/](../gateway_langgraph/) (Gateway’s one-node stub bridge for `ax gateway agents add --template langgraph`). **This** example is for operators who drive **`ax listen`** directly with an OpenAI-compatible model.
+
+---
+
+## Prerequisites
+
+1. **Python 3.11+** and a venv under this directory (recommended).
+2. **ax-cli** installed; agent registered; **`.ax/config.toml`** in your workspace with runtime fields — see `config.example.toml`. Prefer **`token_file`**.
+3. **`OPENAI_API_KEY`** (see `env.example`). Optional: **`OPENAI_API_BASE`** for compatible APIs.
+
+---
+
+## Quick start
+
+```bash
+cd examples/langgraph_agent
+
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+
+cp config.example.toml /path/to/your/workspace/.ax/config.toml
+# Edit token_file, agent_name, etc.
+
+cp env.example .env
+# Edit .env — OPENAI_API_KEY, optional LANGGRAPH_MODEL
+
+./run.sh your_agent_name
+```
+
+`@mention` the agent in the space; `ax listen` runs `agent.py` once per mention.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This guide |
+| `agent.py` | LangGraph graph + LLM nodes |
+| `run.sh` | Loads `.env`, runs `ax listen --exec` |
+| `requirements.txt` | `langgraph`, `langchain-openai` |
+| `config.example.toml` | Example runtime config (copy to workspace `.ax/`) |
+| `env.example` | Copy to `.env` (repo ignores `.env`) |
+
+---
+
+## Environment
+
+| Variable | Default | Notes |
+|----------|---------|--------|
+| `OPENAI_API_KEY` | — | Required |
+| `LANGGRAPH_MODEL` | `gpt-4o-mini` | Chat model name |
+| `OPENAI_API_BASE` | — | Optional alternate base URL |
+
+---
+
+## Security
+
+Do not commit real tokens. This example sends mention text to your LLM provider only.
+
+---
+
+## Troubleshooting
+
+- **`(no mention content received)`** — use `ax listen --exec`, or set `AX_MENTION_CONTENT` when testing.
+- **`langgraph` / `langchain_openai` import errors** — `pip install -r requirements.txt` in the same interpreter as `run.sh` uses.

--- a/examples/langgraph_agent/agent.py
+++ b/examples/langgraph_agent/agent.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""agent.py — LangGraph StateGraph invoked by `ax listen --exec` per @mention.
+
+Two nodes: analyze (intent bullets) → respond (channel reply). Final text on stdout.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TypedDict
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+
+
+class GraphState(TypedDict):
+    mention: str
+    analysis: str
+    reply: str
+
+
+def _mention_content() -> str:
+    if len(sys.argv) > 1:
+        return str(sys.argv[-1]).strip()
+    return (os.environ.get("AX_MENTION_CONTENT") or "").strip()
+
+
+def _chat() -> ChatOpenAI:
+    api_key = (os.environ.get("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY is not set")
+    model = (os.environ.get("LANGGRAPH_MODEL") or "gpt-4o-mini").strip()
+    kwargs: dict = {
+        "model": model,
+        "api_key": api_key,
+        "temperature": 0,
+    }
+    base = (os.environ.get("OPENAI_API_BASE") or "").strip()
+    if base:
+        kwargs["base_url"] = base.rstrip("/")
+    return ChatOpenAI(**kwargs)
+
+
+def _analyze(state: GraphState) -> GraphState:
+    llm = _chat()
+    msg = llm.invoke(
+        [
+            SystemMessage(
+                content="You extract intent from one chat @mention. Be brief.",
+            ),
+            HumanMessage(
+                content=(
+                    f"Message:\n---\n{state['mention']}\n---\n"
+                    "Reply with 2–4 short bullet points only."
+                ),
+            ),
+        ]
+    )
+    text = (msg.content or "").strip()
+    return {**state, "analysis": text}
+
+
+def _respond(state: GraphState) -> GraphState:
+    llm = _chat()
+    msg = llm.invoke(
+        [
+            SystemMessage(
+                content=(
+                    "You post as the aX agent. Plain text, under 2000 characters. "
+                    "No chain-of-thought; only what users read in chat."
+                ),
+            ),
+            HumanMessage(
+                content=(
+                    f"Original message:\n{state['mention']}\n\n"
+                    f"Analysis:\n{state['analysis']}\n\n"
+                    "Write the final reply."
+                ),
+            ),
+        ]
+    )
+    text = (msg.content or "").strip()
+    return {**state, "reply": text}
+
+
+def _build_app():
+    g = StateGraph(GraphState)
+    g.add_node("analyze", _analyze)
+    g.add_node("respond", _respond)
+    g.set_entry_point("analyze")
+    g.add_edge("analyze", "respond")
+    g.add_edge("respond", END)
+    return g.compile()
+
+
+def main() -> int:
+    content = _mention_content()
+    if not content:
+        print("(no mention content received)", file=sys.stderr)
+        return 1
+
+    if not (os.environ.get("OPENAI_API_KEY") or "").strip():
+        print(
+            "ERROR: OPENAI_API_KEY is not set. Add it to .env (see env.example).",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        app = _build_app()
+        out = app.invoke(
+            {"mention": content, "analysis": "", "reply": ""},
+        )
+    except ImportError as e:
+        print(
+            f"ERROR: missing dependency ({e}). Run: pip install -r requirements.txt",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:
+        print(f"ERROR: LangGraph run failed: {exc}", file=sys.stderr)
+        return 1
+
+    reply = (out.get("reply") or "").strip()
+    if not reply:
+        print("(agent produced no output)", file=sys.stderr)
+        return 1
+    print(reply)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/langgraph_agent/config.example.toml
+++ b/examples/langgraph_agent/config.example.toml
@@ -1,0 +1,7 @@
+# Example project-local runtime config — copy to YOUR workspace as `.ax/config.toml`.
+
+base_url = "https://paxai.app"
+# token_file = "/path/to/agent_token.txt"
+agent_name = "langgraph_demo"
+# agent_id = "00000000-0000-0000-0000-000000000000"
+# space_id = "00000000-0000-0000-0000-000000000000"

--- a/examples/langgraph_agent/env.example
+++ b/examples/langgraph_agent/env.example
@@ -1,0 +1,5 @@
+# Copy to `.env` in this directory. `run.sh` sources it before `ax listen`.
+
+OPENAI_API_KEY=sk-...
+# LANGGRAPH_MODEL=gpt-4o-mini
+# OPENAI_API_BASE=https://api.openai.com/v1

--- a/examples/langgraph_agent/requirements.txt
+++ b/examples/langgraph_agent/requirements.txt
@@ -1,0 +1,3 @@
+# Python 3.11+. Pin ranges can be tightened after you verify locally.
+langgraph>=0.3.0,<0.4.0
+langchain-openai>=0.3.0,<0.4.0

--- a/examples/langgraph_agent/run.sh
+++ b/examples/langgraph_agent/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Launch `ax listen` with the LangGraph handler (see README).
+set -euo pipefail
+
+AGENT_NAME="${1:?Usage: $0 <agent_name>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -f "$SCRIPT_DIR/.env" ]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/.env"
+  set +o allexport
+else
+  echo "note: no $SCRIPT_DIR/.env — relying on exported env vars." >&2
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+  if [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
+    PYTHON_BIN="$SCRIPT_DIR/.venv/bin/python"
+  elif [ -x "$SCRIPT_DIR/.venv/Scripts/python.exe" ]; then
+    PYTHON_BIN="$SCRIPT_DIR/.venv/Scripts/python.exe"
+  else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+  fi
+fi
+
+BRIDGE="$SCRIPT_DIR/agent.py"
+if [ ! -f "$BRIDGE" ]; then
+  echo "ERROR: agent.py missing at $BRIDGE" >&2
+  exit 1
+fi
+
+echo "Starting langgraph_agent example"
+echo "  Agent:  $AGENT_NAME"
+echo "  Python: $PYTHON_BIN"
+echo "  Model:  ${LANGGRAPH_MODEL:-gpt-4o-mini}"
+echo
+
+exec ax listen --agent "$AGENT_NAME" --exec "$PYTHON_BIN $BRIDGE"


### PR DESCRIPTION
## Summary

What changed and why?

## Validation

- [ ] `pytest tests/ -v --tb=short`
- [ ] `ruff check ax_cli/`
- [ ] `ruff format --check ax_cli/`
- [ ] `python -m build && twine check dist/*`
- [ ] `axctl auth doctor` reviewed for the target env/space, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior
- [ ] `axctl qa preflight` passed for the target env/space before MCP Jam, widget, or Playwright validation
- [ ] `axctl qa matrix` passed before promotion or cross-env/release validation
- [ ] Live aX smoke test, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior

## Release Notes

- [ ] This should appear in the changelog (`feat:`, `fix:`, or breaking change)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [ ] No token, profile, PAT, JWT, or agent identity behavior changed
- [ ] Auth behavior changed and the docs/tests were updated
