### PR TITLE
fix(heartbeat): move liveness signals from sweep to agent runtime

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -2222,14 +2222,6 @@ def _archive_managed_agent(name: str, *, reason: str | None = None, client_facto
         entry=entry,
         reason=str(reason).strip() if reason else None,
     )
-    user_client = client_factory() if client_factory is not None else _build_session_client_silent()
-    if user_client is not None:
-        from ..gateway import _post_lifecycle_signal as _signal
-
-        try:
-            _signal(user_client, entry, phase="archived", note=str(reason or "")[:240] or None)
-        except Exception:  # noqa: BLE001
-            pass
     return annotate_runtime_health(entry, registry=registry)
 
 
@@ -2255,14 +2247,6 @@ def _restore_managed_agent(name: str, *, client_factory=None) -> dict:
     entry["desired_state"] = prior if prior in {"running", "stopped"} else "stopped"
     save_gateway_registry(registry, merge_archive=False)
     record_gateway_activity("managed_agent_restored", entry=entry)
-    user_client = client_factory() if client_factory is not None else _build_session_client_silent()
-    if user_client is not None:
-        from ..gateway import _post_lifecycle_signal as _signal
-
-        try:
-            _signal(user_client, entry, phase="connected")
-        except Exception:  # noqa: BLE001
-            pass
     return annotate_runtime_health(entry, registry=registry)
 
 

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -52,6 +52,7 @@ DEFAULT_ACTIVITY_LIMIT = 10
 DEFAULT_HANDLER_TIMEOUT_SECONDS = 900
 MIN_HANDLER_TIMEOUT_SECONDS = 1
 SSE_IDLE_TIMEOUT_SECONDS = 45.0
+RUNTIME_HEARTBEAT_INTERVAL_SECONDS = 30.0
 RUNTIME_STALE_AFTER_SECONDS = 75.0
 RUNTIME_HIDDEN_AFTER_SECONDS = 15 * 60.0  # default: hide stale agents after 15 min
 SETUP_ERROR_BACKOFF_SECONDS = 30.0  # silence retry storm after a runtime setup error
@@ -3781,33 +3782,6 @@ def _apply_placement_event(
     }
 
 
-def _post_lifecycle_signal(
-    client: Any,
-    entry: dict[str, Any],
-    *,
-    phase: str,
-    note: str | None = None,
-) -> bool:
-    """Best-effort POST /api/v1/agents/heartbeat with status=<phase>.
-
-    Used to inform the aX platform when a gateway-managed agent crosses a
-    lifecycle threshold (connected/stale/offline/setup_error). 404 means the
-    platform has no record of this agent_id — treat as success so we don't
-    retry forever. Returns True iff a signal was sent (or 404'd).
-    """
-    if client is None:
-        return False
-    agent_id = str(entry.get("agent_id") or "").strip()
-    if not agent_id:
-        return False
-    try:
-        client.send_heartbeat(agent_id=agent_id, status=phase, note=note)
-        return True
-    except Exception as exc:  # noqa: BLE001
-        status_code = getattr(getattr(exc, "response", None), "status_code", None)
-        if status_code == 404:
-            return True
-        return False
 
 
 def _post_placement_ack(
@@ -4742,6 +4716,7 @@ class ManagedAgentRuntime:
         self.stop_event = threading.Event()
         self._listener_thread: threading.Thread | None = None
         self._worker_thread: threading.Thread | None = None
+        self._stale_signaled: bool = False
         self._queue: queue.Queue = queue.Queue(maxsize=int(entry.get("queue_size") or DEFAULT_QUEUE_SIZE))
         self._reply_anchor_ids: set[str] = set()
         self._seen_ids: set[str] = set()
@@ -4812,9 +4787,28 @@ class ManagedAgentRuntime:
             agent_id=self.agent_id,
         )
 
+    def _send_heartbeat_best_effort(self, status: str) -> None:
+        """Create a short-lived client, send one heartbeat, always close it."""
+        client = None
+        try:
+            client = self._new_client()
+            client.send_heartbeat(status=status)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
     def _update_state(self, **fields: Any) -> None:
         with self._state_lock:
+            prev = self._state.get("effective_state")
             self._state.update(fields)
