### PR TITLE
fix(credentials): warn on PATs expiring within 14 days in audit and list

### DIFF
--- a/ax_cli/commands/credentials.py
+++ b/ax_cli/commands/credentials.py
@@ -4,11 +4,26 @@ Requires a user PAT (axp_u_) which exchanges for user_admin JWT.
 All operations are API-first — same as what the UI does.
 """
 
+import datetime
+
 import httpx
 import typer
 
 from ..config import get_client
 from ..output import EXIT_NOT_OK, JSON_OPTION, console, handle_error, print_json, print_table
+
+_EXPIRY_WARNING_DAYS = 14
+
+
+def _days_until_expiry(expires_at: str | None) -> int | None:
+    if not expires_at:
+        return None
+    try:
+        exp = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        return (exp - datetime.datetime.now(datetime.timezone.utc)).days
+    except (ValueError, TypeError):
+        return None
+
 
 app = typer.Typer(name="credentials", help="Credential management (PATs, enrollment tokens)", no_args_is_help=True)
 
@@ -44,12 +59,23 @@ def build_credential_audit(credentials: list[dict]) -> dict:
             severity = "violation"
             recommendation = "revoke stale PATs before minting another token"
 
+        days_each = [_days_until_expiry(c.get("expires_at")) for c in active]
+        days_each = [d for d in days_each if d is not None]
+        expiry_days_min = min(days_each) if days_each else None
+        expiring_soon = expiry_days_min is not None and expiry_days_min < _EXPIRY_WARNING_DAYS
+
+        if expiring_soon and severity == "ok":
+            severity = "warning"
+            recommendation = f"PAT expires in {expiry_days_min}d — rotate before it expires"
+
         agents.append(
             {
                 "agent_id": agent_id,
                 "active_count": count,
                 "status": status,
                 "severity": severity,
+                "expiring_soon": expiring_soon,
+                "expiry_days_min": expiry_days_min,
                 "recommendation": recommendation,
                 "credentials": [
                     {
@@ -68,15 +94,17 @@ def build_credential_audit(credentials: list[dict]) -> dict:
 
     summary = {
         "agents_checked": len(agents),
-        "ok": sum(1 for agent in agents if agent["status"] == "ok"),
-        "rotation_windows": sum(1 for agent in agents if agent["status"] == "rotation_window"),
-        "cleanup_required": sum(1 for agent in agents if agent["status"] == "cleanup_required"),
+        "ok": sum(1 for a in agents if a["status"] == "ok" and not a["expiring_soon"]),
+        "expiring_soon": sum(1 for a in agents if a["expiring_soon"]),
+        "rotation_windows": sum(1 for a in agents if a["status"] == "rotation_window"),
+        "cleanup_required": sum(1 for a in agents if a["status"] == "cleanup_required"),
     }
     return {
         "policy": {
             "normal_active_agent_pats": 1,
             "rotation_window_active_agent_pats": 2,
             "max_active_agent_pats": 2,
+            "expiry_warning_days": _EXPIRY_WARNING_DAYS,
         },
         "summary": summary,
         "agents": agents,
@@ -214,27 +242,29 @@ def audit(
         summary = report["summary"]
         console.print(
             "[bold]Agent PAT audit[/bold] "
-            f"ok={summary['ok']} rotation_windows={summary['rotation_windows']} "
+            f"ok={summary['ok']} expiring_soon={summary['expiring_soon']} "
+            f"rotation_windows={summary['rotation_windows']} "
             f"cleanup_required={summary['cleanup_required']}"
         )
         if not report["agents"]:
             console.print("[dim]No active agent-bound PATs found.[/dim]")
         else:
             print_table(
-                ["Agent", "Active", "Status", "Recommendation"],
+                ["Agent", "Active", "Expires In", "Status", "Recommendation"],
                 [
                     {
                         "agent": agent["agent_id"],
                         "active": agent["active_count"],
-                        "status": agent["status"],
+                        "expires_in": f"{agent['expiry_days_min']}d" if agent["expiry_days_min"] is not None else "—",
+                        "status": agent["status"] + (" ⚠" if agent["expiring_soon"] else ""),
                         "recommendation": agent["recommendation"],
                     }
                     for agent in report["agents"]
                 ],
-                keys=["agent", "active", "status", "recommendation"],
+                keys=["agent", "active", "expires_in", "status", "recommendation"],
             )
 
-    if strict and report["summary"]["cleanup_required"]:
+    if strict and (report["summary"]["cleanup_required"] or report["summary"]["expiring_soon"]):
         raise typer.Exit(EXIT_NOT_OK)
 
 
@@ -259,4 +289,9 @@ def list_credentials(as_json: bool = JSON_OPTION):
             agent = c.get("bound_agent_id") or "none"
             if agent != "none":
                 agent = agent[:12] + "..."
-            console.print(f"  [{color}]{state:<10s}[/{color}] {c['key_id']}  agent={agent:<16s}  {c.get('name', '')}")
+            days = _days_until_expiry(c.get("expires_at"))
+            expiry_str = f"  expires={days}d" if days is not None else ""
+            expiry_color = " [yellow]⚠[/yellow]" if days is not None and days < _EXPIRY_WARNING_DAYS else ""
+            console.print(
+                f"  [{color}]{state:<10s}[/{color}] {c['key_id']}  agent={agent:<16s}  {c.get('name', '')}{expiry_str}{expiry_color}"
+            )

--- a/ax_cli/commands/credentials.py
+++ b/ax_cli/commands/credentials.py
@@ -295,7 +295,7 @@ def list_credentials(as_json: bool = JSON_OPTION):
                 agent = agent[:12] + "..."
             days = _days_until_expiry(c.get("expires_at"))
             expiry_str = f"  expires={days}d" if days is not None else ""
-            expiry_color = " [yellow]⚠[/yellow]" if days is not None and days < _EXPIRY_WARNING_DAYS else ""
+            expiry_color = " [yellow]⚠[/yellow]" if days is not None and days <= _EXPIRY_WARNING_DAYS else ""
             console.print(
                 f"  [{color}]{state:<10s}[/{color}] {c['key_id']}  agent={agent:<16s}  {c.get('name', '')}{expiry_str}{expiry_color}"
             )

--- a/ax_cli/commands/credentials.py
+++ b/ax_cli/commands/credentials.py
@@ -62,7 +62,7 @@ def build_credential_audit(credentials: list[dict]) -> dict:
         days_each = [_days_until_expiry(c.get("expires_at")) for c in active]
         days_each = [d for d in days_each if d is not None]
         expiry_days_min = min(days_each) if days_each else None
-        expiring_soon = expiry_days_min is not None and expiry_days_min < _EXPIRY_WARNING_DAYS
+        expiring_soon = expiry_days_min is not None and expiry_days_min <= _EXPIRY_WARNING_DAYS
 
         if expiring_soon and severity == "ok":
             severity = "warning"
@@ -226,7 +226,11 @@ def revoke(
 @app.command("audit")
 def audit(
     as_json: bool = JSON_OPTION,
-    strict: bool = typer.Option(False, "--strict", help="Exit non-zero when any agent has more than two active PATs"),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Exit non-zero when any agent has more than two active PATs or a PAT expiring within 14 days",
+    ),
 ):
     """Audit active agent PAT counts without minting or revoking credentials."""
     client = get_client()

--- a/tests/test_credentials_commands.py
+++ b/tests/test_credentials_commands.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 
 from typer.testing import CliRunner
@@ -8,13 +9,18 @@ from ax_cli.main import app
 runner = CliRunner()
 
 
+def _expires_in(days: int) -> str:
+    dt = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _credential(
     agent_id: str,
     credential_id: str,
     *,
     state: str = "active",
     created_at: str = "2026-04-15T00:00:00Z",
-    expires_at: str = "2027-01-01T00:00:00Z",
+    expires_at: str | None = None,
 ):
     return {
         "credential_id": credential_id,
@@ -24,7 +30,7 @@ def _credential(
         "audience": "both",
         "lifecycle_state": state,
         "created_at": created_at,
-        "expires_at": expires_at,
+        "expires_at": expires_at or _expires_in(90),
         "last_used_at": None,
     }
 
@@ -108,24 +114,28 @@ def test_build_credential_audit_flags_expiring_soon():
     report = build_credential_audit(
         [
             _credential("agent-ok", "ok-1"),
-            _credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z"),
-            _credential("agent-boundary", "boundary-1", expires_at="2026-05-26T00:00:00Z"),
+            _credential("agent-expiring", "exp-1", expires_at=_expires_in(5)),
+            _credential(
+                "agent-boundary", "boundary-1", expires_at=_expires_in(15)
+            ),  # ~14 computed days — boundary included
+            _credential("agent-safe", "safe-1", expires_at=_expires_in(16)),  # ~15 computed days — outside window
         ]
     )
     by_agent = {a["agent_id"]: a for a in report["agents"]}
     assert not by_agent["agent-ok"]["expiring_soon"]
+    assert not by_agent["agent-safe"]["expiring_soon"]
     assert by_agent["agent-expiring"]["expiring_soon"]
-    assert by_agent["agent-boundary"]["expiring_soon"]  # exactly 14 days — included
+    assert by_agent["agent-boundary"]["expiring_soon"]
     assert by_agent["agent-expiring"]["severity"] == "warning"
     assert "rotate" in by_agent["agent-expiring"]["recommendation"]
     assert report["summary"]["expiring_soon"] == 2
-    assert report["summary"]["ok"] == 1
+    assert report["summary"]["ok"] == 2
 
 
 def test_credentials_audit_strict_fails_for_expiring_soon(monkeypatch):
     class ExpiringClient:
         def mgmt_list_credentials(self):
-            return [_credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z")]
+            return [_credential("agent-expiring", "exp-1", expires_at=_expires_in(5))]
 
     monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: ExpiringClient())
 
@@ -138,10 +148,26 @@ def test_credentials_audit_strict_fails_for_expiring_soon(monkeypatch):
 def test_credentials_audit_expiring_soon_shown_in_human_output(monkeypatch):
     class ExpiringClient:
         def mgmt_list_credentials(self):
-            return [_credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z")]
+            return [_credential("agent-expiring", "exp-1", expires_at=_expires_in(5))]
 
     monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: ExpiringClient())
 
     result = runner.invoke(app, ["credentials", "audit"])
     assert result.exit_code == 0, result.output
     assert "expiring_soon=1" in result.output
+
+
+def test_credentials_list_shows_expiry_and_warns_when_close(monkeypatch):
+    class FakeClient:
+        def mgmt_list_credentials(self):
+            return [
+                _credential("agent-a", "cred-safe", expires_at=_expires_in(60)),
+                _credential("agent-b", "cred-warn", expires_at=_expires_in(5)),
+            ]
+
+    monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: FakeClient())
+
+    result = runner.invoke(app, ["credentials", "list"])
+    assert result.exit_code == 0, result.output
+    assert "expires=" in result.output
+    assert "⚠" in result.output

--- a/tests/test_credentials_commands.py
+++ b/tests/test_credentials_commands.py
@@ -109,14 +109,16 @@ def test_build_credential_audit_flags_expiring_soon():
         [
             _credential("agent-ok", "ok-1"),
             _credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z"),
+            _credential("agent-boundary", "boundary-1", expires_at="2026-05-26T00:00:00Z"),
         ]
     )
     by_agent = {a["agent_id"]: a for a in report["agents"]}
     assert not by_agent["agent-ok"]["expiring_soon"]
     assert by_agent["agent-expiring"]["expiring_soon"]
+    assert by_agent["agent-boundary"]["expiring_soon"]  # exactly 14 days — included
     assert by_agent["agent-expiring"]["severity"] == "warning"
     assert "rotate" in by_agent["agent-expiring"]["recommendation"]
-    assert report["summary"]["expiring_soon"] == 1
+    assert report["summary"]["expiring_soon"] == 2
     assert report["summary"]["ok"] == 1
 
 

--- a/tests/test_credentials_commands.py
+++ b/tests/test_credentials_commands.py
@@ -8,7 +8,14 @@ from ax_cli.main import app
 runner = CliRunner()
 
 
-def _credential(agent_id: str, credential_id: str, *, state: str = "active", created_at: str = "2026-04-15T00:00:00Z"):
+def _credential(
+    agent_id: str,
+    credential_id: str,
+    *,
+    state: str = "active",
+    created_at: str = "2026-04-15T00:00:00Z",
+    expires_at: str = "2027-01-01T00:00:00Z",
+):
     return {
         "credential_id": credential_id,
         "key_id": f"key-{credential_id}",
@@ -17,7 +24,7 @@ def _credential(agent_id: str, credential_id: str, *, state: str = "active", cre
         "audience": "both",
         "lifecycle_state": state,
         "created_at": created_at,
-        "expires_at": "2026-05-15T00:00:00Z",
+        "expires_at": expires_at,
         "last_used_at": None,
     }
 
@@ -45,6 +52,7 @@ def test_build_credential_audit_classifies_active_agent_pat_counts():
     assert report["summary"] == {
         "agents_checked": 3,
         "ok": 1,
+        "expiring_soon": 0,
         "rotation_windows": 1,
         "cleanup_required": 1,
     }
@@ -72,7 +80,7 @@ def test_credentials_audit_json_reports_rotation_and_cleanup(monkeypatch):
     assert report["summary"]["cleanup_required"] == 1
 
 
-def test_credentials_audit_strict_fails_only_for_cleanup_required(monkeypatch):
+def test_credentials_audit_strict_passes_for_rotation_window(monkeypatch):
     class RotationWindowClient:
         def mgmt_list_credentials(self):
             return [_credential("agent-rotate", "rotate-1"), _credential("agent-rotate", "rotate-2")]
@@ -94,3 +102,44 @@ def test_credentials_audit_strict_fails_only_for_cleanup_required(monkeypatch):
 
     cleanup_result = runner.invoke(app, ["credentials", "audit", "--strict", "--json"])
     assert cleanup_result.exit_code == 2, cleanup_result.output
+
+
+def test_build_credential_audit_flags_expiring_soon():
+    report = build_credential_audit(
+        [
+            _credential("agent-ok", "ok-1"),
+            _credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z"),
+        ]
+    )
+    by_agent = {a["agent_id"]: a for a in report["agents"]}
+    assert not by_agent["agent-ok"]["expiring_soon"]
+    assert by_agent["agent-expiring"]["expiring_soon"]
+    assert by_agent["agent-expiring"]["severity"] == "warning"
+    assert "rotate" in by_agent["agent-expiring"]["recommendation"]
+    assert report["summary"]["expiring_soon"] == 1
+    assert report["summary"]["ok"] == 1
+
+
+def test_credentials_audit_strict_fails_for_expiring_soon(monkeypatch):
+    class ExpiringClient:
+        def mgmt_list_credentials(self):
+            return [_credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z")]
+
+    monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: ExpiringClient())
+
+    result = runner.invoke(app, ["credentials", "audit", "--strict", "--json"])
+    assert result.exit_code == 2, result.output
+    report = json.loads(result.output)
+    assert report["summary"]["expiring_soon"] == 1
+
+
+def test_credentials_audit_expiring_soon_shown_in_human_output(monkeypatch):
+    class ExpiringClient:
+        def mgmt_list_credentials(self):
+            return [_credential("agent-expiring", "exp-1", expires_at="2026-05-15T00:00:00Z")]
+
+    monkeypatch.setattr("ax_cli.commands.credentials.get_client", lambda: ExpiringClient())
+
+    result = runner.invoke(app, ["credentials", "audit"])
+    assert result.exit_code == 0, result.output
+    assert "expiring_soon=1" in result.output


### PR DESCRIPTION
## Summary

- `ax credentials audit` now flags agent PATs expiring within 14 days: adds `expiring_soon` field per agent, bumps severity to `warning`, and includes a rotation recommendation with days remaining
- `ax credentials audit --strict` exits non-zero on expiring tokens in addition to `cleanup_required` (help text updated to match)
- `ax credentials list` shows days-to-expiry and a `⚠` indicator for credentials at or under the 14-day threshold
- Expiry warning threshold is a named constant (`_EXPIRY_WARNING_DAYS = 14`) for easy future adjustment

## Problem

Operators had no signal that an agent PAT was approaching expiry. The token would silently stop working, breaking the agent with no advance warning in `audit` or `list` output.

## Test plan

- [x] `build_credential_audit` flags expiring tokens and leaves safe tokens clean
- [x] Boundary: token with exactly 14 computed days remaining is included in the warning
- [x] Token with 15 computed days remaining is not flagged (outside window)
- [x] `audit --strict` exits non-zero on expiring tokens
- [x] `credentials list` shows `expires=Nd` and `⚠` for tokens within the window
- [x] All existing tests pass - no regressions
- [x] `uv run ruff check` and `ruff format` pass

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed - read-only diagnostic surface only
