### PR TITLE
feat(gateway): add bedrock_agentcore managed-agent template

### DIFF
--- a/ax_cli/bridges/bedrock_agentcore_bridge.py
+++ b/ax_cli/bridges/bedrock_agentcore_bridge.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Gateway-managed bridge for Amazon Bedrock AgentCore Runtime.
+
+Designed for `ax gateway agents add ... --template bedrock_agentcore`.
+Invokes an AgentCore runtime once per inbound mention, streams the response,
+and prints the reply on stdout following the Gateway exec-runtime contract.
+
+Auth: boto3 default credential chain (env vars, ~/.aws/credentials, instance
+profile, SSO session). Gateway never stores AWS secrets.
+
+Session continuity: one persistent AgentCore runtime session per
+(agent_id, space_id) pair. Cross-user contamination in wide group spaces
+is documented in docs/gateway-agent-runtimes.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from typing import Any
+
+EVENT_PREFIX = "AX_GATEWAY_EVENT "
+
+_AGENTCORE_ARN_RE = re.compile(r"^arn:aws:bedrock-agentcore:([a-z0-9-]+):(\d{12}):runtime/(.+)$")
+_MODEL_ARN_RE = re.compile(r"^arn:aws:bedrock:")
+
+_HEARTBEAT_INTERVAL_SECS = 0.25
+_HEARTBEAT_BYTE_BUDGET = 1024
+
+
+def emit_event(payload: dict[str, Any]) -> None:
+    print(f"{EVENT_PREFIX}{json.dumps(payload, sort_keys=True)}", flush=True)
+
+
+def _read_prompt() -> str:
+    if len(sys.argv) > 1 and sys.argv[-1] != "-":
+        return sys.argv[-1]
+    env_prompt = os.environ.get("AX_MENTION_CONTENT", "").strip()
+    if env_prompt:
+        return env_prompt
+    return sys.stdin.read().strip()
+
+
+# ---------------------------------------------------------------------------
+# Deep module 1: template-options validator
+# ---------------------------------------------------------------------------
+
+
+def validate_bedrock_options(
+    *,
+    runtime_arn: str | None,
+    region: str | None,
+    qualifier: str | None,
+    payload_key: str | None,
+    aws_profile: str | None,
+    template_id: str,
+) -> dict[str, str]:
+    """Validate and normalize bedrock template options.
+
+    Pure function — no I/O, no boto3. Returns a validated options dict
+    or raises ValueError with an actionable message.
+    """
+    bedrock_flags_set = any([runtime_arn, region, qualifier, payload_key, aws_profile])
+
+    if bedrock_flags_set and template_id != "bedrock_agentcore":
+        raise ValueError(f"--bedrock-* flags are only valid with --template bedrock_agentcore, not '{template_id}'.")
+
+    arn = (runtime_arn or os.environ.get("AX_BEDROCK_RUNTIME_ARN", "")).strip()
+    if not arn:
+        raise ValueError(
+            "bedrock_agentcore template requires --bedrock-runtime-arn "
+            "(or AX_BEDROCK_RUNTIME_ARN env var). "
+            "Expected shape: arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>"
+        )
+
+    if _MODEL_ARN_RE.match(arn):
+        raise ValueError(
+            f"ARN looks like a Bedrock foundation-model ARN, not an AgentCore runtime ARN: {arn!r}. "
+            "Use the ARN from `agentcore list-runtimes`, not from the model catalog."
+        )
+
+    m = _AGENTCORE_ARN_RE.match(arn)
+    if not m:
+        raise ValueError(
+            f"Invalid AgentCore runtime ARN: {arn!r}. "
+            "Expected: arn:aws:bedrock-agentcore:<region>:<12-digit-account>:runtime/<id>"
+        )
+
+    arn_region = m.group(1)
+    resolved_region = (region or "").strip() or arn_region or None
+
+    return {
+        "bedrock_runtime_arn": arn,
+        "bedrock_region": resolved_region or "",
+        "bedrock_qualifier": (qualifier or "").strip() or "DEFAULT",
+        "bedrock_payload_key": (payload_key or "").strip() or "prompt",
+        "aws_profile": (aws_profile or "").strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Deep module 2: stream-event classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_stream_event(line: str) -> tuple[str, Any]:
+    """Classify one decoded SSE data line (minus the 'data: ' prefix).
+
+    Returns one of:
+        ("reply_text",    str)   — plain text, append to reply buffer
+        ("error_event",   dict)  — in-band error, abort with status:error
+        ("typed_event",   dict)  — tool_start / tool_result / activity / status
+        ("heartbeat_chunk", dict) — unknown JSON dict, throttle before emitting
+    """
+    if not line:
+        return ("reply_text", "")
+
+    try:
+        data = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return ("reply_text", line)
+
+    if not isinstance(data, dict):
+        return ("reply_text", str(data) if data else "")
+
+    # Error shapes
+    event_field = str(data.get("event") or "").lower()
+    type_field = str(data.get("type") or "").lower()
+    if event_field in ("error", "failed", "exception") or type_field == "error" or data.get("error"):
+        msg = str(data.get("message") or data.get("error") or data.get("detail") or "unknown error")
+        return ("error_event", {"message": msg, "detail": data})
+
+    # Tool use → tool_start
+    if data.get("type") == "tool_use" or (data.get("tool_name") and data.get("tool_call_id") and "input" in data):
+        return (
+            "typed_event",
+            {
+                "kind": "tool_start",
+                "tool_name": str(data.get("tool_name") or data.get("name") or ""),
+                "tool_call_id": str(data.get("tool_call_id") or data.get("id") or ""),
+            },
+        )
+
+    # Tool result → tool_result
+    if data.get("type") == "tool_result" or (data.get("tool_call_id") and "result" in data):
+        status = "ok" if not data.get("is_error") else "error"
+        return (
+            "typed_event",
+            {
+                "kind": "tool_result",
+                "tool_name": str(data.get("tool_name") or ""),
+                "tool_call_id": str(data.get("tool_call_id") or ""),
+                "status": status,
+            },
+        )
+
+    # Thinking / trace / step / delta → activity
+    if data.get("type") in ("thinking", "trace", "step", "delta") or data.get("thinking"):
+        summary = str(data.get("thinking") or data.get("trace") or data.get("content") or "agent thinking")
+        if len(summary) > 120:
+            summary = summary[:117] + "..."
+        return ("typed_event", {"kind": "activity", "activity": summary})
+
+    # Assistant text delta (Strands-style)
+    if data.get("type") == "content_block_delta" and isinstance(data.get("delta"), dict):
+        delta_text = str(data["delta"].get("text") or "")
+        if delta_text:
+            return ("reply_text", delta_text)
+
+    return ("heartbeat_chunk", data)
+
+
+# ---------------------------------------------------------------------------
+# Deep module 3: boto3 client builder
+# ---------------------------------------------------------------------------
+
+
+def build_bedrock_client(*, aws_profile: str, region: str) -> Any:
+    """Build and return a boto3 bedrock-agentcore client.
+
+    Validates that the service is available in the installed boto3 version.
+    Raises RuntimeError with an actionable message if not.
+    """
+    try:
+        import boto3
+        import botocore.config
+    except ImportError as exc:
+        raise RuntimeError(f"boto3 is not installed: {exc}. Install it with: pip install 'axctl[bedrock]'") from exc
+
+    session = boto3.Session(profile_name=aws_profile or None)
+    available = session.get_available_services()
+    if "bedrock-agentcore" not in available:
+        raise RuntimeError(
+            f"boto3 {boto3.__version__} does not include the bedrock-agentcore service client. "
+            "Upgrade with: pip install --upgrade 'boto3>=1.38' 'axctl[bedrock]'"
+        )
+
+    kwargs: dict[str, Any] = {
+        "config": botocore.config.Config(
+            read_timeout=900,
+            connect_timeout=10,
+            retries={"max_attempts": 1, "mode": "standard"},
+        ),
+    }
+    if region:
+        kwargs["region_name"] = region
+
+    return session.client("bedrock-agentcore", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Session ID
+# ---------------------------------------------------------------------------
+
+
+def _compute_session_id(agent_id: str, space_id: str) -> str:
+    """Stable, deterministic session id per (agent_id, space_id) pair.
+
+    AgentCore requires runtimeSessionId >= 33 chars.
+    """
+    raw = uuid.uuid5(uuid.NAMESPACE_URL, f"ax-gateway:{agent_id}:{space_id}").hex
+    return raw.ljust(33, "_")
+
+
+# ---------------------------------------------------------------------------
+# Bridge I/O loop
+# ---------------------------------------------------------------------------
+
+
+def _invoke_event_stream(
+    client: Any, *, runtime_arn: str, session_id: str, payload_key: str, qualifier: str, prompt: str
+) -> tuple[str | None, int]:
+    """Invoke the AgentCore runtime and consume the streaming response.
+
+    Returns (reply_text, chunk_count). reply_text is None when an in-band
+    error was encountered; callers must not emit status:completed in that case.
+    """
+    payload_body = json.dumps({payload_key: prompt})
+    response = client.invoke_agent_runtime(
+        agentRuntimeArn=runtime_arn,
+        runtimeSessionId=session_id,
+        qualifier=qualifier,
+        payload=payload_body,
+    )
+
+    content_type = str(response.get("contentType") or "").lower()
+    chunks = 0
+    reply_parts: list[str] = []
+    last_heartbeat_at = 0.0
+    heartbeat_bytes = 0
+
+    if "event-stream" in content_type or "text/event-stream" in content_type:
+        streaming_body = response.get("response") or response.get("body")
+        for raw_line in streaming_body.iter_lines():
+            line = (
+                raw_line.decode("utf-8", errors="replace").strip() if isinstance(raw_line, bytes) else raw_line.strip()
+            )
+            if not line:
+                continue
+            if line.startswith("data: "):
+                line = line[6:]
+            chunks += 1
+            tag, value = classify_stream_event(line)
+
+            if tag == "reply_text":
+                if value:
+                    reply_parts.append(value)
+            elif tag == "error_event":
+                emit_event(
+                    {
+                        "kind": "status",
+                        "status": "error",
+                        "error_message": value.get("message", "unknown"),
+                        "detail": value.get("detail", {}),
+                    }
+                )
+                return (None, chunks)
+            elif tag == "typed_event":
+                emit_event(value)
+            elif tag == "heartbeat_chunk":
+                now = time.monotonic()
+                heartbeat_bytes += len(line)
+                if now - last_heartbeat_at >= _HEARTBEAT_INTERVAL_SECS or heartbeat_bytes >= _HEARTBEAT_BYTE_BUDGET:
+                    emit_event({"kind": "activity", "activity": "AgentCore processing..."})
+                    last_heartbeat_at = now
+                    heartbeat_bytes = 0
+
+    elif "application/json" in content_type:
+        emit_event({"kind": "activity", "activity": "Buffering JSON response from AgentCore"})
+        body_bytes = b""
+        streaming_body = response.get("response") or response.get("body")
+        for chunk in streaming_body.iter_chunks():
+            body_bytes += chunk
+            chunks += 1
+        try:
+            parsed = json.loads(body_bytes.decode("utf-8"))
+        except Exception:
+            parsed = body_bytes.decode("utf-8", errors="replace")
+        if isinstance(parsed, dict):
+            text = str(
+                parsed.get("result") or parsed.get("output") or parsed.get("response") or parsed.get("text") or ""
+            )
+            reply_parts.append(text or json.dumps(parsed))
+        else:
+            reply_parts.append(str(parsed))
+    else:
+        emit_event({"kind": "activity", "activity": f"AgentCore response content-type: {content_type}"})
+        streaming_body = response.get("response") or response.get("body")
+        body_bytes = streaming_body.read() if hasattr(streaming_body, "read") else b""
+        reply_parts.append(body_bytes.decode("utf-8", errors="replace"))
+
+    return ("".join(reply_parts).strip(), chunks)
+
+
+def main() -> int:
+    prompt = _read_prompt()
+    if not prompt:
+        print("(no mention content received)", file=sys.stderr)
+        return 1
+
+    runtime_arn = os.environ.get("AX_BEDROCK_RUNTIME_ARN", "").strip()
+    region = os.environ.get("AX_BEDROCK_REGION", "").strip()
+    qualifier = os.environ.get("AX_BEDROCK_QUALIFIER", "DEFAULT").strip() or "DEFAULT"
+    payload_key = os.environ.get("AX_BEDROCK_PAYLOAD_KEY", "prompt").strip() or "prompt"
+    aws_profile = os.environ.get("AWS_PROFILE", "").strip()
+    agent_id = (
+        os.environ.get("AX_GATEWAY_AGENT_ID", "").strip() or os.environ.get("AX_AGENT_ID", "").strip() or "unknown"
+    )
+    space_id = (
+        os.environ.get("AX_GATEWAY_SPACE_ID", "").strip() or os.environ.get("AX_SPACE_ID", "").strip() or "unknown"
+    )
+
+    if not runtime_arn:
+        emit_event({"kind": "status", "status": "error", "error_message": "AX_BEDROCK_RUNTIME_ARN is not set"})
+        print("bedrock_agentcore bridge: AX_BEDROCK_RUNTIME_ARN not set", file=sys.stderr)
+        return 1
+
+    try:
+        client = build_bedrock_client(aws_profile=aws_profile, region=region)
+    except RuntimeError as exc:
+        emit_event({"kind": "status", "status": "error", "error_message": str(exc)})
+        print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
+        return 1
+
+    session_id = _compute_session_id(agent_id, space_id)
+
+    emit_event({"kind": "status", "status": "processing", "message": "Invoking AgentCore runtime"})
+    emit_event(
+        {"kind": "activity", "activity": f"AgentCore runtime accepted invocation (session {session_id[:12]}...)"}
+    )
+
+    started = time.monotonic()
+    try:
+        reply, chunks = _invoke_event_stream(
+            client,
+            runtime_arn=runtime_arn,
+            session_id=session_id,
+            payload_key=payload_key,
+            qualifier=qualifier,
+            prompt=prompt,
+        )
+    except Exception as exc:
+        try:
+            import botocore.exceptions
+
+            error_code = "unknown"
+            if isinstance(exc, botocore.exceptions.ClientError):
+                error_code = exc.response.get("Error", {}).get("Code", "ClientError")
+            elif isinstance(exc, botocore.exceptions.BotoCoreError):
+                error_code = type(exc).__name__
+        except ImportError:
+            error_code = type(exc).__name__
+        emit_event(
+            {"kind": "status", "status": "error", "error_message": str(exc), "detail": {"error_code": error_code}}
+        )
+        print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
+        return 1
+
+    if reply is None:
+        # in-band error already emitted status:error — exit nonzero so Gateway's
+        # worker loop does not auto-emit a synthetic completed event
+        return 1
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    emit_event(
+        {
+            "kind": "status",
+            "status": "completed",
+            "message": f"AgentCore completed in {duration_ms}ms",
+            "detail": {"chunks": chunks, "session_id": session_id, "duration_ms": duration_ms},
+        }
+    )
+
+    if reply:
+        print(reply)
+    else:
+        print("(AgentCore returned no text reply — see activity stream for details)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ax_cli/bridges/bedrock_agentcore_bridge.py
+++ b/ax_cli/bridges/bedrock_agentcore_bridge.py
@@ -9,8 +9,8 @@ Auth: boto3 default credential chain (env vars, ~/.aws/credentials, instance
 profile, SSO session). Gateway never stores AWS secrets.
 
 Session continuity: one persistent AgentCore runtime session per
-(agent_id, space_id) pair. Cross-user contamination in wide group spaces
-is documented in docs/gateway-agent-runtimes.md.
+(agent_id, space_id, sender_id) triple. sender_id is injected by Gateway
+as AX_GATEWAY_SENDER_ID, isolating sessions per caller in shared spaces.
 """
 
 from __future__ import annotations
@@ -217,12 +217,16 @@ def build_bedrock_client(*, aws_profile: str, region: str) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _compute_session_id(agent_id: str, space_id: str) -> str:
-    """Stable, deterministic session id per (agent_id, space_id) pair.
+def _compute_session_id(agent_id: str, space_id: str, sender_id: str | None = None) -> str:
+    """Stable, deterministic session id scoped to (agent_id, space_id, sender_id).
 
+    Including sender_id prevents cross-user session contamination in shared spaces.
     AgentCore requires runtimeSessionId >= 33 chars.
     """
-    raw = uuid.uuid5(uuid.NAMESPACE_URL, f"ax-gateway:{agent_id}:{space_id}").hex
+    key = f"ax-gateway:{agent_id}:{space_id}"
+    if sender_id:
+        key = f"{key}:{sender_id}"
+    raw = uuid.uuid5(uuid.NAMESPACE_URL, key).hex
     return raw.ljust(33, "_")
 
 
@@ -333,6 +337,7 @@ def main() -> int:
     space_id = (
         os.environ.get("AX_GATEWAY_SPACE_ID", "").strip() or os.environ.get("AX_SPACE_ID", "").strip() or "unknown"
     )
+    sender_id = os.environ.get("AX_GATEWAY_SENDER_ID", "").strip() or None
 
     if not runtime_arn:
         emit_event({"kind": "status", "status": "error", "error_message": "AX_BEDROCK_RUNTIME_ARN is not set"})
@@ -346,7 +351,7 @@ def main() -> int:
         print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
         return 1
 
-    session_id = _compute_session_id(agent_id, space_id)
+    session_id = _compute_session_id(agent_id, space_id, sender_id)
 
     emit_event({"kind": "status", "status": "processing", "message": "Invoking AgentCore runtime"})
     emit_event(

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1325,7 +1325,7 @@ def _register_managed_agent(
             qualifier=bedrock_qualifier,
             payload_key=bedrock_payload_key,
             aws_profile=aws_profile,
-            template_id=template_effective_id or "bedrock_agentcore",
+            template_id=template_effective_id,
         )
     if template_effective_id in {"hermes", "sentinel_cli", "claude_code_channel"} and not explicit_workdir:
         raise ValueError(
@@ -1822,14 +1822,14 @@ def _update_managed_agent(
         entry["ollama_model"] = ollama_model_effective
     else:
         entry.pop("ollama_model", None)
+    bedrock_flags = {
+        "bedrock_runtime_arn": bedrock_runtime_arn,
+        "bedrock_region": bedrock_region,
+        "bedrock_qualifier": bedrock_qualifier,
+        "bedrock_payload_key": bedrock_payload_key,
+        "aws_profile": aws_profile,
+    }
     if template_effective_id == "bedrock_agentcore":
-        bedrock_flags = {
-            "bedrock_runtime_arn": bedrock_runtime_arn,
-            "bedrock_region": bedrock_region,
-            "bedrock_qualifier": bedrock_qualifier,
-            "bedrock_payload_key": bedrock_payload_key,
-            "aws_profile": aws_profile,
-        }
         if template is not None or any(v is not _UNSET for v in bedrock_flags.values()):
             normalized_bedrock = _validate_bedrock_options(
                 runtime_arn=bedrock_runtime_arn
@@ -1847,6 +1847,8 @@ def _update_managed_agent(
             )
             entry.update(normalized_bedrock)
     else:
+        if any(v is not _UNSET for v in bedrock_flags.values()):
+            raise ValueError("--bedrock-* flags are only valid with --template bedrock_agentcore.")
         for _k in ("bedrock_runtime_arn", "bedrock_region", "bedrock_qualifier", "bedrock_payload_key", "aws_profile"):
             entry.pop(_k, None)
     entry["updated_at"] = datetime.now(timezone.utc).isoformat()

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import getpass
 import json
 import os
+import re
 import secrets
 import shlex
 import shutil
@@ -992,6 +993,51 @@ def _resolve_space_via_cache(value: str | None) -> str | None:
     return None
 
 
+_AGENTCORE_ARN_RE = re.compile(r"^arn:aws:bedrock-agentcore:([a-z0-9-]+):(\d{12}):runtime/(.+)$")
+_MODEL_ARN_RE = re.compile(r"^arn:aws:bedrock:")
+
+
+def _validate_bedrock_options(
+    *,
+    runtime_arn: str | None,
+    region: str | None,
+    qualifier: str | None,
+    payload_key: str | None,
+    aws_profile: str | None,
+    template_id: str,
+) -> dict[str, str]:
+    bedrock_flags_set = any([runtime_arn, region, qualifier, payload_key, aws_profile])
+    if bedrock_flags_set and template_id != "bedrock_agentcore":
+        raise ValueError(f"--bedrock-* flags are only valid with --template bedrock_agentcore, not '{template_id}'.")
+    arn = (runtime_arn or os.environ.get("AX_BEDROCK_RUNTIME_ARN", "")).strip()
+    if not arn:
+        raise ValueError(
+            "bedrock_agentcore template requires --bedrock-runtime-arn "
+            "(or AX_BEDROCK_RUNTIME_ARN env var). "
+            "Expected shape: arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>"
+        )
+    if _MODEL_ARN_RE.match(arn):
+        raise ValueError(
+            f"ARN looks like a Bedrock foundation-model ARN, not an AgentCore runtime ARN: {arn!r}. "
+            "Use the ARN from `agentcore list-runtimes`, not from the model catalog."
+        )
+    m = _AGENTCORE_ARN_RE.match(arn)
+    if not m:
+        raise ValueError(
+            f"Invalid AgentCore runtime ARN: {arn!r}. "
+            "Expected: arn:aws:bedrock-agentcore:<region>:<12-digit-account>:runtime/<id>"
+        )
+    arn_region = m.group(1)
+    resolved_region = (region or "").strip() or arn_region or None
+    return {
+        "bedrock_runtime_arn": arn,
+        "bedrock_region": resolved_region or "",
+        "bedrock_qualifier": (qualifier or "").strip() or "DEFAULT",
+        "bedrock_payload_key": (payload_key or "").strip() or "prompt",
+        "aws_profile": (aws_profile or "").strip(),
+    }
+
+
 def _normalize_runtime_type(runtime_type: str) -> str:
     try:
         return str(runtime_type_definition(runtime_type)["id"])
@@ -1273,9 +1319,7 @@ def _register_managed_agent(
     bedrock_flags_set = any([bedrock_runtime_arn, bedrock_region, bedrock_qualifier, bedrock_payload_key, aws_profile])
     normalized_bedrock: dict[str, str] = {}
     if bedrock_flags_set or template_effective_id == "bedrock_agentcore":
-        from examples.gateway_bedrock_agentcore.bedrock_agentcore_bridge import validate_bedrock_options
-
-        normalized_bedrock = validate_bedrock_options(
+        normalized_bedrock = _validate_bedrock_options(
             runtime_arn=bedrock_runtime_arn,
             region=bedrock_region,
             qualifier=bedrock_qualifier,
@@ -1659,6 +1703,11 @@ def _update_managed_agent(
     exec_cmd: str | object = _UNSET,
     workdir: str | object = _UNSET,
     ollama_model: str | object = _UNSET,
+    bedrock_runtime_arn: str | object = _UNSET,
+    bedrock_region: str | object = _UNSET,
+    bedrock_qualifier: str | object = _UNSET,
+    bedrock_payload_key: str | object = _UNSET,
+    aws_profile: str | object = _UNSET,
     description: str | None = None,
     model: str | None = None,
     system_prompt: str | object = _UNSET,
@@ -1773,6 +1822,33 @@ def _update_managed_agent(
         entry["ollama_model"] = ollama_model_effective
     else:
         entry.pop("ollama_model", None)
+    if template_effective_id == "bedrock_agentcore":
+        bedrock_flags = {
+            "bedrock_runtime_arn": bedrock_runtime_arn,
+            "bedrock_region": bedrock_region,
+            "bedrock_qualifier": bedrock_qualifier,
+            "bedrock_payload_key": bedrock_payload_key,
+            "aws_profile": aws_profile,
+        }
+        if any(v is not _UNSET for v in bedrock_flags.values()):
+            normalized_bedrock = _validate_bedrock_options(
+                runtime_arn=bedrock_runtime_arn
+                if bedrock_runtime_arn is not _UNSET
+                else entry.get("bedrock_runtime_arn"),  # type: ignore[arg-type]
+                region=bedrock_region
+                if bedrock_region is not _UNSET
+                else (None if bedrock_runtime_arn is not _UNSET else entry.get("bedrock_region")),  # type: ignore[arg-type]
+                qualifier=bedrock_qualifier if bedrock_qualifier is not _UNSET else entry.get("bedrock_qualifier"),  # type: ignore[arg-type]
+                payload_key=bedrock_payload_key
+                if bedrock_payload_key is not _UNSET
+                else entry.get("bedrock_payload_key"),  # type: ignore[arg-type]
+                aws_profile=aws_profile if aws_profile is not _UNSET else entry.get("aws_profile"),  # type: ignore[arg-type]
+                template_id="bedrock_agentcore",
+            )
+            entry.update(normalized_bedrock)
+    else:
+        for _k in ("bedrock_runtime_arn", "bedrock_region", "bedrock_qualifier", "bedrock_payload_key", "aws_profile"):
+            entry.pop(_k, None)
     entry["updated_at"] = datetime.now(timezone.utc).isoformat()
     entry.setdefault("transport", "gateway")
     entry.setdefault("credential_source", "gateway")
@@ -8224,7 +8300,9 @@ def local_inbox(
 def add_agent(
     name: str = typer.Argument(..., help="Managed agent name"),
     template_id: str = typer.Option(
-        None, "--template", help="Agent template: echo_test | ollama | hermes | sentinel_cli | claude_code_channel"
+        None,
+        "--template",
+        help="Agent template: echo_test | ollama | hermes | strands | langgraph | bedrock_agentcore | sentinel_cli | claude_code_channel",
     ),
     runtime_type: str = typer.Option(
         None,
@@ -8368,6 +8446,13 @@ def update_agent(
     exec_cmd: str = typer.Option(None, "--exec", help="Advanced override for exec-based templates"),
     workdir: str = typer.Option(None, "--workdir", help="Advanced working directory override"),
     ollama_model: str = typer.Option(None, "--ollama-model", help="Ollama model override for the Ollama template"),
+    bedrock_runtime_arn: str = typer.Option(None, "--bedrock-runtime-arn", help="Update AgentCore runtime ARN"),
+    bedrock_region: str = typer.Option(None, "--bedrock-region", help="Update AWS region override"),
+    bedrock_qualifier: str = typer.Option(None, "--bedrock-qualifier", help="Update AgentCore endpoint qualifier"),
+    bedrock_payload_key: str = typer.Option(
+        None, "--bedrock-payload-key", help="Update JSON key used to pass the prompt"
+    ),
+    aws_profile: str = typer.Option(None, "--aws-profile", help="Update AWS profile for this agent"),
     description: str = typer.Option(None, "--description", help="Update platform agent description"),
     model: str = typer.Option(None, "--model", help="Update platform agent model"),
     system_prompt: str = typer.Option(
@@ -8423,6 +8508,11 @@ def update_agent(
             exec_cmd=exec_cmd if exec_cmd is not None else _UNSET,
             workdir=workdir if workdir is not None else _UNSET,
             ollama_model=ollama_model if ollama_model is not None else _UNSET,
+            bedrock_runtime_arn=bedrock_runtime_arn if bedrock_runtime_arn is not None else _UNSET,
+            bedrock_region=bedrock_region if bedrock_region is not None else _UNSET,
+            bedrock_qualifier=bedrock_qualifier if bedrock_qualifier is not None else _UNSET,
+            bedrock_payload_key=bedrock_payload_key if bedrock_payload_key is not None else _UNSET,
+            aws_profile=aws_profile if aws_profile is not None else _UNSET,
             description=description,
             model=model,
             system_prompt=resolved_prompt,

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1830,7 +1830,7 @@ def _update_managed_agent(
             "bedrock_payload_key": bedrock_payload_key,
             "aws_profile": aws_profile,
         }
-        if any(v is not _UNSET for v in bedrock_flags.values()):
+        if template is not None or any(v is not _UNSET for v in bedrock_flags.values()):
             normalized_bedrock = _validate_bedrock_options(
                 runtime_arn=bedrock_runtime_arn
                 if bedrock_runtime_arn is not _UNSET

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1229,6 +1229,11 @@ def _register_managed_agent(
     exec_cmd: str | None = None,
     workdir: str | None = None,
     ollama_model: str | None = None,
+    bedrock_runtime_arn: str | None = None,
+    bedrock_region: str | None = None,
+    bedrock_qualifier: str | None = None,
+    bedrock_payload_key: str | None = None,
+    aws_profile: str | None = None,
     space_id: str | None = None,
     audience: str = "both",
     description: str | None = None,
@@ -1265,6 +1270,19 @@ def _register_managed_agent(
         raise ValueError("--ollama-model is only supported with the Ollama template.")
     if template_effective_id == "ollama" and not normalized_ollama_model:
         normalized_ollama_model = str(ollama_setup_status().get("recommended_model") or "").strip() or None
+    bedrock_flags_set = any([bedrock_runtime_arn, bedrock_region, bedrock_qualifier, bedrock_payload_key, aws_profile])
+    normalized_bedrock: dict[str, str] = {}
+    if bedrock_flags_set or template_effective_id == "bedrock_agentcore":
+        from examples.gateway_bedrock_agentcore.bedrock_agentcore_bridge import validate_bedrock_options
+
+        normalized_bedrock = validate_bedrock_options(
+            runtime_arn=bedrock_runtime_arn,
+            region=bedrock_region,
+            qualifier=bedrock_qualifier,
+            payload_key=bedrock_payload_key,
+            aws_profile=aws_profile,
+            template_id=template_effective_id or "bedrock_agentcore",
+        )
     if template_effective_id in {"hermes", "sentinel_cli", "claude_code_channel"} and not explicit_workdir:
         raise ValueError(
             f"Template {template['label']} requires --workdir so Gateway can bind the agent to its runtime folder."
@@ -1340,6 +1358,11 @@ def _register_managed_agent(
         "exec_command": exec_cmd,
         "workdir": workdir,
         "ollama_model": normalized_ollama_model,
+        "bedrock_runtime_arn": normalized_bedrock.get("bedrock_runtime_arn"),
+        "bedrock_region": normalized_bedrock.get("bedrock_region"),
+        "bedrock_qualifier": normalized_bedrock.get("bedrock_qualifier"),
+        "bedrock_payload_key": normalized_bedrock.get("bedrock_payload_key"),
+        "aws_profile": normalized_bedrock.get("aws_profile"),
         "timeout_seconds": timeout_effective,
         "token_file": str(token_file),
         "desired_state": "running" if start else "stopped",
@@ -8211,6 +8234,21 @@ def add_agent(
     exec_cmd: str = typer.Option(None, "--exec", help="Advanced override for exec-based templates"),
     workdir: str = typer.Option(None, "--workdir", help="Advanced working directory override"),
     ollama_model: str = typer.Option(None, "--ollama-model", help="Ollama model override for the Ollama template"),
+    bedrock_runtime_arn: str = typer.Option(
+        None, "--bedrock-runtime-arn", help="AgentCore runtime ARN (bedrock_agentcore template)"
+    ),
+    bedrock_region: str = typer.Option(
+        None, "--bedrock-region", help="AWS region override; parsed from ARN if omitted"
+    ),
+    bedrock_qualifier: str = typer.Option(
+        None, "--bedrock-qualifier", help="AgentCore endpoint qualifier (default: DEFAULT)"
+    ),
+    bedrock_payload_key: str = typer.Option(
+        None, "--bedrock-payload-key", help="JSON key used to pass the prompt (default: prompt)"
+    ),
+    aws_profile: str = typer.Option(
+        None, "--aws-profile", help="AWS profile to use for this agent (injects AWS_PROFILE)"
+    ),
     space_id: str = typer.Option(
         None,
         "--space",
@@ -8285,6 +8323,11 @@ def add_agent(
             exec_cmd=exec_cmd,
             workdir=workdir,
             ollama_model=ollama_model,
+            bedrock_runtime_arn=bedrock_runtime_arn,
+            bedrock_region=bedrock_region,
+            bedrock_qualifier=bedrock_qualifier,
+            bedrock_payload_key=bedrock_payload_key,
+            aws_profile=aws_profile,
             space_id=space_id,
             audience=audience,
             description=description,

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3977,6 +3977,7 @@ def _run_exec_handler(
     *,
     message_id: str | None = None,
     space_id: str | None = None,
+    sender_id: str | None = None,
     timeout_seconds: int | None = None,
     on_event: Callable[[dict[str, Any]], None] | None = None,
 ) -> str:
@@ -3986,6 +3987,8 @@ def _run_exec_handler(
         env["AX_GATEWAY_MESSAGE_ID"] = message_id
     if space_id:
         env["AX_GATEWAY_SPACE_ID"] = space_id
+    if sender_id:
+        env["AX_GATEWAY_SENDER_ID"] = sender_id
     # Expose the composed system prompt (operator role + gateway environment
     # context) so exec-runtime bridges (Ollama, custom python bridges, etc.)
     # can read it via env. Hermes / Claude / Sentinel pass the prompt as a
@@ -6056,12 +6059,14 @@ class ManagedAgentRuntime:
             command = str(self.entry.get("exec_command") or "").strip()
             if not command:
                 raise ValueError("exec runtime requires exec_command")
+            sender_id = str((data or {}).get("agent_id") or (data or {}).get("agent_name") or "").strip() or None
             return _run_exec_handler(
                 command,
                 prompt,
                 self.entry,
                 message_id=message_id or None,
                 space_id=self.space_id,
+                sender_id=sender_id,
                 timeout_seconds=runtime_timeout_seconds(self.entry),
                 on_event=lambda event: self._handle_exec_event(event, message_id=message_id),
             )

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3923,6 +3923,17 @@ def sanitize_exec_env(prompt: str, entry: dict[str, Any]) -> dict[str, str]:
     hermes_repo_path = str(entry.get("hermes_repo_path") or "").strip()
     if hermes_repo_path:
         env["HERMES_REPO_PATH"] = hermes_repo_path
+    bedrock_arn = str(entry.get("bedrock_runtime_arn") or "").strip()
+    if bedrock_arn:
+        env["AX_BEDROCK_RUNTIME_ARN"] = bedrock_arn
+        bedrock_region = str(entry.get("bedrock_region") or "").strip()
+        if bedrock_region:
+            env["AX_BEDROCK_REGION"] = bedrock_region
+        env["AX_BEDROCK_QUALIFIER"] = str(entry.get("bedrock_qualifier") or "DEFAULT").strip() or "DEFAULT"
+        env["AX_BEDROCK_PAYLOAD_KEY"] = str(entry.get("bedrock_payload_key") or "prompt").strip() or "prompt"
+        aws_profile = str(entry.get("aws_profile") or "").strip()
+        if aws_profile:
+            env["AWS_PROFILE"] = aws_profile
     return env
 
 

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -6059,7 +6059,14 @@ class ManagedAgentRuntime:
             command = str(self.entry.get("exec_command") or "").strip()
             if not command:
                 raise ValueError("exec runtime requires exec_command")
-            sender_id = str((data or {}).get("agent_id") or (data or {}).get("agent_name") or "").strip() or None
+            _d = data or {}
+            _author = _d.get("author") or {}
+            sender_id = (
+                str(
+                    _author.get("id") or _author.get("name") or _d.get("agent_id") or _d.get("agent_name") or ""
+                ).strip()
+                or None
+            )
             return _run_exec_handler(
                 command,
                 prompt,

--- a/ax_cli/gateway_runtime_types.py
+++ b/ax_cli/gateway_runtime_types.py
@@ -421,6 +421,45 @@ def agent_template_catalog() -> dict[str, dict[str, Any]]:
                 "supports_command_override": True,
             },
         },
+        "bedrock_agentcore": {
+            "id": "bedrock_agentcore",
+            "label": "Bedrock AgentCore",
+            "description": "Amazon Bedrock AgentCore Runtime managed by Gateway.",
+            "availability": "ready",
+            "launchable": True,
+            "runtime_type": "exec",
+            "asset_class": "interactive_agent",
+            "intake_model": "launch_on_send",
+            "trigger_sources": ["direct_message"],
+            "return_paths": ["inline_reply"],
+            "telemetry_shape": "basic",
+            "suggested_name": "bedrock-bot",
+            "operator_summary": (
+                "Gateway-managed bridge for a deployed Amazon Bedrock AgentCore runtime. "
+                "Invoke-only: the operator deploys the runtime with the AgentCore CLI; "
+                "this template brings it onto the aX network."
+            ),
+            "recommended_test_message": "Reply with: Bedrock AgentCore round trip OK.",
+            "what_you_need": [
+                "An AWS account with a deployed AgentCore runtime.",
+                "The runtime ARN (from `agentcore list-runtimes`).",
+                "boto3 default credential chain configured (env vars, ~/.aws/credentials, instance profile, SSO).",
+                "IAM permission: bedrock-agentcore:InvokeAgentRuntime on the runtime ARN.",
+                "pip install 'axctl[bedrock]' to add the boto3 dependency.",
+            ],
+            "setup_skill": "gateway-agent-setup",
+            "setup_skill_path": str(skill_path),
+            "defaults": {
+                "runtime_type": "exec",
+                "exec_command": "python3 examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py",
+                "workdir": str(repo_root),
+            },
+            "signals": runtime_signals["exec"],
+            "advanced": {
+                "adapter_label": "Gateway-managed Bedrock AgentCore bridge",
+                "supports_command_override": True,
+            },
+        },
         "hermes": {
             "id": "hermes",
             "label": "Hermes",
@@ -639,6 +678,7 @@ def agent_template_list(*, include_advanced: bool = False) -> list[dict[str, Any
         "ollama",
         "langgraph",
         "strands",
+        "bedrock_agentcore",
         "echo_test",
         "service_account",
         "pass_through",

--- a/ax_cli/gateway_runtime_types.py
+++ b/ax_cli/gateway_runtime_types.py
@@ -451,8 +451,7 @@ def agent_template_catalog() -> dict[str, dict[str, Any]]:
             "setup_skill_path": str(skill_path),
             "defaults": {
                 "runtime_type": "exec",
-                "exec_command": "python3 examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py",
-                "workdir": str(repo_root),
+                "exec_command": "python3 -m ax_cli.bridges.bedrock_agentcore_bridge",
             },
             "signals": runtime_signals["exec"],
             "advanced": {

--- a/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
+++ b/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
@@ -179,7 +179,7 @@ def classify_stream_event(line: str) -> tuple[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def build_bedrock_client(*, aws_profile: str, region: str, runtime_arn: str) -> Any:
+def build_bedrock_client(*, aws_profile: str, region: str) -> Any:
     """Build and return a boto3 bedrock-agentcore client.
 
     Validates that the service is available in the installed boto3 version.
@@ -191,7 +191,7 @@ def build_bedrock_client(*, aws_profile: str, region: str, runtime_arn: str) -> 
     except ImportError as exc:
         raise RuntimeError(f"boto3 is not installed: {exc}. Install it with: pip install 'axctl[bedrock]'") from exc
 
-    session = boto3.Session()
+    session = boto3.Session(profile_name=aws_profile or None)
     available = session.get_available_services()
     if "bedrock-agentcore" not in available:
         raise RuntimeError(
@@ -233,10 +233,11 @@ def _compute_session_id(agent_id: str, space_id: str) -> str:
 
 def _invoke_event_stream(
     client: Any, *, runtime_arn: str, session_id: str, payload_key: str, qualifier: str, prompt: str
-) -> tuple[str, int]:
+) -> tuple[str | None, int]:
     """Invoke the AgentCore runtime and consume the streaming response.
 
-    Returns (reply_text, chunk_count).
+    Returns (reply_text, chunk_count). reply_text is None when an in-band
+    error was encountered; callers must not emit status:completed in that case.
     """
     payload_body = json.dumps({payload_key: prompt})
     response = client.invoke_agent_runtime(
@@ -269,8 +270,15 @@ def _invoke_event_stream(
                 if value:
                     reply_parts.append(value)
             elif tag == "error_event":
-                emit_event({"kind": "status", "status": "error", "error_message": value.get("message", "unknown")})
-                return ("", chunks)
+                emit_event(
+                    {
+                        "kind": "status",
+                        "status": "error",
+                        "error_message": value.get("message", "unknown"),
+                        "detail": value.get("detail", {}),
+                    }
+                )
+                return (None, chunks)
             elif tag == "typed_event":
                 emit_event(value)
             elif tag == "heartbeat_chunk":
@@ -332,7 +340,7 @@ def main() -> int:
         return 1
 
     try:
-        client = build_bedrock_client(aws_profile=aws_profile, region=region, runtime_arn=runtime_arn)
+        client = build_bedrock_client(aws_profile=aws_profile, region=region)
     except RuntimeError as exc:
         emit_event({"kind": "status", "status": "error", "error_message": str(exc)})
         print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
@@ -371,6 +379,10 @@ def main() -> int:
         )
         print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
         return 1
+
+    if reply is None:
+        # in-band error already emitted status:error — do not follow with status:completed
+        return 0
 
     duration_ms = int((time.monotonic() - started) * 1000)
     emit_event(

--- a/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
+++ b/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
@@ -381,8 +381,9 @@ def main() -> int:
         return 1
 
     if reply is None:
-        # in-band error already emitted status:error — do not follow with status:completed
-        return 0
+        # in-band error already emitted status:error — exit nonzero so Gateway's
+        # worker loop does not auto-emit a synthetic completed event
+        return 1
 
     duration_ms = int((time.monotonic() - started) * 1000)
     emit_event(

--- a/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
+++ b/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Gateway-managed bridge for Amazon Bedrock AgentCore Runtime.
+
+Designed for `ax gateway agents add ... --template bedrock_agentcore`.
+Invokes an AgentCore runtime once per inbound mention, streams the response,
+and prints the reply on stdout following the Gateway exec-runtime contract.
+
+Auth: boto3 default credential chain (env vars, ~/.aws/credentials, instance
+profile, SSO session). Gateway never stores AWS secrets.
+
+Session continuity: one persistent AgentCore runtime session per
+(agent_id, space_id) pair. Cross-user contamination in wide group spaces
+is documented in docs/gateway-agent-runtimes.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from typing import Any
+
+EVENT_PREFIX = "AX_GATEWAY_EVENT "
+
+_AGENTCORE_ARN_RE = re.compile(r"^arn:aws:bedrock-agentcore:([a-z0-9-]+):(\d{12}):runtime/(.+)$")
+_MODEL_ARN_RE = re.compile(r"^arn:aws:bedrock:")
+
+_HEARTBEAT_INTERVAL_SECS = 0.25
+_HEARTBEAT_BYTE_BUDGET = 1024
+
+
+def emit_event(payload: dict[str, Any]) -> None:
+    print(f"{EVENT_PREFIX}{json.dumps(payload, sort_keys=True)}", flush=True)
+
+
+def _read_prompt() -> str:
+    if len(sys.argv) > 1 and sys.argv[-1] != "-":
+        return sys.argv[-1]
+    env_prompt = os.environ.get("AX_MENTION_CONTENT", "").strip()
+    if env_prompt:
+        return env_prompt
+    return sys.stdin.read().strip()
+
+
+# ---------------------------------------------------------------------------
+# Deep module 1: template-options validator
+# ---------------------------------------------------------------------------
+
+
+def validate_bedrock_options(
+    *,
+    runtime_arn: str | None,
+    region: str | None,
+    qualifier: str | None,
+    payload_key: str | None,
+    aws_profile: str | None,
+    template_id: str,
+) -> dict[str, str]:
+    """Validate and normalize bedrock template options.
+
+    Pure function — no I/O, no boto3. Returns a validated options dict
+    or raises ValueError with an actionable message.
+    """
+    bedrock_flags_set = any([runtime_arn, region, qualifier, payload_key, aws_profile])
+
+    if bedrock_flags_set and template_id != "bedrock_agentcore":
+        raise ValueError(f"--bedrock-* flags are only valid with --template bedrock_agentcore, not '{template_id}'.")
+
+    arn = (runtime_arn or os.environ.get("AX_BEDROCK_RUNTIME_ARN", "")).strip()
+    if not arn:
+        raise ValueError(
+            "bedrock_agentcore template requires --bedrock-runtime-arn "
+            "(or AX_BEDROCK_RUNTIME_ARN env var). "
+            "Expected shape: arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>"
+        )
+
+    if _MODEL_ARN_RE.match(arn):
+        raise ValueError(
+            f"ARN looks like a Bedrock foundation-model ARN, not an AgentCore runtime ARN: {arn!r}. "
+            "Use the ARN from `agentcore list-runtimes`, not from the model catalog."
+        )
+
+    m = _AGENTCORE_ARN_RE.match(arn)
+    if not m:
+        raise ValueError(
+            f"Invalid AgentCore runtime ARN: {arn!r}. "
+            "Expected: arn:aws:bedrock-agentcore:<region>:<12-digit-account>:runtime/<id>"
+        )
+
+    arn_region = m.group(1)
+    resolved_region = (region or "").strip() or arn_region or None
+
+    return {
+        "bedrock_runtime_arn": arn,
+        "bedrock_region": resolved_region or "",
+        "bedrock_qualifier": (qualifier or "").strip() or "DEFAULT",
+        "bedrock_payload_key": (payload_key or "").strip() or "prompt",
+        "aws_profile": (aws_profile or "").strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Deep module 2: stream-event classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_stream_event(line: str) -> tuple[str, Any]:
+    """Classify one decoded SSE data line (minus the 'data: ' prefix).
+
+    Returns one of:
+        ("reply_text",    str)   — plain text, append to reply buffer
+        ("error_event",   dict)  — in-band error, abort with status:error
+        ("typed_event",   dict)  — tool_start / tool_result / activity / status
+        ("heartbeat_chunk", dict) — unknown JSON dict, throttle before emitting
+    """
+    if not line:
+        return ("reply_text", "")
+
+    try:
+        data = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return ("reply_text", line)
+
+    if not isinstance(data, dict):
+        return ("reply_text", str(data) if data else "")
+
+    # Error shapes
+    event_field = str(data.get("event") or "").lower()
+    type_field = str(data.get("type") or "").lower()
+    if event_field in ("error", "failed", "exception") or type_field == "error" or data.get("error"):
+        msg = str(data.get("message") or data.get("error") or data.get("detail") or "unknown error")
+        return ("error_event", {"message": msg, "detail": data})
+
+    # Tool use → tool_start
+    if data.get("type") == "tool_use" or (data.get("tool_name") and data.get("tool_call_id") and "input" in data):
+        return (
+            "typed_event",
+            {
+                "kind": "tool_start",
+                "tool_name": str(data.get("tool_name") or data.get("name") or ""),
+                "tool_call_id": str(data.get("tool_call_id") or data.get("id") or ""),
+            },
+        )
+
+    # Tool result → tool_result
+    if data.get("type") == "tool_result" or (data.get("tool_call_id") and "result" in data):
+        status = "ok" if not data.get("is_error") else "error"
+        return (
+            "typed_event",
+            {
+                "kind": "tool_result",
+                "tool_name": str(data.get("tool_name") or ""),
+                "tool_call_id": str(data.get("tool_call_id") or ""),
+                "status": status,
+            },
+        )
+
+    # Thinking / trace / step / delta → activity
+    if data.get("type") in ("thinking", "trace", "step", "delta") or data.get("thinking"):
+        summary = str(data.get("thinking") or data.get("trace") or data.get("content") or "agent thinking")
+        if len(summary) > 120:
+            summary = summary[:117] + "..."
+        return ("typed_event", {"kind": "activity", "activity": summary})
+
+    # Assistant text delta (Strands-style)
+    if data.get("type") == "content_block_delta" and isinstance(data.get("delta"), dict):
+        delta_text = str(data["delta"].get("text") or "")
+        if delta_text:
+            return ("reply_text", delta_text)
+
+    return ("heartbeat_chunk", data)
+
+
+# ---------------------------------------------------------------------------
+# Deep module 3: boto3 client builder
+# ---------------------------------------------------------------------------
+
+
+def build_bedrock_client(*, aws_profile: str, region: str, runtime_arn: str) -> Any:
+    """Build and return a boto3 bedrock-agentcore client.
+
+    Validates that the service is available in the installed boto3 version.
+    Raises RuntimeError with an actionable message if not.
+    """
+    try:
+        import boto3
+        import botocore.config
+    except ImportError as exc:
+        raise RuntimeError(f"boto3 is not installed: {exc}. Install it with: pip install 'axctl[bedrock]'") from exc
+
+    session = boto3.Session()
+    available = session.get_available_services()
+    if "bedrock-agentcore" not in available:
+        raise RuntimeError(
+            f"boto3 {boto3.__version__} does not include the bedrock-agentcore service client. "
+            "Upgrade with: pip install --upgrade 'boto3>=1.38' 'axctl[bedrock]'"
+        )
+
+    kwargs: dict[str, Any] = {
+        "config": botocore.config.Config(
+            read_timeout=900,
+            connect_timeout=10,
+            retries={"max_attempts": 1, "mode": "standard"},
+        ),
+    }
+    if region:
+        kwargs["region_name"] = region
+
+    return session.client("bedrock-agentcore", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Session ID
+# ---------------------------------------------------------------------------
+
+
+def _compute_session_id(agent_id: str, space_id: str) -> str:
+    """Stable, deterministic session id per (agent_id, space_id) pair.
+
+    AgentCore requires runtimeSessionId >= 33 chars.
+    """
+    raw = uuid.uuid5(uuid.NAMESPACE_URL, f"ax-gateway:{agent_id}:{space_id}").hex
+    return raw.ljust(33, "_")
+
+
+# ---------------------------------------------------------------------------
+# Bridge I/O loop
+# ---------------------------------------------------------------------------
+
+
+def _invoke_event_stream(
+    client: Any, *, runtime_arn: str, session_id: str, payload_key: str, qualifier: str, prompt: str
+) -> tuple[str, int]:
+    """Invoke the AgentCore runtime and consume the streaming response.
+
+    Returns (reply_text, chunk_count).
+    """
+    payload_body = json.dumps({payload_key: prompt})
+    response = client.invoke_agent_runtime(
+        agentRuntimeArn=runtime_arn,
+        runtimeSessionId=session_id,
+        qualifier=qualifier,
+        payload=payload_body,
+    )
+
+    content_type = str(response.get("contentType") or "").lower()
+    chunks = 0
+    reply_parts: list[str] = []
+    last_heartbeat_at = 0.0
+    heartbeat_bytes = 0
+
+    if "event-stream" in content_type or "text/event-stream" in content_type:
+        streaming_body = response.get("response") or response.get("body")
+        for raw_line in streaming_body.iter_lines():
+            line = (
+                raw_line.decode("utf-8", errors="replace").strip() if isinstance(raw_line, bytes) else raw_line.strip()
+            )
+            if not line:
+                continue
+            if line.startswith("data: "):
+                line = line[6:]
+            chunks += 1
+            tag, value = classify_stream_event(line)
+
+            if tag == "reply_text":
+                if value:
+                    reply_parts.append(value)
+            elif tag == "error_event":
+                emit_event({"kind": "status", "status": "error", "error_message": value.get("message", "unknown")})
+                return ("", chunks)
+            elif tag == "typed_event":
+                emit_event(value)
+            elif tag == "heartbeat_chunk":
+                now = time.monotonic()
+                heartbeat_bytes += len(line)
+                if now - last_heartbeat_at >= _HEARTBEAT_INTERVAL_SECS or heartbeat_bytes >= _HEARTBEAT_BYTE_BUDGET:
+                    emit_event({"kind": "activity", "activity": "AgentCore processing..."})
+                    last_heartbeat_at = now
+                    heartbeat_bytes = 0
+
+    elif "application/json" in content_type:
+        emit_event({"kind": "activity", "activity": "Buffering JSON response from AgentCore"})
+        body_bytes = b""
+        streaming_body = response.get("response") or response.get("body")
+        for chunk in streaming_body.iter_chunks():
+            body_bytes += chunk
+            chunks += 1
+        try:
+            parsed = json.loads(body_bytes.decode("utf-8"))
+        except Exception:
+            parsed = body_bytes.decode("utf-8", errors="replace")
+        if isinstance(parsed, dict):
+            text = str(
+                parsed.get("result") or parsed.get("output") or parsed.get("response") or parsed.get("text") or ""
+            )
+            reply_parts.append(text or json.dumps(parsed))
+        else:
+            reply_parts.append(str(parsed))
+    else:
+        emit_event({"kind": "activity", "activity": f"AgentCore response content-type: {content_type}"})
+        streaming_body = response.get("response") or response.get("body")
+        body_bytes = streaming_body.read() if hasattr(streaming_body, "read") else b""
+        reply_parts.append(body_bytes.decode("utf-8", errors="replace"))
+
+    return ("".join(reply_parts).strip(), chunks)
+
+
+def main() -> int:
+    prompt = _read_prompt()
+    if not prompt:
+        print("(no mention content received)", file=sys.stderr)
+        return 1
+
+    runtime_arn = os.environ.get("AX_BEDROCK_RUNTIME_ARN", "").strip()
+    region = os.environ.get("AX_BEDROCK_REGION", "").strip()
+    qualifier = os.environ.get("AX_BEDROCK_QUALIFIER", "DEFAULT").strip() or "DEFAULT"
+    payload_key = os.environ.get("AX_BEDROCK_PAYLOAD_KEY", "prompt").strip() or "prompt"
+    aws_profile = os.environ.get("AWS_PROFILE", "").strip()
+    agent_id = (
+        os.environ.get("AX_GATEWAY_AGENT_ID", "").strip() or os.environ.get("AX_AGENT_ID", "").strip() or "unknown"
+    )
+    space_id = (
+        os.environ.get("AX_GATEWAY_SPACE_ID", "").strip() or os.environ.get("AX_SPACE_ID", "").strip() or "unknown"
+    )
+
+    if not runtime_arn:
+        emit_event({"kind": "status", "status": "error", "error_message": "AX_BEDROCK_RUNTIME_ARN is not set"})
+        print("bedrock_agentcore bridge: AX_BEDROCK_RUNTIME_ARN not set", file=sys.stderr)
+        return 1
+
+    try:
+        client = build_bedrock_client(aws_profile=aws_profile, region=region, runtime_arn=runtime_arn)
+    except RuntimeError as exc:
+        emit_event({"kind": "status", "status": "error", "error_message": str(exc)})
+        print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
+        return 1
+
+    session_id = _compute_session_id(agent_id, space_id)
+
+    emit_event({"kind": "status", "status": "processing", "message": "Invoking AgentCore runtime"})
+    emit_event(
+        {"kind": "activity", "activity": f"AgentCore runtime accepted invocation (session {session_id[:12]}...)"}
+    )
+
+    started = time.monotonic()
+    try:
+        reply, chunks = _invoke_event_stream(
+            client,
+            runtime_arn=runtime_arn,
+            session_id=session_id,
+            payload_key=payload_key,
+            qualifier=qualifier,
+            prompt=prompt,
+        )
+    except Exception as exc:
+        try:
+            import botocore.exceptions
+
+            error_code = "unknown"
+            if isinstance(exc, botocore.exceptions.ClientError):
+                error_code = exc.response.get("Error", {}).get("Code", "ClientError")
+            elif isinstance(exc, botocore.exceptions.BotoCoreError):
+                error_code = type(exc).__name__
+        except ImportError:
+            error_code = type(exc).__name__
+        emit_event(
+            {"kind": "status", "status": "error", "error_message": str(exc), "detail": {"error_code": error_code}}
+        )
+        print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
+        return 1
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    emit_event(
+        {
+            "kind": "status",
+            "status": "completed",
+            "message": f"AgentCore completed in {duration_ms}ms",
+            "detail": {"chunks": chunks, "session_id": session_id, "duration_ms": duration_ms},
+        }
+    )
+
+    if reply:
+        print(reply)
+    else:
+        print("(AgentCore returned no text reply — see activity stream for details)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
+++ b/examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py
@@ -9,8 +9,8 @@ Auth: boto3 default credential chain (env vars, ~/.aws/credentials, instance
 profile, SSO session). Gateway never stores AWS secrets.
 
 Session continuity: one persistent AgentCore runtime session per
-(agent_id, space_id) pair. Cross-user contamination in wide group spaces
-is documented in docs/gateway-agent-runtimes.md.
+(agent_id, space_id, sender_id) triple. sender_id is injected by Gateway
+as AX_GATEWAY_SENDER_ID, isolating sessions per caller in shared spaces.
 """
 
 from __future__ import annotations
@@ -217,12 +217,16 @@ def build_bedrock_client(*, aws_profile: str, region: str) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _compute_session_id(agent_id: str, space_id: str) -> str:
-    """Stable, deterministic session id per (agent_id, space_id) pair.
+def _compute_session_id(agent_id: str, space_id: str, sender_id: str | None = None) -> str:
+    """Stable, deterministic session id scoped to (agent_id, space_id, sender_id).
 
+    Including sender_id prevents cross-user session contamination in shared spaces.
     AgentCore requires runtimeSessionId >= 33 chars.
     """
-    raw = uuid.uuid5(uuid.NAMESPACE_URL, f"ax-gateway:{agent_id}:{space_id}").hex
+    key = f"ax-gateway:{agent_id}:{space_id}"
+    if sender_id:
+        key = f"{key}:{sender_id}"
+    raw = uuid.uuid5(uuid.NAMESPACE_URL, key).hex
     return raw.ljust(33, "_")
 
 
@@ -333,6 +337,7 @@ def main() -> int:
     space_id = (
         os.environ.get("AX_GATEWAY_SPACE_ID", "").strip() or os.environ.get("AX_SPACE_ID", "").strip() or "unknown"
     )
+    sender_id = os.environ.get("AX_GATEWAY_SENDER_ID", "").strip() or None
 
     if not runtime_arn:
         emit_event({"kind": "status", "status": "error", "error_message": "AX_BEDROCK_RUNTIME_ARN is not set"})
@@ -346,7 +351,7 @@ def main() -> int:
         print(f"bedrock_agentcore bridge: {exc}", file=sys.stderr)
         return 1
 
-    session_id = _compute_session_id(agent_id, space_id)
+    session_id = _compute_session_id(agent_id, space_id, sender_id)
 
     emit_event({"kind": "status", "status": "processing", "message": "Invoking AgentCore runtime"})
     emit_event(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
     "ruff>=0.15.12",
     "twine>=6.2.0",
 ]
+bedrock = [
+    "boto3>=1.38",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_gateway_bedrock_agentcore_template.py
+++ b/tests/test_gateway_bedrock_agentcore_template.py
@@ -272,13 +272,37 @@ def test_build_bedrock_client_raises_on_missing_service(monkeypatch):
 
     with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": MagicMock(), "botocore.config": MagicMock()}):
         with pytest.raises(RuntimeError, match="bedrock-agentcore service client"):
-            bridge.build_bedrock_client(aws_profile="", region="us-east-1", runtime_arn=VALID_ARN)
+            bridge.build_bedrock_client(aws_profile="", region="us-east-1")
 
 
 def test_build_bedrock_client_raises_on_missing_boto3(monkeypatch):
     with patch.dict(sys.modules, {"boto3": None}):
         with pytest.raises((RuntimeError, ImportError)):
-            bridge.build_bedrock_client(aws_profile="", region="us-east-1", runtime_arn=VALID_ARN)
+            bridge.build_bedrock_client(aws_profile="", region="us-east-1")
+
+
+def test_build_bedrock_client_passes_profile_to_session():
+    mock_session = MagicMock()
+    mock_session.get_available_services.return_value = ["bedrock-agentcore"]
+    mock_session.client.return_value = MagicMock()
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value = mock_session
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": MagicMock(), "botocore.config": MagicMock()}):
+        bridge.build_bedrock_client(aws_profile="my-profile", region="us-east-1")
+        mock_boto3.Session.assert_called_once_with(profile_name="my-profile")
+
+
+def test_build_bedrock_client_passes_none_profile_when_empty():
+    mock_session = MagicMock()
+    mock_session.get_available_services.return_value = ["bedrock-agentcore"]
+    mock_session.client.return_value = MagicMock()
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value = mock_session
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": MagicMock(), "botocore.config": MagicMock()}):
+        bridge.build_bedrock_client(aws_profile="", region="us-east-1")
+        mock_boto3.Session.assert_called_once_with(profile_name=None)
 
 
 # ---------------------------------------------------------------------------
@@ -379,14 +403,15 @@ def test_bridge_inband_error_exits_nonzero(monkeypatch, capsys):
 
     rc = bridge.main()
     captured = capsys.readouterr()
-    assert rc == 0  # main() returns 0 after emitting status:error; error surfaced via event
+    assert rc == 0  # in-band error returns 0; error surfaced via status:error event
     event_lines = [ln for ln in captured.out.splitlines() if ln.startswith(bridge.EVENT_PREFIX)]
-    error_events = [
-        json.loads(ln[len(bridge.EVENT_PREFIX) :])
-        for ln in event_lines
-        if json.loads(ln[len(bridge.EVENT_PREFIX) :]).get("status") == "error"
-    ]
-    assert error_events, "expected a status:error event"
+    events = [json.loads(ln[len(bridge.EVENT_PREFIX) :]) for ln in event_lines]
+    statuses = [e.get("status") for e in events]
+    assert "error" in statuses, "expected a status:error event"
+    assert "completed" not in statuses, "status:completed must not follow status:error"
+    error_event = next(e for e in events if e.get("status") == "error")
+    assert "guardrail tripped" in error_event.get("error_message", "")
+    assert "detail" in error_event
 
 
 def test_bridge_empty_reply_emits_placeholder(monkeypatch, capsys):

--- a/tests/test_gateway_bedrock_agentcore_template.py
+++ b/tests/test_gateway_bedrock_agentcore_template.py
@@ -1,0 +1,439 @@
+"""Regression: bedrock_agentcore template registers correctly and the bridge
+modules behave per the Gateway exec-runtime contract.
+
+Tests cover:
+  - Template catalog registration and ordering
+  - Bridge file existence
+  - Deep module 1: validate_bedrock_options (ARN validator)
+  - Deep module 2: classify_stream_event (SSE classifier)
+  - Deep module 3: build_bedrock_client (boto3 version check)
+  - Bridge I/O loop integration (missing ARN, event-stream, error, empty reply)
+  - CLI cross-template gating (--bedrock-* with non-bedrock template)
+  - Deterministic session ID shape
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ax_cli.gateway_runtime_types import (
+    agent_template_catalog,
+    agent_template_definition,
+    agent_template_list,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BRIDGE_PATH = REPO_ROOT / "examples" / "gateway_bedrock_agentcore" / "bedrock_agentcore_bridge.py"
+
+sys.path.insert(0, str(BRIDGE_PATH.parent))
+import bedrock_agentcore_bridge as bridge  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Template catalog
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_agentcore_template_is_registered():
+    catalog = agent_template_catalog()
+    assert "bedrock_agentcore" in catalog
+    t = agent_template_definition("bedrock_agentcore")
+    assert t["id"] == "bedrock_agentcore"
+    assert t["runtime_type"] == "exec"
+    assert t["intake_model"] == "launch_on_send"
+    assert t["return_paths"] == ["inline_reply"]
+    assert t["availability"] == "ready"
+    assert t["launchable"] is True
+
+
+def test_bedrock_agentcore_template_exec_command_points_at_bridge():
+    t = agent_template_definition("bedrock_agentcore")
+    cmd = str((t.get("defaults") or {}).get("exec_command") or "")
+    assert "examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py" in cmd
+
+
+def test_bedrock_agentcore_template_listed_after_strands():
+    ids = [item["id"] for item in agent_template_list()]
+    assert "bedrock_agentcore" in ids
+    assert ids.index("bedrock_agentcore") > ids.index("strands")
+
+
+def test_bedrock_agentcore_bridge_file_exists():
+    assert BRIDGE_PATH.exists()
+
+
+# ---------------------------------------------------------------------------
+# Deep module 1: validate_bedrock_options
+# ---------------------------------------------------------------------------
+
+VALID_ARN = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-runtime"
+
+
+def test_validate_valid_arn_extracts_region():
+    opts = bridge.validate_bedrock_options(
+        runtime_arn=VALID_ARN,
+        region=None,
+        qualifier=None,
+        payload_key=None,
+        aws_profile=None,
+        template_id="bedrock_agentcore",
+    )
+    assert opts["bedrock_runtime_arn"] == VALID_ARN
+    assert opts["bedrock_region"] == "us-east-1"
+    assert opts["bedrock_qualifier"] == "DEFAULT"
+    assert opts["bedrock_payload_key"] == "prompt"
+
+
+def test_validate_explicit_region_overrides_arn():
+    opts = bridge.validate_bedrock_options(
+        runtime_arn=VALID_ARN,
+        region="eu-west-1",
+        qualifier=None,
+        payload_key=None,
+        aws_profile=None,
+        template_id="bedrock_agentcore",
+    )
+    assert opts["bedrock_region"] == "eu-west-1"
+
+
+def test_validate_explicit_qualifier_and_payload_key():
+    opts = bridge.validate_bedrock_options(
+        runtime_arn=VALID_ARN,
+        region=None,
+        qualifier="my-canary",
+        payload_key="input",
+        aws_profile=None,
+        template_id="bedrock_agentcore",
+    )
+    assert opts["bedrock_qualifier"] == "my-canary"
+    assert opts["bedrock_payload_key"] == "input"
+
+
+def test_validate_malformed_arn_raises():
+    with pytest.raises(ValueError, match="Invalid AgentCore runtime ARN"):
+        bridge.validate_bedrock_options(
+            runtime_arn="arn:aws:bedrock-agentcore:us-east-1:short:runtime/x",
+            region=None,
+            qualifier=None,
+            payload_key=None,
+            aws_profile=None,
+            template_id="bedrock_agentcore",
+        )
+
+
+def test_validate_model_arn_raises():
+    model_arn = "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3"
+    with pytest.raises(ValueError, match="foundation-model"):
+        bridge.validate_bedrock_options(
+            runtime_arn=model_arn,
+            region=None,
+            qualifier=None,
+            payload_key=None,
+            aws_profile=None,
+            template_id="bedrock_agentcore",
+        )
+
+
+def test_validate_missing_arn_raises():
+    with pytest.raises(ValueError, match="bedrock_agentcore template requires"):
+        bridge.validate_bedrock_options(
+            runtime_arn=None,
+            region=None,
+            qualifier=None,
+            payload_key=None,
+            aws_profile=None,
+            template_id="bedrock_agentcore",
+        )
+
+
+def test_validate_env_var_supplies_arn(monkeypatch):
+    monkeypatch.setenv("AX_BEDROCK_RUNTIME_ARN", VALID_ARN)
+    opts = bridge.validate_bedrock_options(
+        runtime_arn=None,
+        region=None,
+        qualifier=None,
+        payload_key=None,
+        aws_profile=None,
+        template_id="bedrock_agentcore",
+    )
+    assert opts["bedrock_runtime_arn"] == VALID_ARN
+
+
+def test_validate_bedrock_flag_with_wrong_template_raises():
+    with pytest.raises(ValueError, match="only valid with --template bedrock_agentcore"):
+        bridge.validate_bedrock_options(
+            runtime_arn=VALID_ARN,
+            region=None,
+            qualifier=None,
+            payload_key=None,
+            aws_profile=None,
+            template_id="ollama",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deep module 2: classify_stream_event
+# ---------------------------------------------------------------------------
+
+
+def test_classify_plain_text():
+    tag, val = bridge.classify_stream_event("hello world")
+    assert tag == "reply_text"
+    assert val == "hello world"
+
+
+def test_classify_empty_string():
+    tag, val = bridge.classify_stream_event("")
+    assert tag == "reply_text"
+    assert val == ""
+
+
+def test_classify_malformed_json():
+    tag, val = bridge.classify_stream_event("{not valid json")
+    assert tag == "reply_text"
+
+
+def test_classify_json_primitive():
+    tag, val = bridge.classify_stream_event("42")
+    assert tag == "reply_text"
+
+
+def test_classify_error_event_field():
+    line = json.dumps({"event": "error", "message": "something broke"})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "error_event"
+    assert "something broke" in val["message"]
+
+
+def test_classify_error_type_field():
+    line = json.dumps({"type": "error", "message": "bad"})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "error_event"
+
+
+def test_classify_error_truthy_error_key():
+    line = json.dumps({"error": "ThrottlingException"})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "error_event"
+
+
+def test_classify_tool_use():
+    line = json.dumps({"type": "tool_use", "tool_name": "search", "tool_call_id": "tc-1", "input": {}})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "typed_event"
+    assert val["kind"] == "tool_start"
+    assert val["tool_name"] == "search"
+
+
+def test_classify_tool_result():
+    line = json.dumps({"type": "tool_result", "tool_call_id": "tc-1", "tool_name": "search", "result": "ok"})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "typed_event"
+    assert val["kind"] == "tool_result"
+    assert val["status"] == "ok"
+
+
+def test_classify_thinking():
+    line = json.dumps({"type": "thinking", "thinking": "let me consider this"})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "typed_event"
+    assert val["kind"] == "activity"
+
+
+def test_classify_content_block_delta():
+    line = json.dumps({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hello"}})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "reply_text"
+    assert val == "hello"
+
+
+def test_classify_unrecognised_dict():
+    line = json.dumps({"some_unknown_key": "value"})
+    tag, val = bridge.classify_stream_event(line)
+    assert tag == "heartbeat_chunk"
+
+
+# ---------------------------------------------------------------------------
+# Deep module 3: build_bedrock_client
+# ---------------------------------------------------------------------------
+
+
+def test_build_bedrock_client_raises_on_missing_service(monkeypatch):
+    mock_session = MagicMock()
+    mock_session.get_available_services.return_value = ["s3", "ec2"]
+    mock_boto3 = MagicMock()
+    mock_boto3.Session.return_value = mock_session
+    mock_boto3.__version__ = "1.20.0"
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": MagicMock(), "botocore.config": MagicMock()}):
+        with pytest.raises(RuntimeError, match="bedrock-agentcore service client"):
+            bridge.build_bedrock_client(aws_profile="", region="us-east-1", runtime_arn=VALID_ARN)
+
+
+def test_build_bedrock_client_raises_on_missing_boto3(monkeypatch):
+    with patch.dict(sys.modules, {"boto3": None}):
+        with pytest.raises((RuntimeError, ImportError)):
+            bridge.build_bedrock_client(aws_profile="", region="us-east-1", runtime_arn=VALID_ARN)
+
+
+# ---------------------------------------------------------------------------
+# Session ID
+# ---------------------------------------------------------------------------
+
+
+def test_compute_session_id_is_deterministic():
+    sid1 = bridge._compute_session_id("agent-123", "space-456")
+    sid2 = bridge._compute_session_id("agent-123", "space-456")
+    assert sid1 == sid2
+
+
+def test_compute_session_id_min_length():
+    sid = bridge._compute_session_id("a", "b")
+    assert len(sid) >= 33
+
+
+def test_compute_session_id_differs_by_agent():
+    sid1 = bridge._compute_session_id("agent-1", "space-1")
+    sid2 = bridge._compute_session_id("agent-2", "space-1")
+    assert sid1 != sid2
+
+
+# ---------------------------------------------------------------------------
+# Bridge I/O loop integration
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_client(chunks: list[str], content_type: str = "text/event-stream") -> MagicMock:
+    lines = [c.encode() for c in chunks]
+
+    class FakeBody:
+        def iter_lines(self):
+            return iter(lines)
+
+        def iter_chunks(self):
+            return iter(lines)
+
+        def read(self):
+            return b"".join(lines)
+
+    client = MagicMock()
+    client.invoke_agent_runtime.return_value = {
+        "contentType": content_type,
+        "response": FakeBody(),
+    }
+    return client
+
+
+def test_bridge_missing_arn_exits_nonzero(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["bridge.py", "hello"])
+    monkeypatch.delenv("AX_BEDROCK_RUNTIME_ARN", raising=False)
+    monkeypatch.setenv("AX_MENTION_CONTENT", "hello")
+
+    rc = bridge.main()
+    assert rc != 0
+    out = capsys.readouterr().out
+    assert "error" in out.lower()
+
+
+def test_bridge_plain_text_stream(monkeypatch, capsys):
+    # Two plain-text chunks — bridge strips each line so they join without separator
+    fake_client = _make_fake_client(["hello", "world"])
+
+    monkeypatch.setenv("AX_BEDROCK_RUNTIME_ARN", VALID_ARN)
+    monkeypatch.setenv("AX_BEDROCK_REGION", "us-east-1")
+    monkeypatch.setenv("AX_GATEWAY_AGENT_ID", "agent-1")
+    monkeypatch.setenv("AX_GATEWAY_SPACE_ID", "space-1")
+    monkeypatch.setattr(sys, "argv", ["bridge.py", "test prompt"])
+    monkeypatch.setattr(bridge, "build_bedrock_client", lambda **_: fake_client)
+
+    rc = bridge.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "helloworld" in captured.out
+
+    event_lines = [ln for ln in captured.out.splitlines() if ln.startswith(bridge.EVENT_PREFIX)]
+    statuses = [
+        json.loads(ln[len(bridge.EVENT_PREFIX) :]).get("status")
+        for ln in event_lines
+        if json.loads(ln[len(bridge.EVENT_PREFIX) :]).get("kind") == "status"
+    ]
+    assert "processing" in statuses
+    assert "completed" in statuses
+
+
+def test_bridge_inband_error_exits_nonzero(monkeypatch, capsys):
+    error_chunk = json.dumps({"event": "error", "message": "guardrail tripped"})
+    fake_client = _make_fake_client([error_chunk])
+
+    monkeypatch.setenv("AX_BEDROCK_RUNTIME_ARN", VALID_ARN)
+    monkeypatch.setenv("AX_BEDROCK_REGION", "us-east-1")
+    monkeypatch.setenv("AX_GATEWAY_AGENT_ID", "agent-1")
+    monkeypatch.setenv("AX_GATEWAY_SPACE_ID", "space-1")
+    monkeypatch.setattr(sys, "argv", ["bridge.py", "test prompt"])
+    monkeypatch.setattr(bridge, "build_bedrock_client", lambda **_: fake_client)
+
+    rc = bridge.main()
+    captured = capsys.readouterr()
+    assert rc == 0  # main() returns 0 after emitting status:error; error surfaced via event
+    event_lines = [ln for ln in captured.out.splitlines() if ln.startswith(bridge.EVENT_PREFIX)]
+    error_events = [
+        json.loads(ln[len(bridge.EVENT_PREFIX) :])
+        for ln in event_lines
+        if json.loads(ln[len(bridge.EVENT_PREFIX) :]).get("status") == "error"
+    ]
+    assert error_events, "expected a status:error event"
+
+
+def test_bridge_empty_reply_emits_placeholder(monkeypatch, capsys):
+    typed_chunk = json.dumps({"type": "thinking", "thinking": "thinking..."})
+    fake_client = _make_fake_client([typed_chunk])
+
+    monkeypatch.setenv("AX_BEDROCK_RUNTIME_ARN", VALID_ARN)
+    monkeypatch.setenv("AX_BEDROCK_REGION", "us-east-1")
+    monkeypatch.setenv("AX_GATEWAY_AGENT_ID", "agent-1")
+    monkeypatch.setenv("AX_GATEWAY_SPACE_ID", "space-1")
+    monkeypatch.setattr(sys, "argv", ["bridge.py", "test prompt"])
+    monkeypatch.setattr(bridge, "build_bedrock_client", lambda **_: fake_client)
+
+    rc = bridge.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    reply_lines = [ln for ln in captured.out.splitlines() if not ln.startswith(bridge.EVENT_PREFIX)]
+    assert reply_lines, "expected a placeholder reply line"
+    assert "activity stream" in reply_lines[-1].lower() or "no text" in reply_lines[-1].lower()
+
+
+def test_bridge_boto3_client_error_exits_nonzero(monkeypatch, capsys):
+    botocore = pytest.importorskip("botocore")
+
+    def raise_client_error(**_):
+        raise botocore.exceptions.ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}}, "InvokeAgentRuntime"
+        )
+
+    fake_client = MagicMock()
+    fake_client.invoke_agent_runtime.side_effect = raise_client_error
+
+    monkeypatch.setenv("AX_BEDROCK_RUNTIME_ARN", VALID_ARN)
+    monkeypatch.setenv("AX_BEDROCK_REGION", "us-east-1")
+    monkeypatch.setenv("AX_GATEWAY_AGENT_ID", "agent-1")
+    monkeypatch.setenv("AX_GATEWAY_SPACE_ID", "space-1")
+    monkeypatch.setattr(sys, "argv", ["bridge.py", "test prompt"])
+    monkeypatch.setattr(bridge, "build_bedrock_client", lambda **_: fake_client)
+
+    rc = bridge.main()
+    captured = capsys.readouterr()
+    assert rc != 0
+    event_lines = [ln for ln in captured.out.splitlines() if ln.startswith(bridge.EVENT_PREFIX)]
+    error_events = [
+        json.loads(ln[len(bridge.EVENT_PREFIX) :])
+        for ln in event_lines
+        if json.loads(ln[len(bridge.EVENT_PREFIX) :]).get("status") == "error"
+    ]
+    assert error_events
+    assert error_events[0].get("detail", {}).get("error_code") == "ThrottlingException"

--- a/tests/test_gateway_bedrock_agentcore_template.py
+++ b/tests/test_gateway_bedrock_agentcore_template.py
@@ -28,10 +28,8 @@ from ax_cli.gateway_runtime_types import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-BRIDGE_PATH = REPO_ROOT / "examples" / "gateway_bedrock_agentcore" / "bedrock_agentcore_bridge.py"
 
-sys.path.insert(0, str(BRIDGE_PATH.parent))
-import bedrock_agentcore_bridge as bridge  # noqa: E402, I001
+import ax_cli.bridges.bedrock_agentcore_bridge as bridge  # noqa: E402, I001
 
 
 # ---------------------------------------------------------------------------
@@ -54,7 +52,7 @@ def test_bedrock_agentcore_template_is_registered():
 def test_bedrock_agentcore_template_exec_command_points_at_bridge():
     t = agent_template_definition("bedrock_agentcore")
     cmd = str((t.get("defaults") or {}).get("exec_command") or "")
-    assert "examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py" in cmd
+    assert "ax_cli.bridges.bedrock_agentcore_bridge" in cmd
 
 
 def test_bedrock_agentcore_template_listed_after_strands():
@@ -64,7 +62,8 @@ def test_bedrock_agentcore_template_listed_after_strands():
 
 
 def test_bedrock_agentcore_bridge_file_exists():
-    assert BRIDGE_PATH.exists()
+    bridge_path = REPO_ROOT / "ax_cli" / "bridges" / "bedrock_agentcore_bridge.py"
+    assert bridge_path.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +172,20 @@ def test_validate_bedrock_flag_with_wrong_template_raises():
             payload_key=None,
             aws_profile=None,
             template_id="ollama",
+        )
+
+
+def test_validate_bedrock_flag_with_empty_template_raises():
+    # Passing bedrock flags without selecting any template must be rejected.
+    # An empty template_id must not silently pass as "bedrock_agentcore".
+    with pytest.raises(ValueError, match="only valid with --template bedrock_agentcore"):
+        bridge.validate_bedrock_options(
+            runtime_arn=VALID_ARN,
+            region=None,
+            qualifier=None,
+            payload_key=None,
+            aws_profile=None,
+            template_id="",
         )
 
 

--- a/tests/test_gateway_bedrock_agentcore_template.py
+++ b/tests/test_gateway_bedrock_agentcore_template.py
@@ -403,7 +403,7 @@ def test_bridge_inband_error_exits_nonzero(monkeypatch, capsys):
 
     rc = bridge.main()
     captured = capsys.readouterr()
-    assert rc == 0  # in-band error returns 0; error surfaced via status:error event
+    assert rc != 0
     event_lines = [ln for ln in captured.out.splitlines() if ln.startswith(bridge.EVENT_PREFIX)]
     events = [json.loads(ln[len(bridge.EVENT_PREFIX) :]) for ln in event_lines]
     statuses = [e.get("status") for e in events]

--- a/tests/test_gateway_bedrock_agentcore_template.py
+++ b/tests/test_gateway_bedrock_agentcore_template.py
@@ -340,6 +340,24 @@ def test_compute_session_id_differs_by_agent():
     assert sid1 != sid2
 
 
+def test_compute_session_id_differs_by_sender():
+    sid1 = bridge._compute_session_id("agent-1", "space-1", "user-a")
+    sid2 = bridge._compute_session_id("agent-1", "space-1", "user-b")
+    assert sid1 != sid2
+
+
+def test_compute_session_id_same_sender_is_stable():
+    sid1 = bridge._compute_session_id("agent-1", "space-1", "user-a")
+    sid2 = bridge._compute_session_id("agent-1", "space-1", "user-a")
+    assert sid1 == sid2
+
+
+def test_compute_session_id_no_sender_differs_from_with_sender():
+    sid_no_sender = bridge._compute_session_id("agent-1", "space-1")
+    sid_with_sender = bridge._compute_session_id("agent-1", "space-1", "user-a")
+    assert sid_no_sender != sid_with_sender
+
+
 # ---------------------------------------------------------------------------
 # Bridge I/O loop integration
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -4280,6 +4280,46 @@ def test_gateway_agents_update_clears_bedrock_on_template_switch(monkeypatch, tm
     assert "aws_profile" not in stored
 
 
+def test_gateway_agents_update_template_switch_to_bedrock_requires_arn(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    monkeypatch.delenv("AX_BEDROCK_RUNTIME_ARN", raising=False)
+    gateway_core.save_gateway_session(
+        {"token": "axp_u_test.token", "base_url": "https://paxai.app", "space_id": "space-1", "username": "codex"}
+    )
+    token_file = tmp_path / "echo.token"
+    token_file.write_text("axp_a_agent.secret")
+    registry = gateway_core.load_gateway_registry()
+    entry = {
+        "name": "echo-bot",
+        "agent_id": "agent-1",
+        "space_id": "space-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "echo",
+        "template_id": "echo_test",
+        "template_label": "Echo (Test)",
+        "desired_state": "running",
+        "effective_state": "running",
+        "token_file": str(token_file),
+        "transport": "gateway",
+        "credential_source": "gateway",
+        "created_via": "cli",
+    }
+    registry["agents"] = [entry]
+    gateway_core.ensure_local_asset_binding(registry, entry, created_via="cli", auto_approve=True)
+    gateway_core.ensure_gateway_identity_binding(registry, entry, session=gateway_core.load_gateway_session())
+    gateway_core.save_gateway_registry(registry)
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: _FakeUserClient())
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "update", "echo-bot", "--template", "bedrock_agentcore", "--json"],
+    )
+
+    assert result.exit_code != 0
+    assert "bedrock-runtime-arn" in result.output.lower() or "runtime_arn" in result.output.lower()
+
+
 def test_gateway_agents_add_ollama_persists_model_override(monkeypatch, tmp_path):
     config_dir = tmp_path / "config"
     monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -146,8 +146,10 @@ def test_gateway_local_init_with_create_workdir_provisions_directory(monkeypatch
     monkeypatch.setattr(
         gateway_cmd,
         "_request_local_connect",
-        lambda **kwargs: calls.setdefault("connect", kwargs)
-        or {"status": "approved", "session_token": "tok", "agent": {"name": kwargs["agent_name"]}},
+        lambda **kwargs: (
+            calls.setdefault("connect", kwargs)
+            or {"status": "approved", "session_token": "tok", "agent": {"name": kwargs["agent_name"]}}
+        ),
     )
 
     new_workdir = tmp_path / "agents" / "fresh"
@@ -315,9 +317,7 @@ def test_session_challenge_valid_proof_rotates_and_returns_next_code(monkeypatch
 
     # First call issues the challenge.
     with pytest.raises(ValueError) as first:
-        gateway_cmd._send_local_session_message(
-            session_token=token, body={"content": "first", "space_id": "space-1"}
-        )
+        gateway_cmd._send_local_session_message(session_token=token, body={"content": "first", "space_id": "space-1"})
     issued = str(first.value).split(":", 1)[1].strip().split(".", 1)[0].strip()
 
     # Second call with the matching proof succeeds and rotates.
@@ -342,9 +342,7 @@ def test_session_challenge_wrong_proof_rejected(monkeypatch, tmp_path):
 
     # Issue a challenge first.
     with pytest.raises(ValueError) as first:
-        gateway_cmd._send_local_session_message(
-            session_token=token, body={"content": "first", "space_id": "space-1"}
-        )
+        gateway_cmd._send_local_session_message(session_token=token, body={"content": "first", "space_id": "space-1"})
     issued = str(first.value).split(":", 1)[1].strip().split(".", 1)[0].strip()
 
     with pytest.raises(ValueError) as wrong:
@@ -1413,11 +1411,7 @@ def test_gateway_local_connect_infers_agent_from_workdir_config(monkeypatch, tmp
     ax_dir = tmp_path / ".ax"
     ax_dir.mkdir()
     (ax_dir / "config.toml").write_text(
-        "[gateway]\n"
-        'mode = "local"\n'
-        'url = "http://127.0.0.1:8765"\n'
-        "[agent]\n"
-        'agent_name = "frontend_sentinel"\n'
+        '[gateway]\nmode = "local"\nurl = "http://127.0.0.1:8765"\n[agent]\nagent_name = "frontend_sentinel"\n'
     )
 
     captured = {}
@@ -1452,11 +1446,7 @@ def test_gateway_local_connect_infers_agent_from_cwd_config(monkeypatch, tmp_pat
     ax_dir = tmp_path / ".ax"
     ax_dir.mkdir()
     (ax_dir / "config.toml").write_text(
-        "[gateway]\n"
-        'mode = "local"\n'
-        'url = "http://127.0.0.1:8765"\n'
-        "[agent]\n"
-        'agent_name = "frontend_sentinel"\n'
+        '[gateway]\nmode = "local"\nurl = "http://127.0.0.1:8765"\n[agent]\nagent_name = "frontend_sentinel"\n'
     )
 
     captured = {}
@@ -1505,9 +1495,7 @@ def test_local_process_fingerprint_resolves_executable_symlink(tmp_path):
 def test_gateway_local_connect_rejects_agent_workdir_mismatch(tmp_path):
     ax_dir = tmp_path / ".ax"
     ax_dir.mkdir()
-    (ax_dir / "config.toml").write_text(
-        "[gateway]\n" 'mode = "local"\n' "[agent]\n" 'agent_name = "frontend_sentinel"\n'
-    )
+    (ax_dir / "config.toml").write_text('[gateway]\nmode = "local"\n[agent]\nagent_name = "frontend_sentinel"\n')
 
     with pytest.raises(ValueError) as exc:
         gateway_cmd._request_local_connect(agent_name="codex", workdir=str(tmp_path))
@@ -1574,9 +1562,7 @@ def test_gateway_local_connect_rejects_second_identity_from_same_origin(monkeypa
         gateway_cmd._connect_local_pass_through_agent(agent_name="frontend_sentinel", fingerprint=changed_name)
 
 
-def test_gateway_local_connect_allows_existing_agent_to_reconnect_when_workdir_is_shared(
-    monkeypatch, tmp_path
-):
+def test_gateway_local_connect_allows_existing_agent_to_reconnect_when_workdir_is_shared(monkeypatch, tmp_path):
     """Multi-tenant case: cli_god and pulse-cc legitimately share a workdir.
 
     If pulse-cc was registered first and cli_god's row also exists, cli_god
@@ -1638,9 +1624,7 @@ def test_gateway_local_connect_allows_existing_agent_to_reconnect_when_workdir_i
     # already registered as @pulse-cc"); now it should succeed because
     # cli_god's own registry row is found by name first, before the
     # collision check runs.
-    result = gateway_cmd._connect_local_pass_through_agent(
-        agent_name="cli_god", fingerprint=cli_god_fingerprint
-    )
+    result = gateway_cmd._connect_local_pass_through_agent(agent_name="cli_god", fingerprint=cli_god_fingerprint)
     assert result["agent"]["name"] == "cli_god"
     assert result["agent"]["agent_id"] == "agent-cli-god"
 
@@ -1679,9 +1663,7 @@ def test_gateway_local_connect_still_blocks_fresh_name_when_workdir_is_owned(mon
 
     fresh_attempt = {**fingerprint, "agent_name": "newbie"}
     with pytest.raises(ValueError, match="already registered as @owner"):
-        gateway_cmd._connect_local_pass_through_agent(
-            agent_name="newbie", fingerprint=fresh_attempt
-        )
+        gateway_cmd._connect_local_pass_through_agent(agent_name="newbie", fingerprint=fresh_attempt)
 
 
 def test_find_agent_entry_by_ref_matches_row_and_stable_prefix():
@@ -3424,11 +3406,12 @@ def test_gateway_templates_command_json():
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     ids = [item["id"] for item in payload["templates"]]
-    assert ids[:9] == [
+    assert ids[:10] == [
         "hermes",
         "ollama",
         "langgraph",
         "strands",
+        "bedrock_agentcore",
         "echo_test",
         "service_account",
         "pass_through",
@@ -3436,7 +3419,7 @@ def test_gateway_templates_command_json():
         "claude_code_channel",
     ]
     assert "inbox" not in ids
-    assert payload["count"] == 9
+    assert payload["count"] == 10
     ollama = next(item for item in payload["templates"] if item["id"] == "ollama")
     assert ollama["runtime_type"] == "exec"
     assert ollama["launchable"] is True
@@ -3580,12 +3563,12 @@ def test_gateway_ui_handler_serves_status_and_agent_detail(monkeypatch, tmp_path
             assert template_payload["templates"][0]["id"] == "hermes"
             assert template_payload["templates"][2]["id"] == "langgraph"
             assert template_payload["templates"][3]["id"] == "strands"
-            assert template_payload["templates"][5]["id"] == "service_account"
+            assert template_payload["templates"][6]["id"] == "service_account"
             channel_template = next(
                 item for item in template_payload["templates"] if item["id"] == "claude_code_channel"
             )
             assert channel_template["runtime_type"] == "claude_code_channel"
-            assert template_payload["count"] == 9
+            assert template_payload["count"] == 10
 
             detail = client.get("/api/agents/echo-bot")
             assert detail.status_code == 200
@@ -3830,9 +3813,7 @@ def test_gateway_move_updates_routing_for_test_messages(monkeypatch, tmp_path):
     # invoking principal, never the auto-created switchboard. This test runs
     # outside a Gateway-managed workspace, so name the sender explicitly to
     # exercise the routing-after-move semantics this test is about.
-    tested = gateway_cmd._send_gateway_test_to_managed_agent(
-        "mover", sender_agent="switchboard-space2"
-    )
+    tested = gateway_cmd._send_gateway_test_to_managed_agent("mover", sender_agent="switchboard-space2")
 
     assert tested["target_agent"] == "mover"
     assert tested["message"]["space_id"] == "space-2"
@@ -5971,21 +5952,21 @@ def test_gateway_activity_command_does_not_emit_credentials(monkeypatch, tmp_pat
 class _RecordingHeartbeatClient:
     """Records send_heartbeat / delete_agent calls for assertion."""
 
-    def __init__(self, *, fail_with: Exception | None = None,
-                 fail_status_code: int | None = None):
+    def __init__(self, *, fail_with: Exception | None = None, fail_status_code: int | None = None):
         self.heartbeats: list[dict] = []
         self.deletes: list[str] = []
         self._fail_with = fail_with
         self._fail_status_code = fail_status_code
 
-    def send_heartbeat(self, *, agent_id=None, status=None, note=None,
-                       cadence_seconds=None):
-        self.heartbeats.append({
-            "agent_id": agent_id,
-            "status": status,
-            "note": note,
-            "cadence_seconds": cadence_seconds,
-        })
+    def send_heartbeat(self, *, agent_id=None, status=None, note=None, cadence_seconds=None):
+        self.heartbeats.append(
+            {
+                "agent_id": agent_id,
+                "status": status,
+                "note": note,
+                "cadence_seconds": cadence_seconds,
+            }
+        )
         if self._fail_with is not None:
             exc = self._fail_with
             if self._fail_status_code is not None:
@@ -6001,8 +5982,9 @@ class _RecordingHeartbeatClient:
         return {"ok": True, "id": identifier}
 
 
-def _stale_hermes_entry(name: str, *, age_seconds: float, liveness: str = "stale",
-                        agent_id: str = "agent-stale-1") -> dict:
+def _stale_hermes_entry(
+    name: str, *, age_seconds: float, liveness: str = "stale", agent_id: str = "agent-stale-1"
+) -> dict:
     return {
         "name": name,
         "agent_id": agent_id,
@@ -6388,9 +6370,7 @@ def test_reconcile_skips_hidden_agents_no_runtime_no_upstream(monkeypatch, tmp_p
     # Hidden + archived must NOT have attestation_state populated by reconcile.
     # (evaluate_runtime_attestation runs only on the active path.)
     assert "attestation_state" not in stored_hidden or stored_hidden["attestation_state"] in (None, "")
-    assert "attestation_state" not in next(
-        a for a in registry["agents"] if a["name"] == "stale-archived"
-    ) or True
+    assert "attestation_state" not in next(a for a in registry["agents"] if a["name"] == "stale-archived") or True
 
 
 def test_reconcile_stops_runtime_when_agent_transitions_to_hidden(monkeypatch, tmp_path):
@@ -6427,8 +6407,7 @@ def test_reconcile_stops_runtime_when_agent_transitions_to_hidden(monkeypatch, t
 
 def test_status_payload_filters_hidden_by_default(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
-    hidden = _stale_hermes_entry("hermes-hidden", age_seconds=30 * 60, liveness="offline",
-                                 agent_id="agent-hidden")
+    hidden = _stale_hermes_entry("hermes-hidden", age_seconds=30 * 60, liveness="offline", agent_id="agent-hidden")
     hidden["lifecycle_phase"] = "hidden"
     active = {
         "name": "hermes-live",
@@ -6452,8 +6431,7 @@ def test_status_payload_filters_hidden_by_default(monkeypatch, tmp_path):
 
 def test_status_payload_include_hidden_returns_all(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
-    hidden = _stale_hermes_entry("hermes-hidden", age_seconds=30 * 60, liveness="offline",
-                                 agent_id="agent-hidden")
+    hidden = _stale_hermes_entry("hermes-hidden", age_seconds=30 * 60, liveness="offline", agent_id="agent-hidden")
     hidden["lifecycle_phase"] = "hidden"
     active = {
         "name": "hermes-live",
@@ -6657,9 +6635,7 @@ def test_operator_cleanup_restore_unhides_selected_agents(monkeypatch, tmp_path)
 
     # Restore one row plus name a non-existent and a non-hidden row to verify
     # missing/not_hidden partitions.
-    payload = gateway_cmd._restore_hidden_managed_agents(
-        ["previously-hidden", "ghost", "active-keeper"]
-    )
+    payload = gateway_cmd._restore_hidden_managed_agents(["previously-hidden", "ghost", "active-keeper"])
 
     assert payload["count"] == 1
     assert payload["missing"] == ["ghost"]
@@ -6769,10 +6745,7 @@ def test_remove_managed_agent_proceeds_on_upstream_failure(monkeypatch, tmp_path
     registry_after = gateway_core.load_gateway_registry()
     assert all(a.get("name") != "doomed-agent" for a in registry_after.get("agents", []))
     recent = gateway_core.load_recent_gateway_activity()
-    assert any(
-        r.get("event") == "managed_agent_remove_upstream_failed"
-        for r in recent
-    )
+    assert any(r.get("event") == "managed_agent_remove_upstream_failed" for r in recent)
 
 
 def test_legacy_entry_without_lifecycle_phase_loads_as_active(monkeypatch, tmp_path):
@@ -6817,12 +6790,7 @@ def test_send_local_session_message_extracts_mentions_when_client_omits_them():
     }
     if body["parent_id"]:
         metadata.setdefault("routing_intent", "reply_with_mentions")
-    metadata = (
-        merge_explicit_mentions_metadata(
-            metadata, body["content"], exclude=["codex-local"]
-        )
-        or metadata
-    )
+    metadata = merge_explicit_mentions_metadata(metadata, body["content"], exclude=["codex-local"]) or metadata
 
     assert metadata["mentions"] == ["night_owl"]
     assert metadata["routing_intent"] == "reply_with_mentions"
@@ -6843,9 +6811,7 @@ def test_archive_managed_agent_sets_phase_and_stops_runtime(monkeypatch, tmp_pat
     }
     gateway_core.save_gateway_registry({"agents": [entry]})
     client = _RecordingHeartbeatClient()
-    result = gateway_cmd._archive_managed_agent(
-        "probe-doomed", reason="cleanup", client_factory=lambda: client
-    )
+    result = gateway_cmd._archive_managed_agent("probe-doomed", reason="cleanup", client_factory=lambda: client)
     assert result["lifecycle_phase"] == "archived"
     registry = gateway_core.load_gateway_registry()
     stored = next(a for a in registry["agents"] if a["name"] == "probe-doomed")
@@ -6876,12 +6842,8 @@ def test_archive_managed_agent_idempotent(monkeypatch, tmp_path):
     }
     gateway_core.save_gateway_registry({"agents": [entry]})
     client = _RecordingHeartbeatClient()
-    gateway_cmd._archive_managed_agent(
-        "probe-already", reason="second call", client_factory=lambda: client
-    )
-    stored = next(
-        a for a in gateway_core.load_gateway_registry()["agents"] if a["name"] == "probe-already"
-    )
+    gateway_cmd._archive_managed_agent("probe-already", reason="second call", client_factory=lambda: client)
+    stored = next(a for a in gateway_core.load_gateway_registry()["agents"] if a["name"] == "probe-already")
     # Reason not overwritten on a no-op archive — first archived_reason preserved.
     assert stored["archived_reason"] == "first call"
     assert client.heartbeats == []
@@ -6903,9 +6865,7 @@ def test_archive_then_restore_returns_to_prior_desired_state(monkeypatch, tmp_pa
     client = _RecordingHeartbeatClient()
     gateway_cmd._archive_managed_agent("probe-roundtrip", client_factory=lambda: client)
     gateway_cmd._restore_managed_agent("probe-roundtrip", client_factory=lambda: client)
-    stored = next(
-        a for a in gateway_core.load_gateway_registry()["agents"] if a["name"] == "probe-roundtrip"
-    )
+    stored = next(a for a in gateway_core.load_gateway_registry()["agents"] if a["name"] == "probe-roundtrip")
     assert stored["lifecycle_phase"] == "active"
     assert stored["desired_state"] == "running"
     assert "archived_at" not in stored
@@ -7039,9 +6999,7 @@ def test_save_registry_preserves_other_writer_added_row(monkeypatch, tmp_path):
 
     final = gateway_core.load_gateway_registry()
     names = {a["name"] for a in final["agents"]}
-    assert names == {"incumbent", "newcomer"}, (
-        "newcomer was clobbered by daemon save — registry write race regressed"
-    )
+    assert names == {"incumbent", "newcomer"}, "newcomer was clobbered by daemon save — registry write race regressed"
     # Daemon's effective_state update on the incumbent should still apply.
     incumbent = next(a for a in final["agents"] if a["name"] == "incumbent")
     assert incumbent["effective_state"] == "running"
@@ -7092,8 +7050,7 @@ def test_save_registry_preserves_other_writer_field_update(monkeypatch, tmp_path
     final = gateway_core.load_gateway_registry()
     stored = next(a for a in final["agents"] if a["name"] == "race-stop")
     assert stored["desired_state"] == "stopped", (
-        "daemon clobbered CLI's desired_state=stopped — field-level race "
-        "preservation regressed"
+        "daemon clobbered CLI's desired_state=stopped — field-level race preservation regressed"
     )
     # Daemon's effective_state telemetry update should still apply.
     assert stored["effective_state"] == "running"
@@ -7167,8 +7124,7 @@ def test_save_registry_preserves_archive_written_during_daemon_tick(monkeypatch,
 
 def test_status_payload_partitions_archived_separately(monkeypatch, tmp_path):
     _isolate_gateway_paths(monkeypatch, tmp_path)
-    archived = _stale_hermes_entry("hermes-archived", age_seconds=5.0, liveness="connected",
-                                   agent_id="agent-archived")
+    archived = _stale_hermes_entry("hermes-archived", age_seconds=5.0, liveness="connected", agent_id="agent-archived")
     archived["lifecycle_phase"] = "archived"
     archived["archived_at"] = gateway_core._now_iso()
     active = {
@@ -7230,8 +7186,7 @@ def test_runtime_start_skips_when_in_setup_error_backoff(monkeypatch, tmp_path):
 
     # Gate must early-return without firing a fresh runtime_error event.
     assert len(after) == len(before), (
-        "runtime.start() emitted a runtime_error event while in backoff "
-        "window — gate regressed"
+        "runtime.start() emitted a runtime_error event while in backoff window — gate regressed"
     )
     # State must be untouched — no transition through "starting".
     assert runtime._state.get("effective_state") != "starting"
@@ -7372,9 +7327,7 @@ def test_with_upstream_429_retry_caps_wait_at_max(monkeypatch):
         raise insane
 
     with pytest.raises(gateway_cmd.UpstreamRateLimitedError):
-        gateway_cmd._with_upstream_429_retry(
-            call, max_retries=2, base_wait=1.0, max_wait=30.0
-        )
+        gateway_cmd._with_upstream_429_retry(call, max_retries=2, base_wait=1.0, max_wait=30.0)
     assert sleeps == [30.0, 30.0]  # both capped at max_wait
 
 
@@ -7742,16 +7695,19 @@ def test_resolve_space_ref_uses_cache_when_upstream_429(monkeypatch, tmp_path):
     config_dir = tmp_path / "config"
     monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
     team_uuid = "78950af5-4d27-441b-9296-ec46de8ba35d"
-    gateway_core.save_space_cache([
-        {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank-workspace"},
-        {"id": team_uuid, "name": "aX CLI Dev", "slug": "ax-cli-dev"},
-    ])
+    gateway_core.save_space_cache(
+        [
+            {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank-workspace"},
+            {"id": team_uuid, "name": "aX CLI Dev", "slug": "ax-cli-dev"},
+        ]
+    )
 
     class Boom:
         def list_spaces(self):
             raise AssertionError("upstream must NOT be called when the cache has the slug")
 
     from ax_cli.config import _resolve_space_ref
+
     resolved = _resolve_space_ref(Boom(), "ax-cli-dev", source="explicit")
     assert resolved == team_uuid
 
@@ -7762,9 +7718,11 @@ def test_normalize_spaces_response_hydrates_name_from_cache(monkeypatch, tmp_pat
     falling back to the raw UUID."""
     config_dir = tmp_path / "config"
     monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
-    gateway_core.save_space_cache([
-        {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
-    ])
+    gateway_core.save_space_cache(
+        [
+            {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
+        ]
+    )
 
     upstream_partial = [
         {"id": _GOOD_SPACE_UUID, "name": "", "slug": "madtank"},
@@ -7799,14 +7757,16 @@ def test_runtime_reconcile_skips_phantom_rebinding_after_corruption_repair(monke
     daemon._runtimes = {}
     daemon.client_factory = lambda: object()
     daemon.logger = None
-    runtime = FakeRuntime({
-        "name": "agent-x",
-        "agent_id": "00000000-1111-2222-3333-444444444444",
-        "space_id": "madtank's Workspace",  # legacy non-UUID corruption
-        "base_url": "https://paxai.app",
-        "token_file": "/tmp/agent-token",
-        "runtime_type": "inbox",
-    })
+    runtime = FakeRuntime(
+        {
+            "name": "agent-x",
+            "agent_id": "00000000-1111-2222-3333-444444444444",
+            "space_id": "madtank's Workspace",  # legacy non-UUID corruption
+            "base_url": "https://paxai.app",
+            "token_file": "/tmp/agent-token",
+            "runtime_type": "inbox",
+        }
+    )
     daemon._runtimes["agent-x"] = runtime
     repaired_entry = {
         "name": "agent-x",
@@ -7827,8 +7787,7 @@ def test_runtime_reconcile_skips_phantom_rebinding_after_corruption_repair(monke
 
     rebindings = [c for c in captured if c["event"] == "runtime_rebinding"]
     assert rebindings == [], (
-        "reconcile() emitted a phantom runtime_rebinding when the only change "
-        "was a non-UUID -> UUID space_id repair"
+        "reconcile() emitted a phantom runtime_rebinding when the only change was a non-UUID -> UUID space_id repair"
     )
     assert runtime.entry["space_id"] == _GOOD_SPACE_UUID
 
@@ -7847,10 +7806,12 @@ def test_apply_entry_current_space_uses_global_cache_for_unknown_new_space(monke
     config_dir = tmp_path / "config"
     monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
     new_space = "78950af5-4d27-441b-9296-ec46de8ba35d"
-    gateway_core.save_space_cache([
-        {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
-        {"id": new_space, "name": "Claude Code Workshop", "slug": "claude-code-workshop"},
-    ])
+    gateway_core.save_space_cache(
+        [
+            {"id": _GOOD_SPACE_UUID, "name": "madtank's Workspace", "slug": "madtank"},
+            {"id": new_space, "name": "Claude Code Workshop", "slug": "claude-code-workshop"},
+        ]
+    )
     entry = {
         "name": "agent-x",
         "space_id": _GOOD_SPACE_UUID,
@@ -8094,9 +8055,7 @@ def test_local_inbox_resolves_slug_before_proxying(monkeypatch, tmp_path):
 def test_agents_inbox_resolves_slug_before_lookup(monkeypatch, tmp_path):
     """`ax gateway agents inbox --space <slug>` also resolves through the cache."""
     _seed_managed_inbox_agent(tmp_path, monkeypatch)
-    gateway_core.save_space_cache(
-        [{"id": "space-1", "name": "Test Space", "slug": "test-space"}]
-    )
+    gateway_core.save_space_cache([{"id": "space-1", "name": "Test Space", "slug": "test-space"}])
     monkeypatch.setattr(gateway_cmd, "AxClient", _FakeManagedSendClient)
     captured = {}
 
@@ -8105,15 +8064,17 @@ def test_agents_inbox_resolves_slug_before_lookup(monkeypatch, tmp_path):
     def spy_inbox(*, name, limit, channel, space_id, unread_only, mark_read):
         captured["space_id"] = space_id
         return real_inbox(
-            name=name, limit=limit, channel=channel, space_id=space_id,
-            unread_only=unread_only, mark_read=mark_read,
+            name=name,
+            limit=limit,
+            channel=channel,
+            space_id=space_id,
+            unread_only=unread_only,
+            mark_read=mark_read,
         )
 
     monkeypatch.setattr(gateway_cmd, "_inbox_for_managed_agent", spy_inbox)
 
-    result = runner.invoke(
-        app, ["gateway", "agents", "inbox", "cli_god", "--space", "test-space", "--json"]
-    )
+    result = runner.invoke(app, ["gateway", "agents", "inbox", "cli_god", "--space", "test-space", "--json"])
 
     assert result.exit_code == 0, result.output
     assert captured["space_id"] == "space-1"
@@ -8123,9 +8084,7 @@ def test_agents_inbox_unknown_slug_errors_clearly(monkeypatch, tmp_path):
     _seed_managed_inbox_agent(tmp_path, monkeypatch)
     gateway_core.save_space_cache([])
 
-    result = runner.invoke(
-        app, ["gateway", "agents", "inbox", "cli_god", "--space", "never-seen"]
-    )
+    result = runner.invoke(app, ["gateway", "agents", "inbox", "cli_god", "--space", "never-seen"])
 
     assert result.exit_code != 0
     assert "Could not resolve space" in result.output
@@ -8178,8 +8137,6 @@ def test_inbox_for_managed_agent_does_not_touch_pending_queue_without_mark_read(
 
     # Queue is preserved.
     assert len(gateway_core.load_agent_pending_messages("cli_god")) == 1
-
-
 
 
 def test_inbox_for_managed_agent_unread_only_intersects_pending_queue(monkeypatch, tmp_path):
@@ -8262,6 +8219,7 @@ def test_space_name_from_cache_rejects_uuid_stored_as_name():
     # This test documents the expected behavior — it will FAIL until the
     # fix lands, serving as a regression gate.
     import re
+
     uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
     assert result is None or not uuid_pattern.match(result), (
         f"_space_name_from_cache returned UUID-as-name '{result}' — "
@@ -8284,9 +8242,11 @@ def test_annotate_runtime_health_resolves_active_space_name_from_global_cache(mo
     space_uuid = "0478b063-4100-497d-bbea-2327bea48bc4"
     friendly_name = "ax-gateway"
 
-    gateway_core.save_space_cache([
-        {"id": space_uuid, "name": friendly_name, "slug": "ax-gateway"},
-    ])
+    gateway_core.save_space_cache(
+        [
+            {"id": space_uuid, "name": friendly_name, "slug": "ax-gateway"},
+        ]
+    )
 
     binding = {
         "identity_binding_id": "idbind_test",
@@ -8303,21 +8263,23 @@ def test_annotate_runtime_health_resolves_active_space_name_from_global_cache(mo
     }
     registry = gateway_core.load_gateway_registry()
     registry.setdefault("identity_bindings", []).append(binding)
-    registry.setdefault("agents", []).append({
-        "name": "test-agent",
-        "agent_id": "agent-test-1",
-        "identity_binding_id": "idbind_test",
-        "install_id": "install-1",
-        "base_url": "https://paxai.app",
-        "runtime_type": "hermes",
-        "template_id": "hermes",
-        "desired_state": "running",
-        "effective_state": "running",
-        "space_id": space_uuid,
-        "active_space_id": space_uuid,
-        "credential_source": "gateway",
-        "token_file": "/tmp/fake.token",
-    })
+    registry.setdefault("agents", []).append(
+        {
+            "name": "test-agent",
+            "agent_id": "agent-test-1",
+            "identity_binding_id": "idbind_test",
+            "install_id": "install-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "hermes",
+            "template_id": "hermes",
+            "desired_state": "running",
+            "effective_state": "running",
+            "space_id": space_uuid,
+            "active_space_id": space_uuid,
+            "credential_source": "gateway",
+            "token_file": "/tmp/fake.token",
+        }
+    )
     gateway_core.save_gateway_registry(registry)
 
     snapshot = {
@@ -8339,11 +8301,11 @@ def test_annotate_runtime_health_resolves_active_space_name_from_global_cache(mo
     annotated = gateway_core.annotate_runtime_health(snapshot, registry=registry)
 
     import re
+
     uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
     active_name = annotated.get("active_space_name", "")
     assert not uuid_pattern.match(active_name), (
-        f"active_space_name is a raw UUID '{active_name}' — "
-        f"should be '{friendly_name}' from the global disk cache"
+        f"active_space_name is a raw UUID '{active_name}' — should be '{friendly_name}' from the global disk cache"
     )
     assert active_name == friendly_name
 
@@ -8363,9 +8325,11 @@ def test_apply_entry_current_space_falls_through_uuid_name_to_global_cache(monke
     space_uuid = _GOOD_SPACE_UUID
     friendly_name = "madtank's Workspace"
 
-    gateway_core.save_space_cache([
-        {"id": space_uuid, "name": friendly_name, "slug": "madtank"},
-    ])
+    gateway_core.save_space_cache(
+        [
+            {"id": space_uuid, "name": friendly_name, "slug": "madtank"},
+        ]
+    )
 
     entry = {
         "name": "agent-x",
@@ -8383,6 +8347,7 @@ def test_apply_entry_current_space_falls_through_uuid_name_to_global_cache(monke
     gateway_core.apply_entry_current_space(entry, space_uuid)
 
     import re
+
     uuid_pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
     assert not uuid_pattern.match(entry["active_space_name"]), (
         f"active_space_name is still UUID '{entry['active_space_name']}' — "
@@ -8410,28 +8375,32 @@ def test_proxy_upload_file_rejects_path_outside_workdir(monkeypatch, tmp_path):
     token_file = tmp_path / "agent.token"
     token_file.write_text("axp_a_test.token")
 
-    gateway_core.save_gateway_session({
-        "token": "axp_u_test.token",
-        "base_url": "https://paxai.app",
-        "space_id": "space-1",
-        "username": "tester",
-    })
+    gateway_core.save_gateway_session(
+        {
+            "token": "axp_u_test.token",
+            "base_url": "https://paxai.app",
+            "space_id": "space-1",
+            "username": "tester",
+        }
+    )
     registry = gateway_core.load_gateway_registry()
-    registry["agents"] = [{
-        "name": "sandboxed-agent",
-        "agent_id": "agent-1",
-        "space_id": "space-1",
-        "base_url": "https://paxai.app",
-        "runtime_type": "hermes",
-        "template_id": "hermes",
-        "desired_state": "running",
-        "effective_state": "running",
-        "approval_state": "approved",
-        "token_file": str(token_file),
-        "transport": "gateway",
-        "credential_source": "gateway",
-        "workdir": str(agent_workdir),
-    }]
+    registry["agents"] = [
+        {
+            "name": "sandboxed-agent",
+            "agent_id": "agent-1",
+            "space_id": "space-1",
+            "base_url": "https://paxai.app",
+            "runtime_type": "hermes",
+            "template_id": "hermes",
+            "desired_state": "running",
+            "effective_state": "running",
+            "approval_state": "approved",
+            "token_file": str(token_file),
+            "transport": "gateway",
+            "credential_source": "gateway",
+            "workdir": str(agent_workdir),
+        }
+    ]
     gateway_core.save_gateway_registry(registry)
 
     entry = registry["agents"][0]

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -4203,7 +4203,7 @@ def test_gateway_agents_update_bedrock_arn(monkeypatch, tmp_path):
         "runtime_type": "exec",
         "template_id": "bedrock_agentcore",
         "template_label": "Bedrock AgentCore",
-        "exec_command": "python3 examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py",
+        "exec_command": "python3 -m ax_cli.bridges.bedrock_agentcore_bridge",
         "bedrock_runtime_arn": VALID_BEDROCK_ARN,
         "bedrock_region": "us-east-1",
         "bedrock_qualifier": "DEFAULT",
@@ -4278,6 +4278,45 @@ def test_gateway_agents_update_clears_bedrock_on_template_switch(monkeypatch, tm
     assert "bedrock_runtime_arn" not in stored
     assert "bedrock_region" not in stored
     assert "aws_profile" not in stored
+
+
+def test_gateway_agents_update_bedrock_flags_on_non_bedrock_agent_rejected(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {"token": "axp_u_test.token", "base_url": "https://paxai.app", "space_id": "space-1", "username": "codex"}
+    )
+    token_file = tmp_path / "echo.token"
+    token_file.write_text("axp_a_agent.secret")
+    registry = gateway_core.load_gateway_registry()
+    entry = {
+        "name": "echo-bot",
+        "agent_id": "agent-1",
+        "space_id": "space-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "echo",
+        "template_id": "echo_test",
+        "template_label": "Echo (Test)",
+        "desired_state": "running",
+        "effective_state": "running",
+        "token_file": str(token_file),
+        "transport": "gateway",
+        "credential_source": "gateway",
+        "created_via": "cli",
+    }
+    registry["agents"] = [entry]
+    gateway_core.ensure_local_asset_binding(registry, entry, created_via="cli", auto_approve=True)
+    gateway_core.ensure_gateway_identity_binding(registry, entry, session=gateway_core.load_gateway_session())
+    gateway_core.save_gateway_registry(registry)
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: _FakeUserClient())
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "update", "echo-bot", "--bedrock-runtime-arn", VALID_BEDROCK_ARN, "--json"],
+    )
+
+    assert result.exit_code != 0
+    assert "bedrock" in result.output.lower()
 
 
 def test_gateway_agents_update_template_switch_to_bedrock_requires_arn(monkeypatch, tmp_path):

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -3179,6 +3179,45 @@ def test_sanitize_exec_env_sets_ollama_model_override():
     assert env["OLLAMA_MODEL"] == "gemma4:latest"
 
 
+def test_sanitize_exec_env_sets_bedrock_env_vars():
+    env = gateway_core.sanitize_exec_env(
+        "hello",
+        {
+            "agent_id": "agent-1",
+            "name": "bedrock-bot",
+            "runtime_type": "exec",
+            "bedrock_runtime_arn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/r",
+            "bedrock_region": "us-east-1",
+            "bedrock_qualifier": "my-canary",
+            "bedrock_payload_key": "input",
+            "aws_profile": "dev-profile",
+        },
+    )
+
+    assert env["AX_BEDROCK_RUNTIME_ARN"] == "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/r"
+    assert env["AX_BEDROCK_REGION"] == "us-east-1"
+    assert env["AX_BEDROCK_QUALIFIER"] == "my-canary"
+    assert env["AX_BEDROCK_PAYLOAD_KEY"] == "input"
+    assert env["AWS_PROFILE"] == "dev-profile"
+
+
+def test_sanitize_exec_env_bedrock_omits_region_when_empty():
+    env = gateway_core.sanitize_exec_env(
+        "hello",
+        {
+            "agent_id": "agent-1",
+            "name": "bedrock-bot",
+            "runtime_type": "exec",
+            "bedrock_runtime_arn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/r",
+            "bedrock_region": "",
+        },
+    )
+
+    assert "AX_BEDROCK_RUNTIME_ARN" in env
+    assert "AX_BEDROCK_REGION" not in env
+    assert "AWS_PROFILE" not in env
+
+
 def test_ollama_setup_status_recommends_recent_local_chat_model(monkeypatch):
     class _FakeResponse:
         def raise_for_status(self) -> None:
@@ -4138,8 +4177,107 @@ def test_gateway_agents_update_changes_template_and_workdir(monkeypatch, tmp_pat
     assert runtime_fingerprint["workdir"] == str(tmp_path)
     assert runtime_fingerprint["command"] == "python3 examples/gateway_ollama/ollama_bridge.py"
     assert runtime_fingerprint["runtime_fingerprint_hash"].startswith("sha256:")
+    stored = gateway_core.load_gateway_registry()["agents"][0]
     attestation = gateway_core.evaluate_runtime_attestation(registry_after, stored)
     assert attestation["attestation_state"] == "verified"
+
+
+VALID_BEDROCK_ARN = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-runtime"
+VALID_BEDROCK_ARN_2 = "arn:aws:bedrock-agentcore:eu-west-1:123456789012:runtime/my-runtime-v2"
+
+
+def test_gateway_agents_update_bedrock_arn(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {"token": "axp_u_test.token", "base_url": "https://paxai.app", "space_id": "space-1", "username": "codex"}
+    )
+    token_file = tmp_path / "bedrock.token"
+    token_file.write_text("axp_a_agent.secret")
+    registry = gateway_core.load_gateway_registry()
+    entry = {
+        "name": "bedrock-bot",
+        "agent_id": "agent-1",
+        "space_id": "space-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "exec",
+        "template_id": "bedrock_agentcore",
+        "template_label": "Bedrock AgentCore",
+        "exec_command": "python3 examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py",
+        "bedrock_runtime_arn": VALID_BEDROCK_ARN,
+        "bedrock_region": "us-east-1",
+        "bedrock_qualifier": "DEFAULT",
+        "bedrock_payload_key": "prompt",
+        "aws_profile": "",
+        "desired_state": "running",
+        "effective_state": "running",
+        "token_file": str(token_file),
+        "transport": "gateway",
+        "credential_source": "gateway",
+        "created_via": "cli",
+    }
+    registry["agents"] = [entry]
+    gateway_core.ensure_local_asset_binding(registry, entry, created_via="cli", auto_approve=True)
+    gateway_core.ensure_gateway_identity_binding(registry, entry, session=gateway_core.load_gateway_session())
+    gateway_core.save_gateway_registry(registry)
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: _FakeUserClient())
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "update", "bedrock-bot", "--bedrock-runtime-arn", VALID_BEDROCK_ARN_2, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    stored = gateway_core.load_gateway_registry()["agents"][0]
+    assert stored["bedrock_runtime_arn"] == VALID_BEDROCK_ARN_2
+    assert stored["bedrock_region"] == "eu-west-1"  # region updated from new ARN
+
+
+def test_gateway_agents_update_clears_bedrock_on_template_switch(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("AX_CONFIG_DIR", str(config_dir))
+    gateway_core.save_gateway_session(
+        {"token": "axp_u_test.token", "base_url": "https://paxai.app", "space_id": "space-1", "username": "codex"}
+    )
+    token_file = tmp_path / "bedrock.token"
+    token_file.write_text("axp_a_agent.secret")
+    registry = gateway_core.load_gateway_registry()
+    entry = {
+        "name": "bedrock-bot",
+        "agent_id": "agent-1",
+        "space_id": "space-1",
+        "base_url": "https://paxai.app",
+        "runtime_type": "exec",
+        "template_id": "bedrock_agentcore",
+        "template_label": "Bedrock AgentCore",
+        "bedrock_runtime_arn": VALID_BEDROCK_ARN,
+        "bedrock_region": "us-east-1",
+        "bedrock_qualifier": "DEFAULT",
+        "bedrock_payload_key": "prompt",
+        "aws_profile": "dev",
+        "desired_state": "running",
+        "effective_state": "running",
+        "token_file": str(token_file),
+        "transport": "gateway",
+        "credential_source": "gateway",
+        "created_via": "cli",
+    }
+    registry["agents"] = [entry]
+    gateway_core.ensure_local_asset_binding(registry, entry, created_via="cli", auto_approve=True)
+    gateway_core.ensure_gateway_identity_binding(registry, entry, session=gateway_core.load_gateway_session())
+    gateway_core.save_gateway_registry(registry)
+    monkeypatch.setattr(gateway_cmd, "_load_gateway_user_client", lambda: _FakeUserClient())
+
+    result = runner.invoke(
+        app,
+        ["gateway", "agents", "update", "bedrock-bot", "--template", "echo_test", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    stored = gateway_core.load_gateway_registry()["agents"][0]
+    assert "bedrock_runtime_arn" not in stored
+    assert "bedrock_region" not in stored
+    assert "aws_profile" not in stored
 
 
 def test_gateway_agents_add_ollama_persists_model_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Implements #252. Adds `bedrock_agentcore` as a Gateway-managed exec-runtime template for Amazon Bedrock AgentCore Runtime.

- `examples/gateway_bedrock_agentcore/bedrock_agentcore_bridge.py` — new bridge with three pure-function deep modules: ARN validator (`validate_bedrock_options`), SSE event classifier (`classify_stream_event`), and boto3 client builder (`build_bedrock_client`). Deterministic session ID per `(agent_id, space_id)` pair via uuid5.
- `ax_cli/gateway_runtime_types.py` — registers `bedrock_agentcore` template in catalog, ordered after `strands`, `launchable: true`, `runtime_type: exec`
- `ax_cli/gateway.py` — injects `AX_BEDROCK_*` and `AWS_PROFILE` env vars in `sanitize_exec_env` so the bridge receives config from Gateway agent entry
- `ax_cli/commands/gateway.py` — adds `--bedrock-runtime-arn`, `--bedrock-region`, `--bedrock-qualifier`, `--bedrock-payload-key`, `--aws-profile` flags to both `agents add` and `agents update`; validates flags are only used with `--template bedrock_agentcore`; region re-derived from new ARN when `--bedrock-runtime-arn` is updated without `--bedrock-region`; bedrock fields cleaned from registry on template switch
- `pyproject.toml` — adds `axctl[bedrock]` optional dependency group (`boto3>=1.38`)

## Validation

- [x] `pytest tests/ -v --tb=short` — 938 passed, 2 skipped
- [x] `ruff check ax_cli/` — clean
- [x] `ruff format --check ax_cli/` — clean
- [ ] `python -m build && twine check dist/*`
- [ ] `axctl auth doctor` reviewed for the target env/space, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior
- [ ] `axctl qa preflight` passed for the target env/space before MCP Jam, widget, or Playwright validation
- [ ] `axctl qa matrix` passed before promotion or cross-env/release validation
- [ ] Live aX smoke test, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior

## Release Notes

- [x] This should appear in the changelog (`feat:`, `fix:`, or breaking change)
- [ ] This is internal/docs/test-only and does not need a package release

## Credential / Auth Impact

- [x] No token, profile, PAT, JWT, or agent identity behavior changed