+            new = self._state.get("effective_state")
+        if new == "error" and prev != "error":
+            self._send_heartbeat_best_effort("setup_error")
 
     def _bump(self, field: str, amount: int = 1) -> None:
         with self._state_lock:
@@ -5035,6 +5029,7 @@ class ManagedAgentRuntime:
             current_tool=None,
             current_tool_call_id=None,
         )
+        self._send_heartbeat_best_effort("offline")
         record_gateway_activity("runtime_stopped", entry=self.entry)
         self._log("stopped")
 
@@ -6221,6 +6216,7 @@ class ManagedAgentRuntime:
                     self._stream_response = response
                     if response.status_code != 200:
                         raise ConnectionError(f"SSE failed: {response.status_code}")
+                    self._stale_signaled = False
                     self._update_state(
                         effective_state="running",
                         current_status=None,
@@ -6232,9 +6228,18 @@ class ManagedAgentRuntime:
                     )
                     record_gateway_activity("listener_connected", entry=self.entry, reconnected=reconnected)
                     backoff = 1.0
+                    import time as _time
+                    _last_heartbeat = _time.monotonic() - RUNTIME_HEARTBEAT_INTERVAL_SECONDS
                     for event_type, data in _iter_sse(response):
                         if self.stop_event.is_set():
                             break
+                        _now = _time.monotonic()
+                        if _now - _last_heartbeat >= RUNTIME_HEARTBEAT_INTERVAL_SECONDS:
+                            try:
+                                self._send_client.send_heartbeat(status="connected")
+                            except Exception:  # noqa: BLE001
+                                pass
+                            _last_heartbeat = _now
                         if event_type in {"bootstrap", "heartbeat", "ping", "identity_bootstrap", "connected"}:
                             self._update_state(last_seen_at=_now_iso())
                             continue
@@ -6351,6 +6356,15 @@ class ManagedAgentRuntime:
                     last_listener_error_at=_now_iso(),
                     reconnect_backoff_seconds=int(backoff),
                 )
+                if not self._stale_signaled:
+                    if self._send_client is not None:
+                        try:
+                            self._send_client.send_heartbeat(status="stale")
+                        except Exception:  # noqa: BLE001
+                            pass
+                    else:
+                        self._send_heartbeat_best_effort("stale")
+                    self._stale_signaled = True
                 record_gateway_activity(
                     event_name, entry=self.entry, error=error_text, reconnect_in_seconds=int(backoff)
                 )
@@ -6751,29 +6765,28 @@ class GatewayDaemon:
         *,
         session: dict[str, Any] | None,
     ) -> None:
-        """Per-tick sweep: signal liveness transitions upstream.
+        """Per-tick sweep: observe liveness and skip non-roster agents.
 
-        Hide and restore are operator-driven only. The sweep observes liveness
-        and signals deltas upstream; it never mutates ``lifecycle_phase``. Use
-        ``ax gateway agents hide`` / ``unhide`` (or the Cleanup UI) to change
-        lifecycle phase.
+        Hide and restore are operator-driven only. The sweep never mutates
+        ``lifecycle_phase``. Use ``ax gateway agents hide`` / ``unhide``
+        (or the Cleanup UI) to change lifecycle phase.
 
-        - Skips system agents (switchboards, service accounts).
-        - Skips archived entries entirely (no upstream signaling either —
-          archive already signaled).
-        - On any liveness delta vs last_lifecycle_signal.phase, calls
-          send_heartbeat upstream best-effort. 404 counts as success.
+        Upstream liveness signaling (heartbeats) is intentionally absent here:
+        the heartbeat endpoint requires an agent-bound token; the sweep's
+        user token is always rejected (400 "Not a bound agent session").
+        Connected heartbeats are sent from _listener_loop using the agent's
+        own bound client. Offline is signaled from stop(). Stale/setup_error
+        require a management endpoint that accepts user-admin tokens — not
+        yet available.
         """
         agents = registry.get("agents") or []
         if not agents:
             return
-        client = self._sweep_client(session)
         for entry in agents:
             if not isinstance(entry, dict):
                 continue
             if _is_system_agent(entry):
                 continue
-            liveness = str(entry.get("liveness") or "").strip().lower()
             phase = str(entry.get("lifecycle_phase") or "active").strip().lower()
             if phase not in _LIFECYCLE_PHASES:
                 phase = "active"
@@ -6786,20 +6799,10 @@ class GatewayDaemon:
             if phase in {"archived", "hidden"}:
                 continue
 
-            # Upstream signal on liveness delta. Sticky liveness rate-limits.
-            if liveness in {"connected", "stale", "offline", "setup_error"}:
-                last_signal = entry.get("last_lifecycle_signal") or {}
-                if not isinstance(last_signal, dict):
-                    last_signal = {}
-                prev_phase = str(last_signal.get("phase") or "").strip().lower()
-                if liveness != prev_phase:
-                    sent = _post_lifecycle_signal(client, entry, phase=liveness)
-                    if sent:
-                        entry["last_lifecycle_signal"] = {
-                            "phase": liveness,
-                            "at": _now_iso(),
-                            "agent_id": str(entry.get("agent_id") or ""),
-                        }
+            # Placeholder: the sweep loop is retained for future per-tick
+            # registry maintenance (e.g. auto-hide long-stale agents, clean
+            # up orphaned entries). Nothing to act on here yet.
+
 
     def run(self, *, once: bool = False) -> None:
         session = load_gateway_session()

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -503,6 +503,7 @@ class _SharedRuntimeClient:
         self.sent = []
         self.processing = []
         self.tool_calls = []
+        self.heartbeats = []
         self.connect_calls = 0
 
     def connect_sse(self, *, space_id, timeout=None):
@@ -538,6 +539,10 @@ class _SharedRuntimeClient:
     def record_tool_call(self, **payload):
         self.tool_calls.append(payload)
         return {"ok": True, "tool_call_id": payload["tool_call_id"]}
+
+    def send_heartbeat(self, *, agent_id=None, status=None, note=None, cadence_seconds=None):
+        self.heartbeats.append({"agent_id": agent_id, "status": status})
+        return {"ok": True}
 
     def close(self):
         return None
@@ -2358,6 +2363,90 @@ def test_managed_echo_runtime_processes_message(tmp_path, monkeypatch):
     assert "message_received" in event_names
     assert "message_claimed" in event_names
     assert "reply_sent" in event_names
+
+
+def test_runtime_sends_connected_heartbeat_on_first_sse_event(tmp_path, monkeypatch):
+    """Listener loop sends 'connected' heartbeat on first SSE event after connecting."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    token_file = tmp_path / "token"
+    token_file.write_text("axp_a_agent.secret")
+    payload = {"id": "msg-hb", "content": "ping", "author": {"id": "u1", "name": "u", "type": "user"}, "mentions": ["hb-bot"]}
+    shared = _SharedRuntimeClient(payload)
+    runtime = gateway_core.ManagedAgentRuntime(
+        {"name": "hb-bot", "agent_id": "agent-hb", "space_id": "s1", "base_url": "https://paxai.app", "runtime_type": "echo", "token_file": str(token_file)},
+        client_factory=lambda **kwargs: shared,
+    )
+    runtime.start()
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not shared.heartbeats:
+        time.sleep(0.05)
+    runtime.stop()
+    assert any(h["status"] == "connected" for h in shared.heartbeats)
+
+
+def test_runtime_sends_stale_heartbeat_on_sse_disconnect(tmp_path, monkeypatch):
+    """Listener loop sends 'stale' heartbeat when SSE connection drops."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    token_file = tmp_path / "token"
+    token_file.write_text("axp_a_agent.secret")
+
+    class _FailOnSecondConnect(_SharedRuntimeClient):
+        def connect_sse(self, *, space_id, timeout=None):
+            self.connect_calls += 1
+            if self.connect_calls == 1:
+                raise ConnectionError("SSE dropped")
+            raise ConnectionError("test done")
+
+    shared = _FailOnSecondConnect({})
+    runtime = gateway_core.ManagedAgentRuntime(
+        {"name": "stale-bot", "agent_id": "agent-stale", "space_id": "s1", "base_url": "https://paxai.app", "runtime_type": "echo", "token_file": str(token_file)},
+        client_factory=lambda **kwargs: shared,
+    )
+    runtime.start()
+    deadline = time.time() + 3.0
+    while time.time() < deadline and not any(h["status"] == "stale" for h in shared.heartbeats):
+        time.sleep(0.05)
+    runtime.stop()
+    assert any(h["status"] == "stale" for h in shared.heartbeats)
+
+
+def test_runtime_sends_offline_heartbeat_on_stop(tmp_path, monkeypatch):
+    """stop() sends 'offline' heartbeat using the agent-bound client."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    token_file = tmp_path / "token"
+    token_file.write_text("axp_a_agent.secret")
+    shared = _SharedRuntimeClient({})
+    runtime = gateway_core.ManagedAgentRuntime(
+        {"name": "offline-bot", "agent_id": "agent-off", "space_id": "s1", "base_url": "https://paxai.app", "runtime_type": "echo", "token_file": str(token_file)},
+        client_factory=lambda **kwargs: shared,
+    )
+    runtime.stop()
+    assert any(h["status"] == "offline" for h in shared.heartbeats)
+
+
+def test_runtime_sends_setup_error_heartbeat_on_error_state(tmp_path, monkeypatch):
+    """_update_state fires 'setup_error' heartbeat on first transition to error."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    token_file = tmp_path / "token"
+    token_file.write_text("axp_a_agent.secret")
+    shared = _SharedRuntimeClient({})
+    runtime = gateway_core.ManagedAgentRuntime(
+        {"name": "err-bot", "agent_id": "agent-err", "space_id": "s1", "base_url": "https://paxai.app", "runtime_type": "echo", "token_file": str(token_file)},
+        client_factory=lambda **kwargs: shared,
+    )
+    runtime._update_state(effective_state="error", last_error="test error")
+    assert any(h["status"] == "setup_error" for h in shared.heartbeats)
+    # Second transition to error should not fire again
+    runtime._update_state(effective_state="error", last_error="still broken")
+    assert sum(1 for h in shared.heartbeats if h["status"] == "setup_error") == 1
 
 
 def test_managed_exec_runtime_parses_gateway_progress_events(tmp_path, monkeypatch):
@@ -6041,8 +6130,9 @@ def test_sweep_does_not_auto_hide_stale_agent(monkeypatch, tmp_path):
     assert "hidden_reason" not in entry
     recent = gateway_core.load_recent_gateway_activity()
     assert not any(r.get("event") == "managed_agent_hidden" for r in recent)
-    # Upstream liveness signal still goes out — that's the sweep's only job.
-    assert client.heartbeats and client.heartbeats[0]["status"] == "stale"
+    # Sweep no longer sends heartbeats — agent runtimes send them from their
+    # own bound clients. Sweep's user token is rejected by the heartbeat endpoint.
+    assert client.heartbeats == []
 
 
 def test_sweep_skips_switchboard(monkeypatch, tmp_path):
@@ -6683,50 +6773,6 @@ def test_operator_cleanup_restore_unhides_selected_agents(monkeypatch, tmp_path)
     assert [event["event"] for event in recent].count("managed_agent_unhidden") == 1
 
 
-def test_lifecycle_signal_sent_on_connected_to_stale(monkeypatch, tmp_path):
-    _isolate_gateway_paths(monkeypatch, tmp_path)
-    client = _RecordingHeartbeatClient()
-    daemon = _build_daemon(client)
-    entry = _stale_hermes_entry("hermes-flap", age_seconds=20 * 60)
-    registry = {"agents": [entry]}
-    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
-    assert len(client.heartbeats) == 1
-    assert client.heartbeats[0]["status"] == "stale"
-    assert client.heartbeats[0]["agent_id"] == entry["agent_id"]
-    assert entry["last_lifecycle_signal"]["phase"] == "stale"
-
-
-def test_lifecycle_signal_idempotent(monkeypatch, tmp_path):
-    _isolate_gateway_paths(monkeypatch, tmp_path)
-    client = _RecordingHeartbeatClient()
-    daemon = _build_daemon(client)
-    entry = _stale_hermes_entry("hermes-flap", age_seconds=20 * 60)
-    registry = {"agents": [entry]}
-    session = {"token": "axp_u_test", "base_url": "http://x"}
-    daemon._sweep_lifecycle(registry, session=session)
-    daemon._sweep_lifecycle(registry, session=session)
-    assert len(client.heartbeats) == 1
-
-
-def test_lifecycle_signal_404_tolerant(monkeypatch, tmp_path):
-    _isolate_gateway_paths(monkeypatch, tmp_path)
-    boom = httpx.HTTPStatusError(
-        "platform has no record",
-        request=httpx.Request("POST", "http://x/api/v1/agents/heartbeat"),
-        response=httpx.Response(404),
-    )
-    client = _RecordingHeartbeatClient(fail_with=boom, fail_status_code=404)
-    daemon = _build_daemon(client)
-    entry = _stale_hermes_entry("hermes-ghost", age_seconds=20 * 60)
-    registry = {"agents": [entry]}
-    daemon._sweep_lifecycle(registry, session={"token": "axp_u_test", "base_url": "http://x"})
-    # Sweep doesn't mutate lifecycle_phase regardless of upstream response.
-    assert entry.get("lifecycle_phase", "active") == "active"
-    # 404 counts as "platform doesn't know about this agent" — sticky signal
-    # still updated so we don't retry forever.
-    assert entry["last_lifecycle_signal"]["phase"] == "stale"
-
-
 def test_remove_managed_agent_calls_delete_agent_then_local_remove(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
     token_path = tmp_path / "tok"
@@ -6854,8 +6900,6 @@ def test_archive_managed_agent_sets_phase_and_stops_runtime(monkeypatch, tmp_pat
     assert stored["desired_state"] == "stopped"
     assert stored["desired_state_before_archive"] == "running"
     assert "archived_at" in stored
-    # Upstream signal sent best-effort.
-    assert any(h["status"] == "archived" for h in client.heartbeats)
     # Audit event recorded.
     recent = gateway_core.load_recent_gateway_activity()
     assert any(r.get("event") == "managed_agent_archived" for r in recent)
@@ -6913,8 +6957,6 @@ def test_archive_then_restore_returns_to_prior_desired_state(monkeypatch, tmp_pa
     assert "desired_state_before_archive" not in stored
     recent = gateway_core.load_recent_gateway_activity()
     assert any(r.get("event") == "managed_agent_restored" for r in recent)
-    # Restore signals 'connected' upstream.
-    assert any(h["status"] == "connected" for h in client.heartbeats)
 
 
 def test_restore_unarchived_agent_is_noop(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

The sweep was sending heartbeats to `/api/v1/agents/heartbeat` using a user-level token. The backend requires an agent-bound session and rejects these with `400 "Not a bound agent session"`. Under a typical gateway load with multiple managed agents, this silently burned the entire rate-limit budget on every 1s reconcile tick.

**Changes:**

- Remove `_post_lifecycle_signal` and all sweep heartbeat calls. The sweep's user token cannot satisfy the agent-bound requirement; a comment explains what a management endpoint would need to support this properly.
- Inject `"connected"` heartbeat into `_listener_loop` using the agent's own bound client. Fires immediately on first SSE event (timer pre-offset by the interval), then every 30s (`RUNTIME_HEARTBEAT_INTERVAL_SECONDS`).
- Send `"stale"` heartbeat from the reconnect error path when the SSE connection drops.
- Send `"offline"` heartbeat from `stop()` on graceful shutdown.
- Send `"setup_error"` heartbeat from `_update_state` on first transition to `effective_state="error"`.
- Remove broken `_post_lifecycle_signal` calls from archive/restore (user token, always 400).
- Add tests covering all four signal paths.

**Known gap:** stale/offline/setup_error signals for agents whose runtime isn't running (e.g. intentionally stopped or archived) require a management endpoint that accepts user-admin tokens — not addressed here.

## Test plan

- Start the gateway with multiple managed agents. Confirm `/api/v1/agents/heartbeat` returns `200` in `api-requests.log` (not `400`).
- Confirm `remaining` in the log stays stable — no longer drains on every reconcile tick.
- Stop a running agent (`ax gateway agents stop <name>`); confirm a `"offline"` heartbeat is sent (visible in the log as a successful POST to `/api/v1/agents/heartbeat`).
- Trigger a setup error (e.g. point an agent at a missing token file); confirm a `"setup_error"` heartbeat is sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)