### PR TITLE
feat(gateway): outbound connectors (Composio, http_mcp, CLI, UI, LangGraph demo)

### DIFF
--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -66,6 +66,7 @@ from ..connectors import (
     uses_managed_auth,
     write_managed_auth_from_file,
 )
+from ..connectors.providers.catalog import providers_payload
 from ..gateway import (
     AX_PLUGIN_NAME,
     GatewayDaemon,
@@ -647,14 +648,19 @@ def connectors_tools_search(
 
 @connectors_app.command("providers")
 def connectors_providers(as_json: bool = JSON_OPTION):
-    """List connector provider ids supported for tool execution."""
-    rows = [{"provider": pid} for pid in sorted(SUPPORTED_PROVIDERS)]
+    """List connector provider types and capabilities."""
+    payload = providers_payload()
     if as_json:
-        print_json({"providers": rows})
+        print_json(payload)
         return
     err_console.print("[bold]Supported connector providers[/bold]")
-    for pid in sorted(SUPPORTED_PROVIDERS):
-        err_console.print(f"  - {pid}")
+    for row in payload.get("providers") or []:
+        if not isinstance(row, dict):
+            continue
+        pid = row.get("id") or row.get("provider")
+        label = row.get("label") or pid
+        caps = ", ".join(row.get("capabilities") or [])
+        err_console.print(f"  - {pid} ({label}): {caps}")
 
 
 @connectors_auth_app.command("bind-managed")
@@ -3343,6 +3349,7 @@ def _connectors_list_payload(*, registry: dict[str, Any] | None = None) -> dict[
         "registry_path": str(connectors_registry_path()),
         "auth_env_dir": str(connectors_auth_env_base()),
         "providers": sorted(SUPPORTED_PROVIDERS),
+        "provider_catalog": providers_payload()["providers"],
         "connectors": rows,
         "count": len(rows),
         "summary": {
@@ -3545,6 +3552,7 @@ def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -
     connector_payload = _connectors_list_payload(registry=registry)
     payload["connectors"] = connector_payload["connectors"]
     payload["connectors_summary"] = connector_payload["summary"]
+    payload["connector_providers"] = connector_payload.get("provider_catalog") or []
     payload["summary"]["connectors"] = connector_payload["summary"]["total"]
     payload["summary"]["connectors_auth_ready"] = connector_payload["summary"]["auth_ready"]
     alerts = _gateway_alerts(payload)
@@ -5712,7 +5720,11 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
               </div>
               <div class="control-group">
                 <label for="connector-provider">Provider</label>
-                <select id="connector-provider" name="provider"><option value="composio">composio</option></select>
+                <select id="connector-provider" name="provider"></select>
+              </div>
+              <div class="control-group" id="connector-base-url-group">
+                <label for="connector-base-url">base_url (http_mcp)</label>
+                <input id="connector-base-url" name="base_url" placeholder="https://mcp.example.com/mcp" />
               </div>
               <div class="control-group">
                 <label for="connector-user-id">user_id</label>
@@ -6178,7 +6190,21 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
     }
 
 
+    function populateConnectorProviderSelect(catalog) {
+      const select = document.getElementById("connector-provider");
+      if (!select) return;
+      const rows = Array.isArray(catalog) ? catalog : [];
+      const current = select.value;
+      select.innerHTML = rows.map((row) => {
+        const id = row.id || row.provider || "";
+        const label = row.label || id;
+        return `<option value="${escapeHtml(id)}">${escapeHtml(label)}</option>`;
+      }).join("") || `<option value="composio">composio</option>`;
+      if (current) select.value = current;
+    }
+
     function renderConnectors(payload) {
+      populateConnectorProviderSelect(payload.connector_providers || payload.provider_catalog || []);
       const rows = payload.connectors || [];
       const summary = payload.connectors_summary || {};
       document.getElementById("connectors-summary").textContent = rows.length
@@ -6619,15 +6645,18 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
       const allowedRaw = String(data.get("allowed_tools") || "").trim();
       const allowed = allowedRaw ? allowedRaw.split(",").map((part) => part.trim()).filter(Boolean) : [];
       const config = {};
+      const provider = String(data.get("provider") || "composio").trim();
       const userId = String(data.get("user_id") || "").trim();
+      const baseUrl = String(data.get("base_url") || "").trim();
       if (userId) config.user_id = userId;
+      if (baseUrl) config.base_url = baseUrl;
       if (allowed.length) config.allowed_tools = allowed;
       try {
         const created = await apiRequest("/api/connectors", {
           method: "POST",
           body: JSON.stringify({
             name: String(data.get("name") || "").trim(),
-            provider: String(data.get("provider") || "composio").trim(),
+            provider,
             managed_auth: data.get("managed_auth") === "on",
             config,
           }),
@@ -6922,6 +6951,9 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                 has_data = bool(payload.get("spaces") or payload.get("active_space_id"))
                 status = HTTPStatus.OK if has_data else HTTPStatus.SERVICE_UNAVAILABLE
                 _write_json_response(self, payload, status=status)
+                return
+            if parsed.path == "/api/connectors/providers":
+                _write_json_response(self, providers_payload())
                 return
             if parsed.path == "/api/connectors":
                 _write_json_response(self, _connectors_list_payload())

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -45,10 +45,13 @@ from ..commands.bootstrap import (
 from ..config import resolve_space_id, resolve_user_base_url, resolve_user_token
 from ..connectors import (
     AUTH_REF_MANAGED,
+    ConnectorProviderError,
+    SUPPORTED_PROVIDERS,
     add_connector,
     connectors_registry_path,
     delete_managed_auth_file,
     ensure_managed_auth_file,
+    execute_connector_tool,
     find_connector,
     list_connectors,
     load_connectors_registry,
@@ -478,6 +481,62 @@ def connectors_set(
         print_json({"registry_path": str(connectors_registry_path()), "connector": dict(updated)})
         return
     err_console.print(f"[green]Updated connector[/green] {updated.get('name')!r}")
+
+
+@connectors_app.command("call")
+def connectors_call(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    tool: str = typer.Option(..., "--tool", "-t", help="Composio tool slug (e.g. GITHUB_LIST_STARGAZERS)"),
+    args_json: str = typer.Option("{}", "--args-json", help="JSON object of tool arguments"),
+    version: str | None = typer.Option(None, "--version", help="Optional Composio tool version"),
+    connected_account_id: str | None = typer.Option(
+        None,
+        "--connected-account-id",
+        help="Optional Composio connected account id",
+    ),
+    as_json: bool = JSON_OPTION,
+):
+    """Execute one outbound tool via the connector's provider adapter."""
+    try:
+        arguments = _connectors_parse_json_object(args_json, label="--args-json")
+        result = execute_connector_tool(
+            ref,
+            tool,
+            arguments,
+            version=version,
+            connected_account_id=connected_account_id,
+        )
+    except ConnectorProviderError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    except typer.BadParameter:
+        raise
+    payload = result.to_dict()
+    if as_json:
+        print_json(payload)
+        raise typer.Exit(0 if result.successful else 1)
+    err_console.print(f"[bold]ax gateway connectors call {ref}[/bold]")
+    err_console.print(f"  tool = {result.tool_slug}")
+    err_console.print(f"  successful = {result.successful}")
+    if result.log_id:
+        err_console.print(f"  log_id = {result.log_id}")
+    if result.error:
+        err_console.print(f"  error = {result.error}")
+    if result.data is not None:
+        err_console.print(f"  data = {json.dumps(result.data, default=str, sort_keys=True)}")
+    raise typer.Exit(0 if result.successful else 1)
+
+
+@connectors_app.command("providers")
+def connectors_providers(as_json: bool = JSON_OPTION):
+    """List connector provider ids supported for tool execution."""
+    rows = [{"provider": pid} for pid in sorted(SUPPORTED_PROVIDERS)]
+    if as_json:
+        print_json({"providers": rows})
+        return
+    err_console.print("[bold]Supported connector providers[/bold]")
+    for pid in sorted(SUPPORTED_PROVIDERS):
+        err_console.print(f"  - {pid}")
 
 
 @connectors_auth_app.command("bind-managed")

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -43,24 +43,22 @@ from ..commands.bootstrap import (
     _polish_metadata,
 )
 from ..config import resolve_space_id, resolve_user_base_url, resolve_user_token
-from ..connectors.auth import (
+from ..connectors import (
     AUTH_REF_MANAGED,
-    delete_managed_auth_file,
-    ensure_managed_auth_file,
-    public_auth_status,
-    release_managed_auth_if_unused,
-    uses_managed_auth,
-    write_managed_auth_from_file,
-)
-from ..connectors.registry import (
     add_connector,
     connectors_registry_path,
+    delete_managed_auth_file,
+    ensure_managed_auth_file,
     find_connector,
     list_connectors,
     load_connectors_registry,
+    public_auth_status,
+    release_managed_auth_if_unused,
     remove_connector,
     save_connectors_registry,
     update_connector,
+    uses_managed_auth,
+    write_managed_auth_from_file,
 )
 from ..gateway import (
     AX_PLUGIN_NAME,

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
@@ -42,6 +43,16 @@ from ..commands.bootstrap import (
     _polish_metadata,
 )
 from ..config import resolve_space_id, resolve_user_base_url, resolve_user_token
+from ..connectors.registry import (
+    add_connector,
+    connectors_registry_path,
+    find_connector,
+    list_connectors,
+    load_connectors_registry,
+    remove_connector,
+    save_connectors_registry,
+    update_connector,
+)
 from ..gateway import (
     AX_PLUGIN_NAME,
     GatewayDaemon,
@@ -123,6 +134,12 @@ app.add_typer(spaces_app, name="spaces")
 app.add_typer(approvals_app, name="approvals")
 app.add_typer(runtime_app, name="runtime")
 app.add_typer(local_app, name="local")
+connectors_app = typer.Typer(
+    name="connectors",
+    help="Manage the Gateway connector registry (outbound tool providers)",
+    no_args_is_help=True,
+)
+app.add_typer(connectors_app, name="connectors")
 
 _STATE_STYLES = {
     "running": "green",
@@ -191,6 +208,217 @@ def _load_gateway_session_or_exit() -> dict:
         err_console.print("[red]Gateway is not logged in.[/red] Run `ax gateway login` first.")
         raise typer.Exit(1)
     return session
+
+
+def _connectors_parse_json_object(raw: str | None, *, label: str) -> dict[str, Any]:
+    if raw is None or not str(raw).strip():
+        return {}
+    try:
+        parsed = json.loads(str(raw))
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"{label} must be valid JSON ({exc})") from exc
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter(f"{label} must be a JSON object")
+    return parsed
+
+
+@connectors_app.command("list")
+def connectors_list(as_json: bool = JSON_OPTION):
+    """List registered outbound connectors."""
+    reg = load_connectors_registry()
+    rows = list_connectors(reg)
+    path = connectors_registry_path()
+    if as_json:
+        print_json({"registry_path": str(path), "connectors": rows})
+        return
+    err_console.print("[bold]ax gateway connectors list[/bold]")
+    err_console.print(f"  registry_path = {path}")
+    if not rows:
+        err_console.print("  (no connectors)")
+        return
+    print_table(
+        ["name", "provider", "enabled", "id", "auth_ref"],
+        [
+            {
+                "name": r.get("name"),
+                "provider": r.get("provider"),
+                "enabled": r.get("enabled"),
+                "id": r.get("id"),
+                "auth_ref": r.get("auth_ref") or "-",
+            }
+            for r in rows
+        ],
+        keys=["name", "provider", "enabled", "id", "auth_ref"],
+    )
+
+
+@connectors_app.command("show")
+def connectors_show(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    as_json: bool = JSON_OPTION,
+):
+    """Show one connector row."""
+    reg = load_connectors_registry()
+    row = find_connector(reg, ref)
+    if not row:
+        err_console.print(f"[red]Unknown connector:[/red] {ref}")
+        raise typer.Exit(1)
+    snapshot = dict(row)
+    if as_json:
+        print_json({"registry_path": str(connectors_registry_path()), "connector": snapshot})
+        return
+    err_console.print(f"[bold]ax gateway connectors show {ref}[/bold]")
+    for key in ("name", "provider", "enabled", "id", "auth_ref", "created_at", "updated_at"):
+        err_console.print(f"  {key} = {snapshot.get(key)}")
+    err_console.print(f"  config = {json.dumps(snapshot.get('config') or {}, sort_keys=True)}")
+    err_console.print(f"  metadata = {json.dumps(snapshot.get('metadata') or {}, sort_keys=True)}")
+
+
+@connectors_app.command("add")
+def connectors_add(
+    name: str = typer.Argument(..., help="Unique connector name"),
+    provider: str = typer.Option(..., "--provider", "-p", help="Provider id (e.g. composio, http_mcp)"),
+    auth_ref: str | None = typer.Option(
+        None,
+        "--auth-ref",
+        help="Non-secret reference only (env file path, vault key). Never paste API keys here.",
+    ),
+    config_json: str | None = typer.Option(None, "--config-json", help="JSON object for provider config (no secrets)"),
+    metadata_json: str | None = typer.Option(None, "--metadata-json", help="JSON object for notes/tags"),
+    disabled: bool = typer.Option(False, "--disabled", help="Create in disabled state"),
+    as_json: bool = JSON_OPTION,
+):
+    """Register a new connector row."""
+    reg = load_connectors_registry()
+    try:
+        cfg = _connectors_parse_json_object(config_json, label="--config-json")
+        meta = _connectors_parse_json_object(metadata_json, label="--metadata-json")
+        rec = add_connector(
+            reg,
+            name=name,
+            provider=provider,
+            enabled=not disabled,
+            auth_ref=auth_ref,
+            config=cfg,
+            metadata=meta,
+        )
+        save_connectors_registry(reg)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    except typer.BadParameter:
+        raise
+    if as_json:
+        print_json({"registry_path": str(connectors_registry_path()), "connector": dict(rec)})
+        return
+    err_console.print(f"[green]Added connector[/green] {rec.get('name')!r} ({rec.get('id')})")
+
+
+@connectors_app.command("remove")
+def connectors_remove(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    as_json: bool = JSON_OPTION,
+):
+    """Remove a connector from the registry."""
+    reg = load_connectors_registry()
+    if not remove_connector(reg, ref):
+        err_console.print(f"[red]Unknown connector:[/red] {ref}")
+        raise typer.Exit(1)
+    try:
+        save_connectors_registry(reg)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    if as_json:
+        print_json({"registry_path": str(connectors_registry_path()), "removed": ref})
+        return
+    err_console.print(f"[green]Removed connector[/green] {ref!r}")
+
+
+@connectors_app.command("set")
+def connectors_set(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    enabled: bool | None = typer.Option(None, "--enable/--disable", help="Set enabled flag"),
+    rename: str | None = typer.Option(None, "--rename", help="New unique name"),
+    provider: str | None = typer.Option(None, "--provider", "-p", help="New provider id"),
+    auth_ref: str | None = typer.Option(None, "--auth-ref", help="Set auth ref (opaque path or key)"),
+    clear_auth_ref: bool = typer.Option(False, "--clear-auth-ref", help="Remove auth_ref"),
+    config_json: str | None = typer.Option(None, "--config-json", help="Replace config object"),
+    metadata_json: str | None = typer.Option(None, "--metadata-json", help="Replace metadata object"),
+    as_json: bool = JSON_OPTION,
+):
+    """Update fields on an existing connector."""
+    if clear_auth_ref and auth_ref is not None:
+        err_console.print("[red]Use either --clear-auth-ref or --auth-ref, not both.[/red]")
+        raise typer.Exit(1)
+    if (
+        enabled is None
+        and rename is None
+        and provider is None
+        and auth_ref is None
+        and not clear_auth_ref
+        and config_json is None
+        and metadata_json is None
+    ):
+        err_console.print(
+            "[red]No changes specified.[/red] Pass at least one of: "
+            "--enable/--disable, --rename, --provider, --auth-ref, --clear-auth-ref, "
+            "--config-json, --metadata-json"
+        )
+        raise typer.Exit(1)
+    reg = load_connectors_registry()
+    cfg: dict[str, Any] | None = None
+    meta: dict[str, Any] | None = None
+    if config_json is not None:
+        cfg = _connectors_parse_json_object(config_json, label="--config-json")
+    if metadata_json is not None:
+        meta = _connectors_parse_json_object(metadata_json, label="--metadata-json")
+    try:
+        if clear_auth_ref:
+            updated = update_connector(
+                reg,
+                ref,
+                name=rename,
+                provider=provider,
+                enabled=enabled,
+                clear_auth_ref=True,
+                config=cfg,
+                metadata=meta,
+            )
+        elif auth_ref is not None:
+            updated = update_connector(
+                reg,
+                ref,
+                name=rename,
+                provider=provider,
+                enabled=enabled,
+                auth_ref=auth_ref,
+                config=cfg,
+                metadata=meta,
+            )
+        else:
+            updated = update_connector(
+                reg,
+                ref,
+                name=rename,
+                provider=provider,
+                enabled=enabled,
+                config=cfg,
+                metadata=meta,
+            )
+        if not updated:
+            err_console.print(f"[red]Unknown connector:[/red] {ref}")
+            raise typer.Exit(1)
+        save_connectors_registry(reg)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    except typer.BadParameter:
+        raise
+    if as_json:
+        print_json({"registry_path": str(connectors_registry_path()), "connector": dict(updated)})
+        return
+    err_console.print(f"[green]Updated connector[/green] {updated.get('name')!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -45,20 +45,22 @@ from ..commands.bootstrap import (
 from ..config import resolve_space_id, resolve_user_base_url, resolve_user_token
 from ..connectors import (
     AUTH_REF_MANAGED,
-    ConnectorProviderError,
     SUPPORTED_PROVIDERS,
+    ConnectorProviderError,
     add_connector,
     connectors_registry_path,
     delete_managed_auth_file,
     ensure_managed_auth_file,
     execute_connector_tool,
     find_connector,
+    list_connector_tools,
     list_connectors,
     load_connectors_registry,
     public_auth_status,
     release_managed_auth_if_unused,
     remove_connector,
     save_connectors_registry,
+    search_connector_tools,
     update_connector,
     uses_managed_auth,
     write_managed_auth_from_file,
@@ -154,8 +156,14 @@ connectors_auth_app = typer.Typer(
     help="Connector auth files (Gateway-managed or external path); never prints secret values",
     no_args_is_help=True,
 )
+connectors_tools_app = typer.Typer(
+    name="tools",
+    help="List and search connector tools (Composio catalog and intent search)",
+    no_args_is_help=True,
+)
 app.add_typer(connectors_app, name="connectors")
 connectors_app.add_typer(connectors_auth_app, name="auth")
+connectors_app.add_typer(connectors_tools_app, name="tools")
 
 _STATE_STYLES = {
     "running": "green",
@@ -524,6 +532,115 @@ def connectors_call(
         err_console.print(f"  error = {result.error}")
     if result.data is not None:
         err_console.print(f"  data = {json.dumps(result.data, default=str, sort_keys=True)}")
+    raise typer.Exit(0 if result.successful else 1)
+
+
+@connectors_tools_app.command("list")
+def connectors_tools_list(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    query: str | None = typer.Option(None, "--query", "-q", help="Composio catalog text search"),
+    toolkit: str | None = typer.Option(None, "--toolkit", help="Filter by toolkit slug (e.g. github)"),
+    limit: int | None = typer.Option(None, "--limit", help="Max tools to return (default from connector config)"),
+    as_json: bool = JSON_OPTION,
+):
+    """List tools available to a connector (Composio API + Gateway allow/deny policy)."""
+    try:
+        payload = list_connector_tools(
+            ref,
+            query=query,
+            toolkit_slug=toolkit,
+            limit=limit,
+        )
+    except ConnectorProviderError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    if as_json:
+        print_json(payload)
+        return
+    err_console.print(f"[bold]ax gateway connectors tools list {ref}[/bold]")
+    err_console.print(f"  count = {payload.get('count')}")
+    if payload.get("policy_applied"):
+        err_console.print("  policy_applied = true")
+    tools = payload.get("tools") or []
+    if not tools:
+        err_console.print("  (no tools)")
+        return
+    print_table(
+        ["slug", "name", "toolkit"],
+        [
+            {
+                "slug": row.get("slug"),
+                "name": row.get("name"),
+                "toolkit": row.get("toolkit_slug") or "-",
+            }
+            for row in tools
+            if isinstance(row, dict)
+        ],
+        keys=["slug", "name", "toolkit"],
+    )
+
+
+@connectors_tools_app.command("search")
+def connectors_tools_search(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    use_case: str = typer.Option(..., "--use-case", "-u", help="Natural-language task description"),
+    mode: str = typer.Option(
+        "auto",
+        "--mode",
+        help="Search mode: auto (intent then catalog), intent (COMPOSIO_SEARCH_TOOLS), catalog (query only)",
+    ),
+    known_fields: str | None = typer.Option(
+        None,
+        "--known-fields",
+        help="Optional known_fields hint for Composio intent search (key:value pairs)",
+    ),
+    session_id: str | None = typer.Option(None, "--session-id", help="Reuse Composio search session id"),
+    limit: int | None = typer.Option(None, "--limit", help="Max tools when falling back to catalog search"),
+    as_json: bool = JSON_OPTION,
+):
+    """Search tools by intent (Composio COMPOSIO_SEARCH_TOOLS) with Gateway policy filtering."""
+    normalized_mode = str(mode or "auto").strip().lower()
+    if normalized_mode not in {"auto", "intent", "catalog"}:
+        err_console.print("[red]--mode must be auto, intent, or catalog.[/red]")
+        raise typer.Exit(1)
+    try:
+        result = search_connector_tools(
+            ref,
+            use_case,
+            mode=normalized_mode,  # type: ignore[arg-type]
+            known_fields=known_fields,
+            session_id=session_id,
+            limit=limit,
+        )
+    except ConnectorProviderError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    payload = result.to_dict()
+    if as_json:
+        print_json(payload)
+        raise typer.Exit(0 if result.successful else 1)
+    err_console.print(f"[bold]ax gateway connectors tools search {ref}[/bold]")
+    err_console.print(f"  mode = {result.mode}")
+    err_console.print(f"  successful = {result.successful}")
+    if result.session_id:
+        err_console.print(f"  session_id = {result.session_id}")
+    if result.error:
+        err_console.print(f"  error = {result.error}")
+    if not result.tools:
+        err_console.print("  (no tools matched policy)")
+        raise typer.Exit(0 if result.successful else 1)
+    print_table(
+        ["slug", "name", "description"],
+        [
+            {
+                "slug": tool.slug,
+                "name": tool.name,
+                "description": (tool.description or "")[:80],
+            }
+            for tool in result.tools
+        ],
+        keys=["slug", "name", "description"],
+    )
     raise typer.Exit(0 if result.successful else 1)
 
 

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -1811,6 +1811,7 @@ def _register_managed_agent(
     timeout_seconds: int | None = None,
     allow_all_users: bool = False,
     allowed_users: str | None = None,
+    connector_ref: str | None = None,
     start: bool = True,
 ) -> dict:
     name = name.strip()
@@ -1842,6 +1843,10 @@ def _register_managed_agent(
     if template_effective_id in {"hermes", "sentinel_cli", "claude_code_channel"} and not explicit_workdir:
         raise ValueError(
             f"Template {template['label']} requires --workdir so Gateway can bind the agent to its runtime folder."
+        )
+    if template_effective_id == "langgraph_composio" and not str(connector_ref or "").strip():
+        raise ValueError(
+            f"Template {template['label']} requires --connector-ref (registered `ax gateway connectors` name or id)."
         )
     _validate_runtime_registration(runtime_type, exec_cmd)
     timeout_effective = _normalize_timeout_seconds(timeout_seconds)
@@ -1934,6 +1939,9 @@ def _register_managed_agent(
         entry_payload["allow_all_users"] = True
     if allowed_users and str(allowed_users).strip():
         entry_payload["allowed_users"] = str(allowed_users).strip()
+    normalized_connector_ref = str(connector_ref or "").strip() or None
+    if normalized_connector_ref:
+        entry_payload["connector_ref"] = normalized_connector_ref
     if requires_approval:
         entry_payload["install_id"] = str(uuid.uuid4())
     entry = upsert_agent_entry(registry, entry_payload)
@@ -2216,6 +2224,7 @@ def _update_managed_agent(
     timeout_seconds: int | object = _UNSET,
     allow_all_users: bool | object = _UNSET,
     allowed_users: str | object = _UNSET,
+    connector_ref: str | object = _UNSET,
     desired_state: str | None = None,
 ) -> dict:
     name = name.strip()
@@ -2320,6 +2329,12 @@ def _update_managed_agent(
             entry["allowed_users"] = allowed_clean
         else:
             entry.pop("allowed_users", None)
+    if connector_ref is not _UNSET:
+        connector_clean = str(connector_ref or "").strip()
+        if connector_clean:
+            entry["connector_ref"] = connector_clean
+        else:
+            entry.pop("connector_ref", None)
     if template_effective_id == "ollama":
         entry["ollama_model"] = ollama_model_effective
     else:
@@ -8823,6 +8838,11 @@ def add_agent(
         "--allowed-users",
         help="Hermes plugin runtime only: comma-separated agent/user names allowed to mention this agent.",
     ),
+    connector_ref: str = typer.Option(
+        None,
+        "--connector-ref",
+        help="Connector registry name/id for langgraph_composio (sets AX_GATEWAY_CONNECTOR_REF on exec).",
+    ),
     start: bool = typer.Option(True, "--start/--no-start", help="Desired running state after registration"),
     as_json: bool = JSON_OPTION,
 ):
@@ -8867,6 +8887,7 @@ def add_agent(
             timeout_seconds=timeout_seconds,
             allow_all_users=allow_all_users,
             allowed_users=allowed_users,
+            connector_ref=connector_ref,
             start=start,
         )
     except (ValueError, LookupError) as exc:
@@ -8884,6 +8905,8 @@ def add_agent(
         err_console.print(f"  desired_state = {entry['desired_state']}")
         if entry.get("timeout_seconds"):
             err_console.print(f"  timeout = {entry.get('timeout_seconds')}s")
+        if entry.get("connector_ref"):
+            err_console.print(f"  connector_ref = {entry['connector_ref']}")
         err_console.print(f"  token_file = {entry['token_file']}")
 
 
@@ -8931,6 +8954,11 @@ def update_agent(
             "Pass an empty string to clear."
         ),
     ),
+    connector_ref: str = typer.Option(
+        None,
+        "--connector-ref",
+        help="Connector registry name/id for langgraph_composio (empty string clears).",
+    ),
     desired_state: str = typer.Option(None, "--desired-state", help="running | stopped"),
     as_json: bool = JSON_OPTION,
 ):
@@ -8960,6 +8988,7 @@ def update_agent(
             timeout_seconds=timeout_seconds if timeout_seconds is not None else _UNSET,
             allow_all_users=allow_all_users if allow_all_users is not None else _UNSET,
             allowed_users=allowed_users if allowed_users is not None else _UNSET,
+            connector_ref=connector_ref if connector_ref is not None else _UNSET,
             desired_state=desired_state,
         )
     except (LookupError, ValueError) as exc:

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -43,6 +43,15 @@ from ..commands.bootstrap import (
     _polish_metadata,
 )
 from ..config import resolve_space_id, resolve_user_base_url, resolve_user_token
+from ..connectors.auth import (
+    AUTH_REF_MANAGED,
+    delete_managed_auth_file,
+    ensure_managed_auth_file,
+    public_auth_status,
+    release_managed_auth_if_unused,
+    uses_managed_auth,
+    write_managed_auth_from_file,
+)
 from ..connectors.registry import (
     add_connector,
     connectors_registry_path,
@@ -139,7 +148,13 @@ connectors_app = typer.Typer(
     help="Manage the Gateway connector registry (outbound tool providers)",
     no_args_is_help=True,
 )
+connectors_auth_app = typer.Typer(
+    name="auth",
+    help="Connector auth files (Gateway-managed or external path); never prints secret values",
+    no_args_is_help=True,
+)
 app.add_typer(connectors_app, name="connectors")
+connectors_app.add_typer(connectors_auth_app, name="auth")
 
 _STATE_STYLES = {
     "running": "green",
@@ -255,6 +270,11 @@ def connectors_list(as_json: bool = JSON_OPTION):
 @connectors_app.command("show")
 def connectors_show(
     ref: str = typer.Argument(..., help="Connector name or id"),
+    auth_status: bool = typer.Option(
+        False,
+        "--auth-status",
+        help="Include redacted auth summary (env key names only; never secret values).",
+    ),
     as_json: bool = JSON_OPTION,
 ):
     """Show one connector row."""
@@ -265,13 +285,24 @@ def connectors_show(
         raise typer.Exit(1)
     snapshot = dict(row)
     if as_json:
-        print_json({"registry_path": str(connectors_registry_path()), "connector": snapshot})
+        payload: dict[str, Any] = {"registry_path": str(connectors_registry_path()), "connector": snapshot}
+        if auth_status:
+            payload["auth"] = public_auth_status(dict(row))
+        print_json(payload)
         return
     err_console.print(f"[bold]ax gateway connectors show {ref}[/bold]")
     for key in ("name", "provider", "enabled", "id", "auth_ref", "created_at", "updated_at"):
         err_console.print(f"  {key} = {snapshot.get(key)}")
     err_console.print(f"  config = {json.dumps(snapshot.get('config') or {}, sort_keys=True)}")
     err_console.print(f"  metadata = {json.dumps(snapshot.get('metadata') or {}, sort_keys=True)}")
+    if auth_status:
+        st = public_auth_status(dict(row))
+        err_console.print(f"  auth.kind = {st.get('kind')}")
+        err_console.print(f"  auth.path_redacted = {st.get('path_redacted')}")
+        err_console.print(f"  auth.file_exists = {st.get('file_exists')}")
+        err_console.print(f"  auth.env_keys = {st.get('env_keys')}")
+        if st.get("error"):
+            err_console.print(f"  auth.error = {st.get('error')}")
 
 
 @connectors_app.command("add")
@@ -283,26 +314,37 @@ def connectors_add(
         "--auth-ref",
         help="Non-secret reference only (env file path, vault key). Never paste API keys here.",
     ),
+    managed_auth: bool = typer.Option(
+        False,
+        "--managed-auth",
+        help=f"Store secrets under Gateway ({AUTH_REF_MANAGED}); creates a per-connector .env file.",
+    ),
     config_json: str | None = typer.Option(None, "--config-json", help="JSON object for provider config (no secrets)"),
     metadata_json: str | None = typer.Option(None, "--metadata-json", help="JSON object for notes/tags"),
     disabled: bool = typer.Option(False, "--disabled", help="Create in disabled state"),
     as_json: bool = JSON_OPTION,
 ):
     """Register a new connector row."""
+    if managed_auth and auth_ref is not None and str(auth_ref).strip():
+        err_console.print("[red]Use either --managed-auth or --auth-ref, not both.[/red]")
+        raise typer.Exit(1)
     reg = load_connectors_registry()
     try:
         cfg = _connectors_parse_json_object(config_json, label="--config-json")
         meta = _connectors_parse_json_object(metadata_json, label="--metadata-json")
+        effective_auth_ref = AUTH_REF_MANAGED if managed_auth else auth_ref
         rec = add_connector(
             reg,
             name=name,
             provider=provider,
             enabled=not disabled,
-            auth_ref=auth_ref,
+            auth_ref=effective_auth_ref,
             config=cfg,
             metadata=meta,
         )
         save_connectors_registry(reg)
+        if managed_auth:
+            ensure_managed_auth_file(str(rec.get("id") or ""))
     except ValueError as exc:
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
@@ -321,14 +363,22 @@ def connectors_remove(
 ):
     """Remove a connector from the registry."""
     reg = load_connectors_registry()
-    if not remove_connector(reg, ref):
+    row = find_connector(reg, ref)
+    if not row:
         err_console.print(f"[red]Unknown connector:[/red] {ref}")
+        raise typer.Exit(1)
+    cid = str(row.get("id") or "").strip()
+    was_managed = uses_managed_auth(dict(row))
+    if not remove_connector(reg, ref):
+        err_console.print(f"[red]Failed to remove connector:[/red] {ref}")
         raise typer.Exit(1)
     try:
         save_connectors_registry(reg)
     except ValueError as exc:
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc
+    if was_managed and cid:
+        delete_managed_auth_file(cid)
     if as_json:
         print_json({"registry_path": str(connectors_registry_path()), "removed": ref})
         return
@@ -367,6 +417,12 @@ def connectors_set(
         )
         raise typer.Exit(1)
     reg = load_connectors_registry()
+    row_before = find_connector(reg, ref)
+    auth_snapshot = (
+        {"id": str(row_before.get("id") or ""), "auth_ref": row_before.get("auth_ref")}
+        if row_before
+        else None
+    )
     cfg: dict[str, Any] | None = None
     meta: dict[str, Any] | None = None
     if config_json is not None:
@@ -410,6 +466,11 @@ def connectors_set(
             err_console.print(f"[red]Unknown connector:[/red] {ref}")
             raise typer.Exit(1)
         save_connectors_registry(reg)
+        if auth_snapshot:
+            release_managed_auth_if_unused(
+                auth_snapshot,
+                auth_ref_after=str(updated.get("auth_ref") or "").strip() or None,
+            )
     except ValueError as exc:
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
@@ -419,6 +480,117 @@ def connectors_set(
         print_json({"registry_path": str(connectors_registry_path()), "connector": dict(updated)})
         return
     err_console.print(f"[green]Updated connector[/green] {updated.get('name')!r}")
+
+
+@connectors_auth_app.command("bind-managed")
+def connectors_auth_bind_managed(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    as_json: bool = JSON_OPTION,
+):
+    """Point connector auth at Gateway-managed ``.env`` and create the file if missing."""
+    reg = load_connectors_registry()
+    row = find_connector(reg, ref)
+    if not row:
+        err_console.print(f"[red]Unknown connector:[/red] {ref}")
+        raise typer.Exit(1)
+    cid = str(row.get("id") or "").strip()
+    if not cid:
+        err_console.print("[red]Connector row is missing id.[/red]")
+        raise typer.Exit(1)
+    try:
+        update_connector(reg, ref, auth_ref=AUTH_REF_MANAGED)
+        ensure_managed_auth_file(cid)
+        save_connectors_registry(reg)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    if as_json:
+        row2 = find_connector(reg, ref)
+        print_json(
+            {
+                "registry_path": str(connectors_registry_path()),
+                "auth_ref": AUTH_REF_MANAGED,
+                "auth": public_auth_status(dict(row2 or {})),
+                "connector_id": cid,
+            }
+        )
+        return
+    err_console.print(f"[green]Managed auth bound[/green] for {ref!r}")
+    st = public_auth_status(dict(find_connector(reg, ref) or {}))
+    err_console.print(f"  auth.path_redacted = {st.get('path_redacted')}")
+
+
+@connectors_auth_app.command("status")
+def connectors_auth_status_cmd(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    as_json: bool = JSON_OPTION,
+):
+    """Show redacted auth storage status (key names only; never values)."""
+    reg = load_connectors_registry()
+    row = find_connector(reg, ref)
+    if not row:
+        err_console.print(f"[red]Unknown connector:[/red] {ref}")
+        raise typer.Exit(1)
+    st = public_auth_status(dict(row))
+    if as_json:
+        print_json({"registry_path": str(connectors_registry_path()), "connector_ref": ref, "auth": st})
+        return
+    err_console.print(f"[bold]ax gateway connectors auth status {ref}[/bold]")
+    err_console.print(f"  kind = {st.get('kind')}")
+    err_console.print(f"  path_redacted = {st.get('path_redacted')}")
+    err_console.print(f"  file_exists = {st.get('file_exists')}")
+    err_console.print(f"  env_keys = {st.get('env_keys')}")
+    if st.get("error"):
+        err_console.print(f"  error = {st.get('error')}")
+
+
+@connectors_auth_app.command("write")
+def connectors_auth_write(
+    ref: str = typer.Argument(..., help="Connector name or id"),
+    from_file: Path = typer.Option(
+        ...,
+        "--from-file",
+        help="Existing file to copy into the managed connector .env (atomic replace).",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    as_json: bool = JSON_OPTION,
+):
+    """Copy a file into the managed auth env (requires ``auth_ref`` = gateway:managed)."""
+    reg = load_connectors_registry()
+    row = find_connector(reg, ref)
+    if not row:
+        err_console.print(f"[red]Unknown connector:[/red] {ref}")
+        raise typer.Exit(1)
+    if not uses_managed_auth(dict(row)):
+        err_console.print(
+            f"[red]Connector is not using managed auth.[/red] Run "
+            f"`ax gateway connectors auth bind-managed {ref}` first."
+        )
+        raise typer.Exit(1)
+    cid = str(row.get("id") or "").strip()
+    if not cid:
+        err_console.print("[red]Connector row is missing id.[/red]")
+        raise typer.Exit(1)
+    try:
+        dest = write_managed_auth_from_file(cid, from_file)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    if as_json:
+        print_json(
+            {
+                "registry_path": str(connectors_registry_path()),
+                "connector_id": cid,
+                "dest_path_redacted": public_auth_status(dict(find_connector(reg, ref) or {})).get(
+                    "path_redacted"
+                ),
+                "bytes_written_hint": dest.stat().st_size if dest.is_file() else None,
+            }
+        )
+        return
+    err_console.print(f"[green]Wrote managed auth[/green] for {ref!r} from {from_file}")
 
 
 # ---------------------------------------------------------------------------

--- a/ax_cli/commands/gateway.py
+++ b/ax_cli/commands/gateway.py
@@ -48,6 +48,7 @@ from ..connectors import (
     SUPPORTED_PROVIDERS,
     ConnectorProviderError,
     add_connector,
+    connectors_auth_env_base,
     connectors_registry_path,
     delete_managed_auth_file,
     ensure_managed_auth_file,
@@ -3289,6 +3290,164 @@ def _no_invoking_principal_error() -> ValueError:
     )
 
 
+def _linked_agents_for_connector_row(row: dict[str, Any], registry: dict[str, Any]) -> list[str]:
+    """Gateway agent names that reference this connector by name or id."""
+    cid = str(row.get("id") or "").strip().lower()
+    cname = str(row.get("name") or "").strip().lower()
+    linked: list[str] = []
+    for agent in registry.get("agents") or []:
+        if not isinstance(agent, dict):
+            continue
+        cref = str(agent.get("connector_ref") or "").strip().lower()
+        if not cref:
+            continue
+        if cref == cname or (cid and cref == cid):
+            name = str(agent.get("name") or "").strip()
+            if name:
+                linked.append(name)
+    return linked
+
+
+def _connector_summary_row(row: dict[str, Any], *, registry: dict[str, Any] | None = None) -> dict[str, Any]:
+    reg = registry or load_gateway_registry()
+    auth = public_auth_status(dict(row))
+    cfg = row.get("config") if isinstance(row.get("config"), dict) else {}
+    auth_ready = bool(auth.get("file_exists")) and bool(auth.get("env_keys")) and not auth.get("error")
+    return {
+        "id": row.get("id"),
+        "name": row.get("name"),
+        "provider": row.get("provider"),
+        "enabled": bool(row.get("enabled", True)),
+        "auth_ref": row.get("auth_ref"),
+        "auth_kind": auth.get("kind"),
+        "auth_ready": auth_ready,
+        "auth_env_keys": list(auth.get("env_keys") or []),
+        "auth_path_redacted": auth.get("path_redacted"),
+        "auth_error": auth.get("error"),
+        "linked_agents": _linked_agents_for_connector_row(row, reg),
+        "user_id": cfg.get("user_id"),
+        "search_mode": cfg.get("search_mode"),
+        "allowed_tools": cfg.get("allowed_tools") or cfg.get("allow_tools"),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+    }
+
+
+def _connectors_list_payload(*, registry: dict[str, Any] | None = None) -> dict[str, Any]:
+    reg = load_connectors_registry()
+    gateway_registry = registry or load_gateway_registry()
+    rows = [_connector_summary_row(dict(row), registry=gateway_registry) for row in list_connectors(reg)]
+    enabled = sum(1 for row in rows if row.get("enabled"))
+    ready = sum(1 for row in rows if row.get("auth_ready"))
+    return {
+        "registry_path": str(connectors_registry_path()),
+        "auth_env_dir": str(connectors_auth_env_base()),
+        "providers": sorted(SUPPORTED_PROVIDERS),
+        "connectors": rows,
+        "count": len(rows),
+        "summary": {
+            "total": len(rows),
+            "enabled": enabled,
+            "auth_ready": ready,
+        },
+    }
+
+
+def _connector_detail_payload(ref: str, *, registry: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    reg = load_connectors_registry()
+    row = find_connector(reg, ref)
+    if not row:
+        return None
+    gateway_registry = registry or load_gateway_registry()
+    snapshot = dict(row)
+    return {
+        "registry_path": str(connectors_registry_path()),
+        "connector": snapshot,
+        "summary": _connector_summary_row(snapshot, registry=gateway_registry),
+        "auth": public_auth_status(snapshot),
+    }
+
+
+def _api_add_connector(body: dict[str, Any]) -> dict[str, Any]:
+    name = str(body.get("name") or "").strip()
+    provider = str(body.get("provider") or "").strip().lower()
+    if not name:
+        raise ValueError("connector name is required")
+    if not provider:
+        raise ValueError("connector provider is required")
+    managed_auth = bool(body.get("managed_auth"))
+    auth_ref_raw = str(body.get("auth_ref") or "").strip() or None
+    if managed_auth and auth_ref_raw:
+        raise ValueError("Use either managed_auth or auth_ref, not both")
+    cfg = body.get("config") if isinstance(body.get("config"), dict) else {}
+    meta = body.get("metadata") if isinstance(body.get("metadata"), dict) else {}
+    reg = load_connectors_registry()
+    rec = add_connector(
+        reg,
+        name=name,
+        provider=provider,
+        enabled=bool(body.get("enabled", True)),
+        auth_ref=AUTH_REF_MANAGED if managed_auth else auth_ref_raw,
+        config=cfg,
+        metadata=meta,
+    )
+    save_connectors_registry(reg)
+    if managed_auth:
+        ensure_managed_auth_file(str(rec.get("id") or ""))
+    return dict(rec)
+
+
+def _api_update_connector(ref: str, body: dict[str, Any]) -> dict[str, Any]:
+    reg = load_connectors_registry()
+    row_before = find_connector(reg, ref)
+    if not row_before:
+        raise LookupError(f"Unknown connector: {ref}")
+    auth_snapshot = {"id": str(row_before.get("id") or ""), "auth_ref": row_before.get("auth_ref")}
+    cfg: dict[str, Any] | None = body.get("config") if isinstance(body.get("config"), dict) else None
+    meta: dict[str, Any] | None = body.get("metadata") if isinstance(body.get("metadata"), dict) else None
+    patch: dict[str, Any] = {}
+    if body.get("name"):
+        patch["name"] = str(body.get("name")).strip()
+    if body.get("provider"):
+        patch["provider"] = str(body.get("provider")).strip().lower()
+    if "enabled" in body:
+        patch["enabled"] = bool(body.get("enabled"))
+    if cfg is not None:
+        patch["config"] = cfg
+    if meta is not None:
+        patch["metadata"] = meta
+    if bool(body.get("clear_auth_ref")):
+        patch["clear_auth_ref"] = True
+    elif bool(body.get("managed_auth")):
+        patch["auth_ref"] = AUTH_REF_MANAGED
+    elif "auth_ref" in body:
+        patch["auth_ref"] = str(body.get("auth_ref") or "").strip() or None
+    updated = update_connector(reg, ref, **patch)
+    if not updated:
+        raise LookupError(f"Unknown connector: {ref}")
+    if patch.get("clear_auth_ref") or ("auth_ref" in patch and patch.get("auth_ref") is None):
+        release_managed_auth_if_unused(auth_snapshot)
+    save_connectors_registry(reg)
+    if uses_managed_auth(dict(updated)):
+        ensure_managed_auth_file(str(updated.get("id") or ""))
+    return dict(updated)
+
+
+def _api_remove_connector(ref: str) -> dict[str, Any]:
+    reg = load_connectors_registry()
+    row = find_connector(reg, ref)
+    if not row:
+        raise LookupError(f"Unknown connector: {ref}")
+    cid = str(row.get("id") or "").strip()
+    was_managed = uses_managed_auth(dict(row))
+    if not remove_connector(reg, ref):
+        raise LookupError(f"Failed to remove connector: {ref}")
+    save_connectors_registry(reg)
+    if was_managed and cid:
+        delete_managed_auth_file(cid)
+    return {"removed": ref, "id": cid}
+
+
 def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -> dict:
     daemon = daemon_status()
     ui = ui_status()
@@ -3383,6 +3542,11 @@ def _status_payload(*, activity_limit: int = 10, include_hidden: bool = False) -
             "pending_approvals": len(pending_approvals),
         },
     }
+    connector_payload = _connectors_list_payload(registry=registry)
+    payload["connectors"] = connector_payload["connectors"]
+    payload["connectors_summary"] = connector_payload["summary"]
+    payload["summary"]["connectors"] = connector_payload["summary"]["total"]
+    payload["summary"]["connectors_auth_ready"] = connector_payload["summary"]["auth_ready"]
     alerts = _gateway_alerts(payload)
     payload["alerts"] = alerts
     payload["summary"]["alert_count"] = len(alerts)
@@ -5512,6 +5676,72 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
       </div>
     </section>
 
+    <section class="panel">
+      <div class="panel-header">
+        <span>Outbound Connectors</span>
+        <span id="connectors-summary" class="caption">loading…</span>
+      </div>
+      <div class="panel-body">
+        <p class="caption">
+          Composio toolbelt rows live in the Gateway registry. Secrets belong in managed
+          <code>connectors/auth/*.env</code> only. See <code>docs/composio-integration.md</code>.
+        </p>
+        <div class="control-grid" style="grid-template-columns: 1.2fr 1fr;">
+          <div>
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Provider</th>
+                  <th>Enabled</th>
+                  <th>Auth</th>
+                  <th>Agents</th>
+                </tr>
+              </thead>
+              <tbody id="connector-rows">
+                <tr><td colspan="5"><div class="empty">Waiting for connectors…</div></td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="detail-card">
+            <h3 style="margin-top:0;">Add connector</h3>
+            <form id="add-connector-form">
+              <div class="control-group">
+                <label for="connector-name">Name</label>
+                <input id="connector-name" name="name" placeholder="my_composio" required />
+              </div>
+              <div class="control-group">
+                <label for="connector-provider">Provider</label>
+                <select id="connector-provider" name="provider"><option value="composio">composio</option></select>
+              </div>
+              <div class="control-group">
+                <label for="connector-user-id">user_id</label>
+                <input id="connector-user-id" name="user_id" placeholder="Composio entity id" />
+              </div>
+              <div class="control-group">
+                <label for="connector-allowed-tools">allowed_tools</label>
+                <input id="connector-allowed-tools" name="allowed_tools" placeholder="GITHUB_*,SLACK_*" />
+              </div>
+              <label style="display:flex; gap:8px; align-items:center; margin:8px 0;">
+                <input id="connector-managed-auth" name="managed_auth" type="checkbox" checked />
+                <span>Gateway-managed auth</span>
+              </label>
+              <div class="action-row">
+                <button type="submit">Add Connector</button>
+              </div>
+              <div id="add-connector-flash" class="flash"></div>
+            </form>
+            <p class="caption" style="margin-top:12px;">
+              Then: <code>ax gateway connectors auth write &lt;name&gt; --from-file ./composio.env</code>
+            </p>
+          </div>
+        </div>
+        <div id="connector-detail" class="detail-card" style="margin-top:16px;">
+          <div class="empty">Select a connector for detail, enable/disable, and tool search.</div>
+        </div>
+      </div>
+    </section>
+
     <section class="control-grid">
       <section class="panel">
         <div class="panel-header">
@@ -5558,6 +5788,13 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
                   <input id="agent-ollama-model" name="ollama_model" list="ollama-model-options" placeholder="gemma4:latest" />
                   <datalist id="ollama-model-options"></datalist>
                   <div id="ollama-model-caption" class="caption"></div>
+                </div>
+                <div class="control-group" id="connector-ref-group" style="display:none;">
+                  <label for="agent-connector-ref">Connector ref</label>
+                  <select id="agent-connector-ref" name="connector_ref">
+                    <option value="">—</option>
+                  </select>
+                  <div class="caption">Required for langgraph_composio.</div>
                 </div>
               </div>
             </details>
@@ -5658,7 +5895,7 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
 
     <section class="panel">
       <div class="panel-body footer-note">
-        <span>Local status API: <code>/api/status</code> and <code>/api/agents/&lt;name&gt;</code></span>
+        <span>Local API: <code>/api/status</code> · <code>/api/connectors</code> · <code>/api/agents/&lt;name&gt;</code></span>
         <span>Setup skill: <code>skills/gateway-agent-setup/SKILL.md</code> · Terminal parity: <code>uv run ax gateway watch</code></span>
       </div>
     </section>
@@ -5667,6 +5904,7 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
   <script>
     const refreshMs = __REFRESH_MS__;
     let selectedAgent = null;
+    let selectedConnector = null;
     let agentTemplates = [];
     let autoRefreshPaused = false;
     let setupMode = "create";
@@ -5733,6 +5971,8 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
       execInput.value = agent.exec_command || "";
       workdirInput.value = agent.workdir || "";
       ollamaModelInput.value = agent.ollama_model || "";
+      const connectorRefInput = document.getElementById("agent-connector-ref");
+      if (connectorRefInput) connectorRefInput.value = agent.connector_ref || "";
       applySetupMode();
       setFlash("add-agent-flash", `Editing @${setupTarget}`, "success");
       document.getElementById("add-agent-form").scrollIntoView({ behavior: "smooth", block: "start" });
@@ -5803,6 +6043,7 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
       const agentNameInput = document.getElementById("agent-name");
       const execGroup = document.getElementById("exec-command-group");
       const workdirGroup = document.getElementById("workdir-group");
+      const connectorRefGroup = document.getElementById("connector-ref-group");
       const ollamaModelGroup = document.getElementById("ollama-model-group");
       const execInput = document.getElementById("agent-exec");
       const workdirInput = document.getElementById("agent-workdir");
@@ -5925,6 +6166,8 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
         ["low confidence", summary.low_confidence_agents ?? 0, "yellow"],
         ["blocked", summary.blocked_agents ?? 0, "red"],
         ["queue depth", queueDepth, "blue"],
+        ["connectors", summary.connectors ?? 0, "cyan"],
+        ["auth ready", summary.connectors_auth_ready ?? 0, "green"],
       ];
       document.getElementById("metrics").innerHTML = metrics.map(([label, value, tone]) => `
         <article class="metric ${tone}">
@@ -5932,6 +6175,104 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
           <span>${escapeHtml(label)}</span>
         </article>
       `).join("");
+    }
+
+
+    function renderConnectors(payload) {
+      const rows = payload.connectors || [];
+      const summary = payload.connectors_summary || {};
+      document.getElementById("connectors-summary").textContent = rows.length
+        ? `${summary.total ?? rows.length} connector${rows.length === 1 ? "" : "s"} · ${summary.auth_ready ?? 0} auth ready`
+        : "no connectors registered";
+      const tbody = document.getElementById("connector-rows");
+      if (!rows.length) {
+        tbody.innerHTML = `<tr><td colspan="5"><div class="empty">No connectors yet. Add one or use the CLI.</div></td></tr>`;
+        renderConnectorDetail(null);
+        return;
+      }
+      tbody.innerHTML = rows.map((row) => {
+        const active = selectedConnector && String(selectedConnector).toLowerCase() === String(row.name || "").toLowerCase();
+        const authLabel = row.auth_ready ? "ready" : (row.auth_error || "missing");
+        const linked = (row.linked_agents || []).length ? row.linked_agents.join(", ") : "—";
+        return `
+          <tr>
+            <td colspan="5">
+              <button type="button" class="agent-button ${active ? "is-active" : ""}" data-connector-name="${escapeHtml(row.name || "")}">
+                <table><tbody><tr>
+                  <td style="width:22%"><strong>${escapeHtml(row.name || "-")}</strong></td>
+                  <td style="width:14%">${escapeHtml(row.provider || "-")}</td>
+                  <td style="width:12%"><span class="status-pill ${row.enabled ? "green" : "yellow"}">${row.enabled ? "on" : "off"}</span></td>
+                  <td style="width:18%"><span class="status-pill ${row.auth_ready ? "green" : "red"}">${escapeHtml(authLabel)}</span></td>
+                  <td style="width:34%">${escapeHtml(linked)}</td>
+                </tr></tbody></table>
+              </button>
+            </td>
+          </tr>`;
+      }).join("");
+      populateConnectorRefSelect(rows);
+    }
+
+    function populateConnectorRefSelect(rows) {
+      const select = document.getElementById("agent-connector-ref");
+      if (!select) return;
+      const current = select.value;
+      select.innerHTML = `<option value="">—</option>` + rows.map((row) =>
+        `<option value="${escapeHtml(row.name || "")}">${escapeHtml(row.name || "")}</option>`
+      ).join("");
+      if (current) select.value = current;
+    }
+
+    async function loadConnectorDetail(name) {
+      if (!name) {
+        renderConnectorDetail(null);
+        return;
+      }
+      try {
+        const payload = await apiRequest(`/api/connectors/${encodeURIComponent(name)}`);
+        renderConnectorDetail(payload);
+      } catch (error) {
+        renderConnectorDetail({ error: error.message || String(error) });
+      }
+    }
+
+    function renderConnectorDetail(payload) {
+      const panel = document.getElementById("connector-detail");
+      if (!payload || !payload.connector) {
+        const err = payload?.error;
+        panel.innerHTML = err
+          ? `<div class="flash error">${escapeHtml(err)}</div>`
+          : `<div class="empty">Select a connector for detail, enable/disable, and tool search.</div>`;
+        return;
+      }
+      const row = payload.connector;
+      const summary = payload.summary || {};
+      const auth = payload.auth || {};
+      const configJson = JSON.stringify(row.config || {}, null, 2);
+      panel.innerHTML = `
+        <div class="detail-card">
+          <div class="agent-name">${escapeHtml(row.name || "-")}</div>
+          <div class="caption">${escapeHtml(row.provider || "-")} · ${summary.enabled ? "enabled" : "disabled"}</div>
+          <div id="connector-detail-flash" class="flash"></div>
+          <dl class="detail-list">
+            <div><dt>Auth</dt><dd>${escapeHtml(auth.kind || "-")} · keys: ${escapeHtml((auth.env_keys || []).join(", ") || "none")}</dd></div>
+            <div><dt>Path</dt><dd>${escapeHtml(auth.path_redacted || "-")}</dd></div>
+            <div><dt>user_id</dt><dd>${escapeHtml(summary.user_id || "-")}</dd></div>
+            <div><dt>Linked agents</dt><dd>${escapeHtml((summary.linked_agents || []).join(", ") || "—")}</dd></div>
+          </dl>
+          <pre style="white-space:pre-wrap; font-size:12px;">${escapeHtml(configJson)}</pre>
+          <div class="action-row">
+            <button type="button" class="ghost" data-connector-action="toggle">${summary.enabled ? "Disable" : "Enable"}</button>
+            <button type="button" class="danger" data-connector-action="remove">Remove</button>
+          </div>
+          <form id="connector-search-form" class="detail-card" style="margin-top:12px;">
+            <div class="control-group">
+              <label for="connector-search-use-case">Tool search use case</label>
+              <input id="connector-search-use-case" name="use_case" placeholder="list GitHub stargazers for owner/repo" />
+            </div>
+            <div class="action-row"><button type="submit">Search tools</button></div>
+          </form>
+          <pre id="connector-search-results" style="white-space:pre-wrap; font-size:12px; margin-top:8px;"></pre>
+        </div>`;
     }
 
     function renderAlerts(payload) {
@@ -6094,6 +6435,7 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
             <div><dt>Doctor Result</dt><dd>${escapeHtml(agent.last_doctor_result?.status || "-")}</dd></div>
             <div><dt>Effective</dt><dd>${escapeHtml(agent.effective_state || "-")}</dd></div>
             <div><dt>Workdir</dt><dd>${escapeHtml(agent.workdir || "-")}</dd></div>
+            <div><dt>Connector</dt><dd>${escapeHtml(agent.connector_ref || "-")}</dd></div>
             <div><dt>Exec</dt><dd>${escapeHtml(agent.exec_command || "-")}</dd></div>
           </dl>
           <div>
@@ -6123,10 +6465,17 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
       renderOverview(payload);
       renderMetrics(payload);
       renderAlerts(payload);
+      renderConnectors(payload);
       renderAgents(payload);
       renderActivity(payload);
       if (!selectedAgent && payload.agents?.length) {
         selectedAgent = payload.agents[0].name;
+      }
+      if (!selectedConnector && payload.connectors?.length) {
+        selectedConnector = payload.connectors[0].name;
+      }
+      if (selectedConnector) {
+        await loadConnectorDetail(selectedConnector);
       }
       if (selectedAgent) {
         await loadAgentDetail(selectedAgent);
@@ -6212,6 +6561,87 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
       }
     });
 
+
+    document.getElementById("connector-rows").addEventListener("click", async (event) => {
+      const button = event.target.closest("[data-connector-name]");
+      if (!button) return;
+      selectedConnector = button.getAttribute("data-connector-name");
+      await loadConnectorDetail(selectedConnector);
+      await tick(true);
+    });
+
+    document.getElementById("connector-detail").addEventListener("click", async (event) => {
+      const button = event.target.closest("[data-connector-action]");
+      if (!button || !selectedConnector) return;
+      const action = button.getAttribute("data-connector-action");
+      try {
+        if (action === "remove") {
+          await apiRequest(`/api/connectors/${encodeURIComponent(selectedConnector)}`, { method: "DELETE" });
+          selectedConnector = null;
+        } else if (action === "toggle") {
+          const detail = await apiRequest(`/api/connectors/${encodeURIComponent(selectedConnector)}`);
+          const enabled = Boolean(detail.summary?.enabled);
+          await apiRequest(`/api/connectors/${encodeURIComponent(selectedConnector)}`, {
+            method: "PUT",
+            body: JSON.stringify({ enabled: !enabled }),
+          });
+        }
+        await tick(true);
+      } catch (error) {
+        setFlash("connector-detail-flash", error.message || String(error), "error");
+      }
+    });
+
+    document.getElementById("connector-detail").addEventListener("submit", async (event) => {
+      const form = event.target.closest("#connector-search-form");
+      if (!form || !selectedConnector) return;
+      event.preventDefault();
+      const data = new FormData(form);
+      const useCase = String(data.get("use_case") || "").trim();
+      if (!useCase) return;
+      try {
+        const result = await apiRequest(`/api/connectors/${encodeURIComponent(selectedConnector)}/tools/search`, {
+          method: "POST",
+          body: JSON.stringify({ use_case: useCase, mode: "auto" }),
+        });
+        const lines = (result.tools || []).map((tool) => `${tool.slug}: ${tool.name || ""}`);
+        document.getElementById("connector-search-results").textContent = lines.length
+          ? lines.join("\n")
+          : JSON.stringify(result, null, 2);
+      } catch (error) {
+        document.getElementById("connector-search-results").textContent = error.message || String(error);
+      }
+    });
+
+    document.getElementById("add-connector-form").addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const data = new FormData(event.currentTarget);
+      const allowedRaw = String(data.get("allowed_tools") || "").trim();
+      const allowed = allowedRaw ? allowedRaw.split(",").map((part) => part.trim()).filter(Boolean) : [];
+      const config = {};
+      const userId = String(data.get("user_id") || "").trim();
+      if (userId) config.user_id = userId;
+      if (allowed.length) config.allowed_tools = allowed;
+      try {
+        const created = await apiRequest("/api/connectors", {
+          method: "POST",
+          body: JSON.stringify({
+            name: String(data.get("name") || "").trim(),
+            provider: String(data.get("provider") || "composio").trim(),
+            managed_auth: data.get("managed_auth") === "on",
+            config,
+          }),
+        });
+        selectedConnector = created.connector?.name || String(data.get("name") || "").trim();
+        setFlash("add-connector-flash", `Added connector ${selectedConnector}`, "success");
+        event.currentTarget.reset();
+        document.getElementById("connector-managed-auth").checked = true;
+        await tick(true);
+      } catch (error) {
+        setFlash("add-connector-flash", error.message || String(error), "error");
+      }
+    });
+
     document.getElementById("refresh-toggle").addEventListener("click", () => {
       autoRefreshPaused = !autoRefreshPaused;
       refreshButtonLabel();
@@ -6239,6 +6669,7 @@ def _render_gateway_ui_page(*, refresh_ms: int) -> str:
         exec_command: String(data.get("exec_command") || "").trim(),
         workdir: String(data.get("workdir") || "").trim(),
         ollama_model: String(data.get("ollama_model") || "").trim(),
+        connector_ref: String(data.get("connector_ref") || "").trim(),
         start: true,
       };
       try {
@@ -6492,6 +6923,24 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                 status = HTTPStatus.OK if has_data else HTTPStatus.SERVICE_UNAVAILABLE
                 _write_json_response(self, payload, status=status)
                 return
+            if parsed.path == "/api/connectors":
+                _write_json_response(self, _connectors_list_payload())
+                return
+            if parsed.path.startswith("/api/connectors/"):
+                suffix = unquote(parsed.path.removeprefix("/api/connectors/")).strip()
+                if not suffix:
+                    _write_json_response(self, {"error": "connector ref required"}, status=HTTPStatus.BAD_REQUEST)
+                    return
+                payload = _connector_detail_payload(suffix)
+                if payload is None:
+                    _write_json_response(
+                        self,
+                        {"error": f"Unknown connector: {suffix}"},
+                        status=HTTPStatus.NOT_FOUND,
+                    )
+                    return
+                _write_json_response(self, payload)
+                return
             if parsed.path.startswith("/api/agents/") and parsed.path.endswith("/inbox"):
                 name = unquote(parsed.path.removeprefix("/api/agents/").removesuffix("/inbox")).strip()
                 query = parse_qs(parsed.query)
@@ -6575,6 +7024,58 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                     status_code = HTTPStatus.OK if payload.get("ready") else HTTPStatus.UNPROCESSABLE_ENTITY
                     _write_json_response(self, payload, status=status_code)
                     return
+                if parsed.path == "/api/connectors":
+                    try:
+                        created = _api_add_connector(body)
+                    except ValueError as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                        return
+                    detail = _connector_detail_payload(str(created.get("name") or ""))
+                    _write_json_response(self, detail or {"connector": created}, status=HTTPStatus.CREATED)
+                    return
+                if parsed.path.startswith("/api/connectors/") and parsed.path.endswith("/tools/search"):
+                    ref = unquote(
+                        parsed.path.removeprefix("/api/connectors/").removesuffix("/tools/search")
+                    ).strip()
+                    use_case = str(body.get("use_case") or body.get("query") or "").strip()
+                    if not use_case:
+                        _write_json_response(
+                            self,
+                            {"error": "use_case is required"},
+                            status=HTTPStatus.BAD_REQUEST,
+                        )
+                        return
+                    try:
+                        mode = str(body.get("mode") or "auto").strip().lower()
+                        result = search_connector_tools(
+                            ref,
+                            use_case,
+                            mode=mode,  # type: ignore[arg-type]
+                            known_fields=str(body.get("known_fields") or "").strip() or None,
+                            session_id=str(body.get("session_id") or "").strip() or None,
+                            limit=body.get("limit"),
+                        )
+                    except (ConnectorProviderError, LookupError, ValueError) as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                        return
+                    _write_json_response(self, result.to_dict())
+                    return
+                if parsed.path.startswith("/api/connectors/") and parsed.path.endswith("/tools/list"):
+                    ref = unquote(
+                        parsed.path.removeprefix("/api/connectors/").removesuffix("/tools/list")
+                    ).strip()
+                    try:
+                        page = list_connector_tools(
+                            ref,
+                            query=str(body.get("query") or "").strip() or None,
+                            toolkit_slug=str(body.get("toolkit") or body.get("toolkit_slug") or "").strip() or None,
+                            limit=body.get("limit"),
+                        )
+                    except (ConnectorProviderError, LookupError, ValueError) as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                        return
+                    _write_json_response(self, page)
+                    return
                 if parsed.path == "/api/agents":
                     try:
                         payload = _register_managed_agent(
@@ -6589,6 +7090,7 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                             description=str(body.get("description") or "").strip() or None,
                             model=str(body.get("model") or "").strip() or None,
                             timeout_seconds=body.get("timeout_seconds", body.get("timeout")),
+                            connector_ref=str(body.get("connector_ref") or "").strip() or None,
                             start=bool(body.get("start", True)),
                         )
                     except UpstreamRateLimitedError as exc:
@@ -6888,8 +7390,24 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
             parsed = urlparse(self.path)
             try:
                 body = _read_json_request(self)
+                if parsed.path.startswith("/api/connectors/"):
+                    ref = unquote(parsed.path.removeprefix("/api/connectors/")).strip()
+                    try:
+                        updated = _api_update_connector(ref, body)
+                    except LookupError as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.NOT_FOUND)
+                        return
+                    except ValueError as exc:
+                        _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                        return
+                    detail = _connector_detail_payload(str(updated.get("name") or ref))
+                    _write_json_response(self, detail or {"connector": updated})
+                    return
                 if parsed.path.startswith("/api/agents/"):
                     name = unquote(parsed.path.removeprefix("/api/agents/")).strip()
+                    connector_ref_kw: dict[str, Any] = {}
+                    if "connector_ref" in body:
+                        connector_ref_kw["connector_ref"] = str(body.get("connector_ref") or "").strip()
                     payload = _update_managed_agent(
                         name=name,
                         template_id=str(body.get("template_id") or "").strip() or None,
@@ -6903,6 +7421,7 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
                         if "timeout_seconds" in body or "timeout" in body
                         else _UNSET,
                         desired_state=str(body.get("desired_state") or "").strip() or None,
+                        **connector_ref_kw,
                     )
                     _write_json_response(self, payload)
                     return
@@ -6919,6 +7438,14 @@ def _build_gateway_ui_handler(*, activity_limit: int, refresh_ms: int):
 
         def do_DELETE(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
+            if parsed.path.startswith("/api/connectors/"):
+                ref = unquote(parsed.path.removeprefix("/api/connectors/")).strip()
+                try:
+                    payload = _api_remove_connector(ref)
+                    _write_json_response(self, payload)
+                except LookupError as exc:
+                    _write_json_response(self, {"error": str(exc)}, status=HTTPStatus.NOT_FOUND)
+                return
             if parsed.path.startswith("/api/agents/"):
                 name = unquote(parsed.path.removeprefix("/api/agents/")).strip()
                 try:

--- a/ax_cli/connectors/__init__.py
+++ b/ax_cli/connectors/__init__.py
@@ -1,4 +1,19 @@
-"""Gateway outbound connector registry (tool providers, MCP backends, etc.)."""
+"""Gateway outbound connectors: registry, auth storage, and future provider adapters.
+
+Package layout (phases 1–3):
+
+- :mod:`constants` — schema version, ``AUTH_REF_MANAGED``, validation limits
+- :mod:`paths` — ``connectors.json`` and managed auth directory paths
+- :mod:`storage` — atomic JSON read/write under the Gateway dir
+- :mod:`validation` — row validate/normalize and registry coercion
+- :mod:`registry` — load/save and CRUD
+- :mod:`auth` — managed ``.env`` files and external auth paths
+- :mod:`envfile` — dotenv parsing for auth files
+- :mod:`types` — ``TypedDict`` shapes for registry rows
+
+Import from this package (``from ax_cli.connectors import …``) rather than
+submodules unless you are extending the connector layer.
+"""
 
 from .auth import (
     AUTH_REF_MANAGED,
@@ -14,10 +29,10 @@ from .auth import (
     uses_managed_auth,
     write_managed_auth_from_file,
 )
+from .constants import CONNECTORS_SCHEMA_VERSION
+from .paths import connectors_registry_path
 from .registry import (
-    CONNECTORS_SCHEMA_VERSION,
     add_connector,
-    connectors_registry_path,
     default_connectors_registry,
     find_connector,
     list_connectors,
@@ -28,10 +43,13 @@ from .registry import (
     update_connector,
     validate_connector_record,
 )
+from .types import ConnectorRecord, ConnectorRegistry
 
 __all__ = [
     "AUTH_REF_MANAGED",
     "CONNECTORS_SCHEMA_VERSION",
+    "ConnectorRecord",
+    "ConnectorRegistry",
     "add_connector",
     "connectors_auth_env_base",
     "connectors_registry_path",

--- a/ax_cli/connectors/__init__.py
+++ b/ax_cli/connectors/__init__.py
@@ -1,6 +1,6 @@
-"""Gateway outbound connectors: registry, auth storage, and future provider adapters.
+"""Gateway outbound connectors: registry, auth storage, and provider adapters.
 
-Package layout (phases 1–3):
+Package layout:
 
 - :mod:`constants` — schema version, ``AUTH_REF_MANAGED``, validation limits
 - :mod:`paths` — ``connectors.json`` and managed auth directory paths
@@ -10,6 +10,7 @@ Package layout (phases 1–3):
 - :mod:`auth` — managed ``.env`` files and external auth paths
 - :mod:`envfile` — dotenv parsing for auth files
 - :mod:`types` — ``TypedDict`` shapes for registry rows
+- :mod:`providers` — provider adapters (Composio tool execution)
 
 Import from this package (``from ax_cli.connectors import …``) rather than
 submodules unless you are extending the connector layer.
@@ -31,6 +32,13 @@ from .auth import (
 )
 from .constants import CONNECTORS_SCHEMA_VERSION
 from .paths import connectors_registry_path
+from .providers import (
+    SUPPORTED_PROVIDERS,
+    ConnectorProviderError,
+    ToolCallResult,
+    adapter_for_connector,
+    execute_connector_tool,
+)
 from .registry import (
     add_connector,
     default_connectors_registry,
@@ -48,8 +56,12 @@ from .types import ConnectorRecord, ConnectorRegistry
 __all__ = [
     "AUTH_REF_MANAGED",
     "CONNECTORS_SCHEMA_VERSION",
+    "ConnectorProviderError",
     "ConnectorRecord",
     "ConnectorRegistry",
+    "SUPPORTED_PROVIDERS",
+    "ToolCallResult",
+    "adapter_for_connector",
     "add_connector",
     "connectors_auth_env_base",
     "connectors_registry_path",
@@ -57,6 +69,7 @@ __all__ = [
     "delete_managed_auth_file",
     "ensure_connectors_auth_env_dir",
     "ensure_managed_auth_file",
+    "execute_connector_tool",
     "find_connector",
     "list_connectors",
     "load_connector_auth_env",

--- a/ax_cli/connectors/__init__.py
+++ b/ax_cli/connectors/__init__.py
@@ -1,5 +1,19 @@
 """Gateway outbound connector registry (tool providers, MCP backends, etc.)."""
 
+from .auth import (
+    AUTH_REF_MANAGED,
+    connectors_auth_env_base,
+    delete_managed_auth_file,
+    ensure_connectors_auth_env_dir,
+    ensure_managed_auth_file,
+    load_connector_auth_env,
+    parse_dotenv,
+    public_auth_status,
+    release_managed_auth_if_unused,
+    resolve_auth_env_path,
+    uses_managed_auth,
+    write_managed_auth_from_file,
+)
 from .registry import (
     CONNECTORS_SCHEMA_VERSION,
     add_connector,
@@ -16,16 +30,28 @@ from .registry import (
 )
 
 __all__ = [
+    "AUTH_REF_MANAGED",
     "CONNECTORS_SCHEMA_VERSION",
     "add_connector",
+    "connectors_auth_env_base",
     "connectors_registry_path",
     "default_connectors_registry",
+    "delete_managed_auth_file",
+    "ensure_connectors_auth_env_dir",
+    "ensure_managed_auth_file",
     "find_connector",
     "list_connectors",
+    "load_connector_auth_env",
     "load_connectors_registry",
     "normalize_connector_record",
+    "parse_dotenv",
+    "public_auth_status",
+    "release_managed_auth_if_unused",
     "remove_connector",
+    "resolve_auth_env_path",
     "save_connectors_registry",
     "update_connector",
+    "uses_managed_auth",
     "validate_connector_record",
+    "write_managed_auth_from_file",
 ]

--- a/ax_cli/connectors/__init__.py
+++ b/ax_cli/connectors/__init__.py
@@ -1,0 +1,31 @@
+"""Gateway outbound connector registry (tool providers, MCP backends, etc.)."""
+
+from .registry import (
+    CONNECTORS_SCHEMA_VERSION,
+    add_connector,
+    connectors_registry_path,
+    default_connectors_registry,
+    find_connector,
+    list_connectors,
+    load_connectors_registry,
+    normalize_connector_record,
+    remove_connector,
+    save_connectors_registry,
+    update_connector,
+    validate_connector_record,
+)
+
+__all__ = [
+    "CONNECTORS_SCHEMA_VERSION",
+    "add_connector",
+    "connectors_registry_path",
+    "default_connectors_registry",
+    "find_connector",
+    "list_connectors",
+    "load_connectors_registry",
+    "normalize_connector_record",
+    "remove_connector",
+    "save_connectors_registry",
+    "update_connector",
+    "validate_connector_record",
+]

--- a/ax_cli/connectors/__init__.py
+++ b/ax_cli/connectors/__init__.py
@@ -11,6 +11,7 @@ Package layout:
 - :mod:`envfile` — dotenv parsing for auth files
 - :mod:`types` — ``TypedDict`` shapes for registry rows
 - :mod:`activity` — Gateway activity.jsonl attribution for connector tools
+- :mod:`filtering` — Gateway allow/deny policy on tool slugs
 - :mod:`providers` — provider adapters (Composio tool execution)
 
 Import from this package (``from ax_cli.connectors import …``) rather than
@@ -37,13 +38,22 @@ from .auth import (
     write_managed_auth_from_file,
 )
 from .constants import CONNECTORS_SCHEMA_VERSION
+from .filtering import (
+    ToolFilterPolicy,
+    assert_tool_allowed,
+    is_tool_allowed,
+    resolve_tool_filter_policy,
+)
 from .paths import connectors_registry_path
 from .providers import (
     SUPPORTED_PROVIDERS,
     ConnectorProviderError,
     ToolCallResult,
+    ToolSearchResult,
     adapter_for_connector,
     execute_connector_tool,
+    list_connector_tools,
+    search_connector_tools,
 )
 from .registry import (
     add_connector,
@@ -67,7 +77,14 @@ __all__ = [
     "ConnectorRegistry",
     "SUPPORTED_PROVIDERS",
     "ToolCallResult",
+    "ToolFilterPolicy",
+    "ToolSearchResult",
     "adapter_for_connector",
+    "assert_tool_allowed",
+    "is_tool_allowed",
+    "list_connector_tools",
+    "resolve_tool_filter_policy",
+    "search_connector_tools",
     "add_connector",
     "connector_activity_fields",
     "connectors_auth_env_base",

--- a/ax_cli/connectors/__init__.py
+++ b/ax_cli/connectors/__init__.py
@@ -10,12 +10,18 @@ Package layout:
 - :mod:`auth` — managed ``.env`` files and external auth paths
 - :mod:`envfile` — dotenv parsing for auth files
 - :mod:`types` — ``TypedDict`` shapes for registry rows
+- :mod:`activity` — Gateway activity.jsonl attribution for connector tools
 - :mod:`providers` — provider adapters (Composio tool execution)
 
 Import from this package (``from ax_cli.connectors import …``) rather than
 submodules unless you are extending the connector layer.
 """
 
+from .activity import (
+    connector_activity_fields,
+    record_connector_tool_finished,
+    record_connector_tool_started,
+)
 from .auth import (
     AUTH_REF_MANAGED,
     connectors_auth_env_base,
@@ -63,6 +69,7 @@ __all__ = [
     "ToolCallResult",
     "adapter_for_connector",
     "add_connector",
+    "connector_activity_fields",
     "connectors_auth_env_base",
     "connectors_registry_path",
     "default_connectors_registry",
@@ -71,6 +78,8 @@ __all__ = [
     "ensure_managed_auth_file",
     "execute_connector_tool",
     "find_connector",
+    "record_connector_tool_finished",
+    "record_connector_tool_started",
     "list_connectors",
     "load_connector_auth_env",
     "load_connectors_registry",

--- a/ax_cli/connectors/activity.py
+++ b/ax_cli/connectors/activity.py
@@ -1,0 +1,114 @@
+"""Gateway activity attribution for outbound connector tool calls."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from ax_cli.gateway import find_agent_entry, load_gateway_registry, record_gateway_activity
+
+from .constants import CONNECTOR_ACTIVITY_EVENTS
+
+_ACTIVITY_MESSAGE_LIMIT = 240
+_TOOL_NAME_LIMIT = 120
+
+
+def connector_activity_fields(connector: dict[str, Any]) -> dict[str, Any]:
+    """Build redacted activity payload fields for a connector row."""
+    name = str(connector.get("name") or "").strip()
+    cid = str(connector.get("id") or "").strip()
+    provider = str(connector.get("provider") or "").strip()
+    fields: dict[str, Any] = {}
+    if name:
+        fields["connector_name"] = name
+    if cid:
+        fields["connector_id"] = cid
+    if provider:
+        fields["provider"] = provider
+    cfg = connector.get("config")
+    if isinstance(cfg, dict):
+        agent_name = str(cfg.get("agent_name") or cfg.get("linked_agent") or "").strip()
+        if agent_name:
+            fields["linked_agent_name"] = agent_name
+    return fields
+
+
+def _linked_agent_entry(connector: dict[str, Any]) -> dict[str, Any] | None:
+    cfg = connector.get("config")
+    if not isinstance(cfg, dict):
+        return None
+    agent_name = str(cfg.get("agent_name") or cfg.get("linked_agent") or "").strip()
+    if not agent_name:
+        return None
+    registry = load_gateway_registry()
+    return find_agent_entry(registry, agent_name)
+
+
+def _tool_display_name(connector: dict[str, Any], tool_slug: str) -> str:
+    provider = str(connector.get("provider") or "connector").strip()
+    slug = str(tool_slug or "").strip() or "tool"
+    label = f"{provider}/{slug}"
+    return label[:_TOOL_NAME_LIMIT]
+
+
+def _activity_message(text: str) -> str:
+    return str(text or "").strip()[:_ACTIVITY_MESSAGE_LIMIT]
+
+
+def record_connector_tool_started(
+    connector: dict[str, Any],
+    tool_slug: str,
+    *,
+    tool_call_id: str | None = None,
+) -> dict[str, Any]:
+    """Record that a connector tool invocation has started."""
+    call_id = str(tool_call_id or uuid.uuid4())
+    name = str(connector.get("name") or "connector").strip()
+    message = _activity_message(f"Connector {name}: calling {tool_slug}")
+    return record_gateway_activity(
+        CONNECTOR_ACTIVITY_EVENTS["started"],
+        entry=_linked_agent_entry(connector),
+        tool_name=_tool_display_name(connector, tool_slug),
+        tool_call_id=call_id,
+        activity_message=message,
+        **connector_activity_fields(connector),
+    )
+
+
+def record_connector_tool_finished(
+    connector: dict[str, Any],
+    tool_slug: str,
+    *,
+    tool_call_id: str | None,
+    successful: bool,
+    error: str | None = None,
+    log_id: str | None = None,
+) -> dict[str, Any]:
+    """Record terminal outcome for a connector tool invocation."""
+    name = str(connector.get("name") or "connector").strip()
+    if successful:
+        event = CONNECTOR_ACTIVITY_EVENTS["completed"]
+        message = _activity_message(f"Connector {name}: {tool_slug} succeeded")
+    else:
+        event = CONNECTOR_ACTIVITY_EVENTS["failed"]
+        detail = _activity_message(error or "tool execution failed")
+        message = _activity_message(f"Connector {name}: {tool_slug} failed — {detail}")
+
+    fields: dict[str, Any] = {
+        "tool_name": _tool_display_name(connector, tool_slug),
+        "activity_message": message,
+        "successful": successful,
+        **connector_activity_fields(connector),
+    }
+    if tool_call_id:
+        fields["tool_call_id"] = tool_call_id
+    if log_id:
+        fields["log_id"] = log_id
+    if not successful and error:
+        fields["error"] = _activity_message(error)
+
+    return record_gateway_activity(
+        event,
+        entry=_linked_agent_entry(connector),
+        **fields,
+    )

--- a/ax_cli/connectors/auth.py
+++ b/ax_cli/connectors/auth.py
@@ -1,0 +1,214 @@
+"""Gateway-managed connector auth: env files on disk, never inline in the registry.
+
+``auth_ref`` may be:
+
+- ``gateway:managed`` — secrets live in ``<gateway_dir>/connectors/auth/<connector_id>.env``
+  (mode ``0o600``).
+- Any other non-empty string — path to an operator-owned env file (expanded, resolved).
+
+Callers must never log return values from :func:`load_connector_auth_env`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from ax_cli.gateway import _chmod_quiet, _redacted_path, gateway_dir
+
+# Stored in ``connectors.json`` ``auth_ref`` to mean managed on-disk secrets.
+AUTH_REF_MANAGED = "gateway:managed"
+
+_SAFE_CONNECTOR_ID = re.compile(r"^[a-zA-Z0-9_.-]{1,128}$")
+
+
+def connectors_auth_env_base() -> Path:
+    """Directory for per-connector ``*.env`` files (path only; may not exist yet)."""
+    return gateway_dir() / "connectors" / "auth"
+
+
+def ensure_connectors_auth_env_dir() -> Path:
+    """Ensure the auth directory exists with restrictive permissions."""
+    path = connectors_auth_env_base()
+    path.mkdir(parents=True, exist_ok=True)
+    _chmod_quiet(path, 0o700)
+    return path
+
+
+def _managed_env_path(connector_id: str) -> Path:
+    cid = str(connector_id or "").strip()
+    if not _SAFE_CONNECTOR_ID.match(cid):
+        raise ValueError("connector id is not usable as a managed auth filename")
+    return connectors_auth_env_base() / f"{cid}.env"
+
+
+def uses_managed_auth(connector: dict[str, Any] | None) -> bool:
+    if not isinstance(connector, dict):
+        return False
+    return str(connector.get("auth_ref") or "").strip() == AUTH_REF_MANAGED
+
+
+def resolve_auth_env_path(connector: dict[str, Any]) -> Path | None:
+    """Resolve the env file path for this connector, or None if unconfigured."""
+    if not isinstance(connector, dict):
+        return None
+    ref = str(connector.get("auth_ref") or "").strip()
+    if not ref:
+        return None
+    if ref == AUTH_REF_MANAGED:
+        cid = str(connector.get("id") or "").strip()
+        if not cid:
+            return None
+        return _managed_env_path(cid)
+    path = Path(ref).expanduser()
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def ensure_managed_auth_file(connector_id: str) -> Path:
+    """Create an empty managed ``.env`` if missing (``0o600``)."""
+    ensure_connectors_auth_env_dir()
+    path = _managed_env_path(connector_id)
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _chmod_quiet(path.parent, 0o700)
+        path.write_text("# Connector secrets (KEY=VALUE). Do not commit.\n", encoding="utf-8")
+    _chmod_quiet(path, 0o600)
+    return path
+
+
+def delete_managed_auth_file(connector_id: str) -> bool:
+    """Remove the managed env file if it exists. Returns whether a file was removed."""
+    try:
+        path = _managed_env_path(connector_id)
+    except ValueError:
+        return False
+    if not path.is_file():
+        return False
+    try:
+        path.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def write_managed_auth_from_file(connector_id: str, source: Path) -> Path:
+    """Atomically replace managed env content with a copy of ``source`` (bytes)."""
+    src = source.expanduser()
+    if not src.is_file():
+        raise ValueError(f"source is not a file: {src}")
+    dest = _managed_env_path(connector_id)
+    ensure_connectors_auth_env_dir()
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "wb",
+            dir=dest.parent,
+            prefix=f".{dest.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            with src.open("rb") as handle:
+                shutil.copyfileobj(handle, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        assert tmp_path is not None
+        tmp_path.chmod(0o600)
+        tmp_path.replace(dest)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+    _chmod_quiet(dest, 0o600)
+    return dest
+
+
+def parse_dotenv(content: str) -> dict[str, str]:
+    """Parse minimal KEY=VALUE lines (no command substitution)."""
+    result: dict[str, str] = {}
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.lower().startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        k = key.strip()
+        if not k or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", k):
+            continue
+        v = value.strip()
+        if len(v) >= 2 and ((v[0] == v[-1] == '"') or (v[0] == v[-1] == "'")):
+            v = v[1:-1]
+        result[k] = v
+    return result
+
+
+def load_connector_auth_env(connector: dict[str, Any]) -> dict[str, str]:
+    """Load env entries from the connector's auth file. Values are sensitive — do not log."""
+    path = resolve_auth_env_path(connector)
+    if path is None:
+        return {}
+    try:
+        if not path.is_file():
+            return {}
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    return parse_dotenv(text)
+
+
+def public_auth_status(connector: dict[str, Any]) -> dict[str, Any]:
+    """Operator-safe summary: no secret values, only paths (redacted) and key names."""
+    ref = str(connector.get("auth_ref") or "").strip() if isinstance(connector, dict) else ""
+    if not ref:
+        return {"kind": "none", "path_redacted": None, "env_keys": [], "file_exists": False, "error": None}
+    path = resolve_auth_env_path(connector) if isinstance(connector, dict) else None
+    kind = "managed" if ref == AUTH_REF_MANAGED else "file"
+    if path is None:
+        return {
+            "kind": kind,
+            "path_redacted": None,
+            "env_keys": [],
+            "file_exists": False,
+            "error": "auth_ref is set but path could not be resolved",
+        }
+    redacted = _redacted_path(str(path))
+    exists = False
+    keys: list[str] = []
+    err: str | None = None
+    try:
+        exists = path.is_file()
+        if exists:
+            keys = sorted(parse_dotenv(path.read_text(encoding="utf-8")).keys())
+    except OSError as exc:
+        err = str(exc)
+    return {
+        "kind": kind,
+        "path_redacted": redacted,
+        "env_keys": keys,
+        "file_exists": exists,
+        "error": err,
+    }
+
+
+def release_managed_auth_if_unused(connector_before: dict[str, Any], *, auth_ref_after: str | None) -> None:
+    """If we are leaving managed auth, delete the managed secret file (best-effort)."""
+    if not uses_managed_auth(connector_before):
+        return
+    after = str(auth_ref_after or "").strip()
+    if after == AUTH_REF_MANAGED:
+        return
+    cid = str(connector_before.get("id") or "").strip()
+    if cid:
+        delete_managed_auth_file(cid)

--- a/ax_cli/connectors/auth.py
+++ b/ax_cli/connectors/auth.py
@@ -1,47 +1,46 @@
-"""Gateway-managed connector auth: env files on disk, never inline in the registry.
-
-``auth_ref`` may be:
-
-- ``gateway:managed`` — secrets live in ``<gateway_dir>/connectors/auth/<connector_id>.env``
-  (mode ``0o600``).
-- Any other non-empty string — path to an operator-owned env file (expanded, resolved).
-
-Callers must never log return values from :func:`load_connector_auth_env`.
-"""
+"""Gateway-managed and file-backed connector auth (secrets never in ``connectors.json``)."""
 
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from ax_cli.gateway import _chmod_quiet, _redacted_path, gateway_dir
+from ax_cli.gateway import _chmod_quiet, _redacted_path
 
-# Stored in ``connectors.json`` ``auth_ref`` to mean managed on-disk secrets.
-AUTH_REF_MANAGED = "gateway:managed"
+from .constants import AUTH_REF_MANAGED, CONNECTOR_ID_FILENAME_RE, FILE_MODE_DIR, FILE_MODE_SECRET
+from .envfile import parse_dotenv
+from .paths import connectors_auth_env_base
 
-_SAFE_CONNECTOR_ID = re.compile(r"^[a-zA-Z0-9_.-]{1,128}$")
-
-
-def connectors_auth_env_base() -> Path:
-    """Directory for per-connector ``*.env`` files (path only; may not exist yet)."""
-    return gateway_dir() / "connectors" / "auth"
+__all__ = [
+    "AUTH_REF_MANAGED",
+    "connectors_auth_env_base",
+    "delete_managed_auth_file",
+    "ensure_connectors_auth_env_dir",
+    "ensure_managed_auth_file",
+    "load_connector_auth_env",
+    "parse_dotenv",
+    "public_auth_status",
+    "release_managed_auth_if_unused",
+    "resolve_auth_env_path",
+    "uses_managed_auth",
+    "write_managed_auth_from_file",
+]
 
 
 def ensure_connectors_auth_env_dir() -> Path:
     """Ensure the auth directory exists with restrictive permissions."""
     path = connectors_auth_env_base()
     path.mkdir(parents=True, exist_ok=True)
-    _chmod_quiet(path, 0o700)
+    _chmod_quiet(path, FILE_MODE_DIR)
     return path
 
 
 def _managed_env_path(connector_id: str) -> Path:
     cid = str(connector_id or "").strip()
-    if not _SAFE_CONNECTOR_ID.match(cid):
+    if not CONNECTOR_ID_FILENAME_RE.match(cid):
         raise ValueError("connector id is not usable as a managed auth filename")
     return connectors_auth_env_base() / f"{cid}.env"
 
@@ -72,14 +71,14 @@ def resolve_auth_env_path(connector: dict[str, Any]) -> Path | None:
 
 
 def ensure_managed_auth_file(connector_id: str) -> Path:
-    """Create an empty managed ``.env`` if missing (``0o600``)."""
+    """Create an empty managed ``.env`` if missing."""
     ensure_connectors_auth_env_dir()
     path = _managed_env_path(connector_id)
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
-        _chmod_quiet(path.parent, 0o700)
+        _chmod_quiet(path.parent, FILE_MODE_DIR)
         path.write_text("# Connector secrets (KEY=VALUE). Do not commit.\n", encoding="utf-8")
-    _chmod_quiet(path, 0o600)
+    _chmod_quiet(path, FILE_MODE_SECRET)
     return path
 
 
@@ -99,7 +98,7 @@ def delete_managed_auth_file(connector_id: str) -> bool:
 
 
 def write_managed_auth_from_file(connector_id: str, source: Path) -> Path:
-    """Atomically replace managed env content with a copy of ``source`` (bytes)."""
+    """Atomically replace managed env content with a copy of ``source``."""
     src = source.expanduser()
     if not src.is_file():
         raise ValueError(f"source is not a file: {src}")
@@ -120,7 +119,7 @@ def write_managed_auth_from_file(connector_id: str, source: Path) -> Path:
             tmp.flush()
             os.fsync(tmp.fileno())
         assert tmp_path is not None
-        tmp_path.chmod(0o600)
+        tmp_path.chmod(FILE_MODE_SECRET)
         tmp_path.replace(dest)
     finally:
         if tmp_path is not None and tmp_path.exists():
@@ -128,30 +127,8 @@ def write_managed_auth_from_file(connector_id: str, source: Path) -> Path:
                 tmp_path.unlink()
             except OSError:
                 pass
-    _chmod_quiet(dest, 0o600)
+    _chmod_quiet(dest, FILE_MODE_SECRET)
     return dest
-
-
-def parse_dotenv(content: str) -> dict[str, str]:
-    """Parse minimal KEY=VALUE lines (no command substitution)."""
-    result: dict[str, str] = {}
-    for raw_line in content.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.lower().startswith("export "):
-            line = line[7:].strip()
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        k = key.strip()
-        if not k or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", k):
-            continue
-        v = value.strip()
-        if len(v) >= 2 and ((v[0] == v[-1] == '"') or (v[0] == v[-1] == "'")):
-            v = v[1:-1]
-        result[k] = v
-    return result
 
 
 def load_connector_auth_env(connector: dict[str, Any]) -> dict[str, str]:

--- a/ax_cli/connectors/constants.py
+++ b/ax_cli/connectors/constants.py
@@ -1,0 +1,31 @@
+"""Shared constants for the Gateway connector registry and auth layers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+CONNECTORS_SCHEMA_VERSION = 1
+
+# ``auth_ref`` value: secrets live under ``<gateway_dir>/connectors/auth/<id>.env``.
+AUTH_REF_MANAGED = "gateway:managed"
+
+# Slug-safe labels for operator UX and future dashboard/API use.
+CONNECTOR_LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,63}$", re.IGNORECASE)
+
+# Managed auth filenames use the connector UUID/id from the registry row.
+CONNECTOR_ID_FILENAME_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,128}$")
+
+MAX_AUTH_REF_LEN = 2048
+MAX_CONNECTOR_ID_LEN = 128
+
+FILE_MODE_SECRET = 0o600
+FILE_MODE_DIR = 0o700
+
+
+class _UnsetType:
+    __slots__ = ()
+
+
+# Sentinel for optional patch fields in :func:`registry.update_connector`.
+UNSET: Any = _UnsetType()

--- a/ax_cli/connectors/constants.py
+++ b/ax_cli/connectors/constants.py
@@ -22,6 +22,13 @@ MAX_CONNECTOR_ID_LEN = 128
 FILE_MODE_SECRET = 0o600
 FILE_MODE_DIR = 0o700
 
+# Gateway activity.jsonl event names (see GATEWAY_ACTIVITY_EVENTS in ax_cli.gateway).
+CONNECTOR_ACTIVITY_EVENTS: dict[str, str] = {
+    "started": "connector_tool_started",
+    "completed": "connector_tool_completed",
+    "failed": "connector_tool_failed",
+}
+
 
 class _UnsetType:
     __slots__ = ()

--- a/ax_cli/connectors/envfile.py
+++ b/ax_cli/connectors/envfile.py
@@ -1,0 +1,27 @@
+"""Minimal dotenv parsing for connector auth files (no shell expansion)."""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_dotenv(content: str) -> dict[str, str]:
+    """Parse KEY=VALUE lines. Values are sensitive — do not log."""
+    result: dict[str, str] = {}
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.lower().startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        k = key.strip()
+        if not k or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", k):
+            continue
+        v = value.strip()
+        if len(v) >= 2 and ((v[0] == v[-1] == '"') or (v[0] == v[-1] == "'")):
+            v = v[1:-1]
+        result[k] = v
+    return result

--- a/ax_cli/connectors/errors.py
+++ b/ax_cli/connectors/errors.py
@@ -1,0 +1,5 @@
+"""Shared connector-layer exceptions (no provider imports)."""
+
+
+class ConnectorProviderError(RuntimeError):
+    """Raised when a connector cannot run a provider tool (config, auth, or API)."""

--- a/ax_cli/connectors/filtering.py
+++ b/ax_cli/connectors/filtering.py
@@ -1,0 +1,137 @@
+"""Gateway tool filter policy for connector tool catalogs and execution."""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from typing import Any
+
+from .errors import ConnectorProviderError
+
+DEFAULT_TOOLS_LIMIT = 50
+MAX_TOOLS_LIMIT = 200
+
+
+@dataclass(frozen=True, slots=True)
+class ToolFilterPolicy:
+    """Operator-defined constraints applied after Composio returns candidates."""
+
+    allowed_patterns: tuple[str, ...] = ()
+    denied_patterns: tuple[str, ...] = ()
+    toolkit_slugs: tuple[str, ...] = ()
+    default_limit: int = DEFAULT_TOOLS_LIMIT
+
+    @property
+    def has_allowlist(self) -> bool:
+        return bool(self.allowed_patterns)
+
+
+def _normalize_patterns(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(",") if part.strip()]
+        return tuple(parts)
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    return ()
+
+
+def _normalize_toolkits(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        slug = value.strip().lower()
+        return (slug,) if slug else ()
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            slug = str(item).strip().lower()
+            if slug and slug not in out:
+                out.append(slug)
+        return tuple(out)
+    return ()
+
+
+def resolve_tool_filter_policy(connector: dict[str, Any]) -> ToolFilterPolicy:
+    """Build filter policy from ``connector["config"]`` (non-secret fields only)."""
+    cfg = connector.get("config")
+    if not isinstance(cfg, dict):
+        cfg = {}
+    limit_raw = cfg.get("tools_limit") or cfg.get("tool_limit")
+    try:
+        limit = int(limit_raw) if limit_raw is not None else DEFAULT_TOOLS_LIMIT
+    except (TypeError, ValueError):
+        limit = DEFAULT_TOOLS_LIMIT
+    limit = max(1, min(limit, MAX_TOOLS_LIMIT))
+    return ToolFilterPolicy(
+        allowed_patterns=_normalize_patterns(cfg.get("allowed_tools") or cfg.get("allow_tools")),
+        denied_patterns=_normalize_patterns(cfg.get("denied_tools") or cfg.get("deny_tools")),
+        toolkit_slugs=_normalize_toolkits(cfg.get("toolkits") or cfg.get("toolkit_slug") or cfg.get("toolkit")),
+        default_limit=limit,
+    )
+
+
+def _matches_any(slug: str, patterns: tuple[str, ...]) -> bool:
+    if not patterns:
+        return False
+    upper = slug.upper()
+    for pattern in patterns:
+        pat = str(pattern).strip().upper()
+        if not pat:
+            continue
+        if fnmatch.fnmatchcase(upper, pat):
+            return True
+    return False
+
+
+def is_tool_allowed(tool_slug: str, policy: ToolFilterPolicy) -> bool:
+    """Return whether ``tool_slug`` may be executed under ``policy``."""
+    slug = str(tool_slug or "").strip()
+    if not slug:
+        return False
+    if policy.denied_patterns and _matches_any(slug, policy.denied_patterns):
+        return False
+    if policy.has_allowlist and not _matches_any(slug, policy.allowed_patterns):
+        return False
+    return True
+
+
+def assert_tool_allowed(tool_slug: str, policy: ToolFilterPolicy, *, connector_name: str | None = None) -> None:
+    if is_tool_allowed(tool_slug, policy):
+        return
+    label = f"connector {connector_name!r}" if connector_name else "connector"
+    if policy.has_allowlist:
+        raise ConnectorProviderError(
+            f"tool {tool_slug!r} is not allowed by {label} allowed_tools policy "
+            f"(patterns: {', '.join(policy.allowed_patterns)})"
+        )
+    raise ConnectorProviderError(f"tool {tool_slug!r} is denied by {label} denied_tools policy")
+
+
+def apply_policy_to_tools(tools: list[dict[str, Any]], policy: ToolFilterPolicy) -> list[dict[str, Any]]:
+    """Filter catalog rows by allow/deny patterns."""
+    return [tool for tool in tools if is_tool_allowed(str(tool.get("slug") or ""), policy)]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCatalogPage:
+    """Paginated tool catalog slice returned to operators."""
+
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    total_items: int | None = None
+    next_cursor: str | None = None
+    provider: str = ""
+    connector_name: str = ""
+    policy_applied: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "connector_name": self.connector_name,
+            "tools": self.tools,
+            "count": len(self.tools),
+            "total_items": self.total_items,
+            "next_cursor": self.next_cursor,
+            "policy_applied": self.policy_applied,
+        }

--- a/ax_cli/connectors/paths.py
+++ b/ax_cli/connectors/paths.py
@@ -1,0 +1,17 @@
+"""Filesystem paths for connector registry and auth (scoped under the Gateway dir)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ax_cli.gateway import gateway_dir
+
+
+def connectors_registry_path() -> Path:
+    """``connectors.json`` — connector rows and non-secret config only."""
+    return gateway_dir() / "connectors.json"
+
+
+def connectors_auth_env_base() -> Path:
+    """Directory for per-connector ``*.env`` secret files (may not exist yet)."""
+    return gateway_dir() / "connectors" / "auth"

--- a/ax_cli/connectors/providers/__init__.py
+++ b/ax_cli/connectors/providers/__init__.py
@@ -1,14 +1,23 @@
 """Outbound connector provider adapters (Composio, future vendors)."""
 
-from .base import ConnectorProviderError, ToolCallResult
-from .dispatch import adapter_for_connector, execute_connector_tool
+from .base import ConnectorProviderError, ToolCallResult, ToolCatalogEntry, ToolSearchResult
+from .dispatch import (
+    adapter_for_connector,
+    execute_connector_tool,
+    list_connector_tools,
+    search_connector_tools,
+)
 from .registry import SUPPORTED_PROVIDERS, get_provider_adapter
 
 __all__ = [
     "ConnectorProviderError",
     "SUPPORTED_PROVIDERS",
     "ToolCallResult",
+    "ToolCatalogEntry",
+    "ToolSearchResult",
     "adapter_for_connector",
     "execute_connector_tool",
     "get_provider_adapter",
+    "list_connector_tools",
+    "search_connector_tools",
 ]

--- a/ax_cli/connectors/providers/__init__.py
+++ b/ax_cli/connectors/providers/__init__.py
@@ -1,6 +1,7 @@
 """Outbound connector provider adapters (Composio, future vendors)."""
 
 from .base import ConnectorProviderError, ToolCallResult, ToolCatalogEntry, ToolSearchResult
+from .catalog import ProviderDefinition, list_provider_definitions, providers_payload
 from .dispatch import (
     adapter_for_connector,
     execute_connector_tool,
@@ -11,7 +12,10 @@ from .registry import SUPPORTED_PROVIDERS, get_provider_adapter
 
 __all__ = [
     "ConnectorProviderError",
+    "ProviderDefinition",
     "SUPPORTED_PROVIDERS",
+    "list_provider_definitions",
+    "providers_payload",
     "ToolCallResult",
     "ToolCatalogEntry",
     "ToolSearchResult",

--- a/ax_cli/connectors/providers/__init__.py
+++ b/ax_cli/connectors/providers/__init__.py
@@ -1,0 +1,14 @@
+"""Outbound connector provider adapters (Composio, future vendors)."""
+
+from .base import ConnectorProviderError, ToolCallResult
+from .dispatch import adapter_for_connector, execute_connector_tool
+from .registry import SUPPORTED_PROVIDERS, get_provider_adapter
+
+__all__ = [
+    "ConnectorProviderError",
+    "SUPPORTED_PROVIDERS",
+    "ToolCallResult",
+    "adapter_for_connector",
+    "execute_connector_tool",
+    "get_provider_adapter",
+]

--- a/ax_cli/connectors/providers/base.py
+++ b/ax_cli/connectors/providers/base.py
@@ -1,0 +1,49 @@
+"""Shared types for connector provider adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+class ConnectorProviderError(RuntimeError):
+    """Raised when a connector cannot run a provider tool (config, auth, or API)."""
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallResult:
+    """Normalized result from an outbound provider tool execution."""
+
+    provider: str
+    tool_slug: str
+    successful: bool
+    data: Any = None
+    error: str | None = None
+    log_id: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "tool_slug": self.tool_slug,
+            "successful": self.successful,
+            "data": self.data,
+            "error": self.error,
+            "log_id": self.log_id,
+        }
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Execute tools for one connector provider implementation."""
+
+    provider_id: str
+
+    def execute_tool(
+        self,
+        tool_slug: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        version: str | None = None,
+        connected_account_id: str | None = None,
+    ) -> ToolCallResult: ...

--- a/ax_cli/connectors/providers/base.py
+++ b/ax_cli/connectors/providers/base.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
+from ..errors import ConnectorProviderError
 
-class ConnectorProviderError(RuntimeError):
-    """Raised when a connector cannot run a provider tool (config, auth, or API)."""
-
+__all__ = ["ConnectorProviderError", "ProviderAdapter", "ToolCallResult", "ToolCatalogEntry", "ToolSearchResult"]
 
 @dataclass(frozen=True, slots=True)
 class ToolCallResult:
@@ -30,6 +29,54 @@ class ToolCallResult:
             "data": self.data,
             "error": self.error,
             "log_id": self.log_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCatalogEntry:
+    """One tool row in a provider catalog (no secrets)."""
+
+    slug: str
+    name: str
+    description: str
+    toolkit_slug: str | None = None
+    toolkit_name: str | None = None
+    version: str | None = None
+    tags: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "name": self.name,
+            "description": self.description,
+            "toolkit_slug": self.toolkit_slug,
+            "toolkit_name": self.toolkit_name,
+            "version": self.version,
+            "tags": list(self.tags),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSearchResult:
+    """Result from Composio intent search (COMPOSIO_SEARCH_TOOLS or catalog query)."""
+
+    mode: str
+    use_case: str
+    tools: tuple[ToolCatalogEntry, ...] = ()
+    session_id: str | None = None
+    successful: bool = True
+    error: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "use_case": self.use_case,
+            "successful": self.successful,
+            "error": self.error,
+            "session_id": self.session_id,
+            "tools": [tool.to_dict() for tool in self.tools],
+            "count": len(self.tools),
         }
 
 

--- a/ax_cli/connectors/providers/catalog.py
+++ b/ax_cli/connectors/providers/catalog.py
@@ -1,0 +1,96 @@
+"""Provider catalog: supported outbound connector types and capabilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+PROVIDER_COMPOSIO = "composio"
+PROVIDER_HTTP_MCP = "http_mcp"
+
+CAP_EXECUTE = "execute"
+CAP_LIST_TOOLS = "list_tools"
+CAP_INTENT_SEARCH = "intent_search"
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDefinition:
+    """One registered connector provider type."""
+
+    id: str
+    label: str
+    description: str
+    capabilities: frozenset[str]
+    auth_env_keys: tuple[str, ...]
+    config_fields: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "description": self.description,
+            "capabilities": sorted(self.capabilities),
+            "auth_env_keys": list(self.auth_env_keys),
+            "config_fields": list(self.config_fields),
+            "supports_execute": CAP_EXECUTE in self.capabilities,
+            "supports_list_tools": CAP_LIST_TOOLS in self.capabilities,
+            "supports_intent_search": CAP_INTENT_SEARCH in self.capabilities,
+        }
+
+
+_PROVIDER_CATALOG: dict[str, ProviderDefinition] = {
+    PROVIDER_COMPOSIO: ProviderDefinition(
+        id=PROVIDER_COMPOSIO,
+        label="Composio",
+        description="Composio tool API (execute, catalog list, and COMPOSIO_SEARCH_TOOLS intent search).",
+        capabilities=frozenset({CAP_EXECUTE, CAP_LIST_TOOLS, CAP_INTENT_SEARCH}),
+        auth_env_keys=("COMPOSIO_API_KEY", "COMPOSIO_KEY", "COMPOSIO_APIKEY", "COMPOSIO_USER_ID"),
+        config_fields=(
+            "user_id",
+            "base_url",
+            "tool_version",
+            "connected_account_id",
+            "allowed_tools",
+            "denied_tools",
+            "toolkits",
+            "tools_limit",
+            "search_mode",
+            "agent_name",
+        ),
+    ),
+    PROVIDER_HTTP_MCP: ProviderDefinition(
+        id=PROVIDER_HTTP_MCP,
+        label="HTTP MCP",
+        description=(
+            "Generic MCP server over HTTP JSON-RPC (tools/list and tools/call). "
+            "Use for self-hosted MCP, Composio hosted MCP URLs, or other streamable HTTP endpoints."
+        ),
+        capabilities=frozenset({CAP_EXECUTE, CAP_LIST_TOOLS}),
+        auth_env_keys=("MCP_BEARER_TOKEN", "MCP_AUTHORIZATION", "MCP_API_KEY"),
+        config_fields=("base_url", "protocol_version", "api_key_header", "skip_initialize"),
+    ),
+}
+
+SUPPORTED_PROVIDERS: frozenset[str] = frozenset(_PROVIDER_CATALOG.keys())
+
+
+def provider_definition(provider_id: str) -> ProviderDefinition:
+    pid = str(provider_id or "").strip().lower()
+    definition = _PROVIDER_CATALOG.get(pid)
+    if definition is None:
+        supported = ", ".join(sorted(SUPPORTED_PROVIDERS))
+        raise ValueError(f"unsupported provider {provider_id!r} (supported: {supported})")
+    return definition
+
+
+def is_supported_provider(provider_id: str) -> bool:
+    return str(provider_id or "").strip().lower() in _PROVIDER_CATALOG
+
+
+def list_provider_definitions() -> list[ProviderDefinition]:
+    return [_PROVIDER_CATALOG[pid] for pid in sorted(_PROVIDER_CATALOG)]
+
+
+def providers_payload() -> dict[str, Any]:
+    items = [definition.to_dict() for definition in list_provider_definitions()]
+    return {"providers": items, "count": len(items)}

--- a/ax_cli/connectors/providers/composio_adapter.py
+++ b/ax_cli/connectors/providers/composio_adapter.py
@@ -88,6 +88,47 @@ class ComposioAdapter:
         if not self._user_id:
             raise ConnectorProviderError("Composio user_id is empty")
 
+    def _headers(self) -> dict[str, str]:
+        return {"x-api-key": self._api_key, "Content-Type": "application/json"}
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        try:
+            if self._client is not None:
+                return self._client.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json_body,
+                    headers=self._headers(),
+                    timeout=self._timeout,
+                )
+            with httpx.Client(timeout=self._timeout) as client:
+                return client.request(method, url, params=params, json=json_body, headers=self._headers())
+        except httpx.HTTPError as exc:
+            raise ConnectorProviderError(f"Composio request failed: {exc}") from exc
+
+    def get_tools(self, params: dict[str, Any]) -> dict[str, Any]:
+        """``GET /api/v3.1/tools`` — Composio catalog with query/toolkit filters."""
+        url = f"{self._base_url}/api/v3.1/tools"
+        response = self._request("GET", url, params=params)
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ConnectorProviderError("Composio tools list returned non-JSON response") from exc
+        if not isinstance(payload, dict):
+            raise ConnectorProviderError("Composio tools list returned unexpected payload")
+        if response.status_code >= 400:
+            err = payload.get("error") or payload.get("message") or response.reason_phrase
+            raise ConnectorProviderError(f"Composio tools list failed: {err}")
+        return payload
+
     def execute_tool(
         self,
         tool_slug: str,
@@ -109,17 +150,7 @@ class ComposioAdapter:
             body["connected_account_id"] = str(connected_account_id).strip()
 
         url = f"{self._base_url}/api/v3/tools/execute/{slug}"
-        headers = {"x-api-key": self._api_key, "Content-Type": "application/json"}
-
-        try:
-            if self._client is not None:
-                response = self._client.post(url, json=body, headers=headers, timeout=self._timeout)
-            else:
-                with httpx.Client(timeout=self._timeout) as client:
-                    response = client.post(url, json=body, headers=headers)
-        except httpx.HTTPError as exc:
-            raise ConnectorProviderError(f"Composio request failed: {exc}") from exc
-
+        response = self._request("POST", url, json_body=body)
         return self._parse_response(slug, response)
 
     def _parse_response(self, tool_slug: str, response: httpx.Response) -> ToolCallResult:

--- a/ax_cli/connectors/providers/composio_adapter.py
+++ b/ax_cli/connectors/providers/composio_adapter.py
@@ -1,0 +1,162 @@
+"""Composio provider: direct tool execution via Composio HTTP API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from ..auth import load_connector_auth_env
+from .base import ConnectorProviderError, ToolCallResult
+
+PROVIDER_ID = "composio"
+DEFAULT_BASE_URL = "https://backend.composio.dev"
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+_API_KEY_ENV_KEYS = ("COMPOSIO_API_KEY", "COMPOSIO_KEY", "COMPOSIO_APIKEY")
+_USER_ID_ENV_KEYS = ("COMPOSIO_USER_ID", "COMPOSIO_ENTITY_ID")
+_BASE_URL_ENV_KEYS = ("COMPOSIO_BASE_URL",)
+
+
+def _first_env(env: dict[str, str], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        val = str(env.get(key) or "").strip()
+        if val:
+            return val
+    return None
+
+
+def _connector_config(connector: dict[str, Any]) -> dict[str, Any]:
+    cfg = connector.get("config")
+    if isinstance(cfg, dict):
+        return cfg
+    return {}
+
+
+def resolve_composio_settings(connector: dict[str, Any]) -> dict[str, str]:
+    """Resolve API key, user_id, and base URL from auth env + connector config."""
+    env = load_connector_auth_env(connector)
+    api_key = _first_env(env, _API_KEY_ENV_KEYS)
+    if not api_key:
+        raise ConnectorProviderError(
+            "Composio API key missing. Set COMPOSIO_API_KEY in the connector auth env file."
+        )
+    cfg = _connector_config(connector)
+    user_id = str(cfg.get("user_id") or "").strip() or _first_env(env, _USER_ID_ENV_KEYS)
+    if not user_id:
+        raise ConnectorProviderError(
+            "Composio user_id missing. Set config.user_id on the connector or COMPOSIO_USER_ID in auth env."
+        )
+    base_url = (
+        str(cfg.get("base_url") or "").strip()
+        or _first_env(env, _BASE_URL_ENV_KEYS)
+        or DEFAULT_BASE_URL
+    ).rstrip("/")
+    return {"api_key": api_key, "user_id": user_id, "base_url": base_url}
+
+
+def build_composio_adapter(connector: dict[str, Any]) -> ComposioAdapter:
+    settings = resolve_composio_settings(connector)
+    return ComposioAdapter(
+        api_key=settings["api_key"],
+        user_id=settings["user_id"],
+        base_url=settings["base_url"],
+    )
+
+
+class ComposioAdapter:
+    """Execute Composio tools by slug (``POST /api/v3/tools/execute/{slug}``)."""
+
+    provider_id = PROVIDER_ID
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        user_id: str,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._api_key = api_key.strip()
+        self._user_id = user_id.strip()
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout_seconds
+        self._client = client
+        if not self._api_key:
+            raise ConnectorProviderError("Composio API key is empty")
+        if not self._user_id:
+            raise ConnectorProviderError("Composio user_id is empty")
+
+    def execute_tool(
+        self,
+        tool_slug: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        version: str | None = None,
+        connected_account_id: str | None = None,
+    ) -> ToolCallResult:
+        slug = str(tool_slug or "").strip()
+        if not slug:
+            raise ConnectorProviderError("tool_slug is required")
+        body: dict[str, Any] = {
+            "user_id": self._user_id,
+            "arguments": dict(arguments or {}),
+        }
+        if version:
+            body["version"] = str(version).strip()
+        if connected_account_id:
+            body["connected_account_id"] = str(connected_account_id).strip()
+
+        url = f"{self._base_url}/api/v3/tools/execute/{slug}"
+        headers = {"x-api-key": self._api_key, "Content-Type": "application/json"}
+
+        try:
+            if self._client is not None:
+                response = self._client.post(url, json=body, headers=headers, timeout=self._timeout)
+            else:
+                with httpx.Client(timeout=self._timeout) as client:
+                    response = client.post(url, json=body, headers=headers)
+        except httpx.HTTPError as exc:
+            raise ConnectorProviderError(f"Composio request failed: {exc}") from exc
+
+        return self._parse_response(slug, response)
+
+    def _parse_response(self, tool_slug: str, response: httpx.Response) -> ToolCallResult:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {"error": response.text[:500] if response.text else "non-JSON response"}
+
+        if not isinstance(payload, dict):
+            payload = {"data": payload}
+
+        if response.status_code >= 400:
+            err = payload.get("error") or payload.get("message") or response.reason_phrase
+            return ToolCallResult(
+                provider=PROVIDER_ID,
+                tool_slug=tool_slug,
+                successful=False,
+                data=payload.get("data"),
+                error=str(err),
+                log_id=_str_or_none(payload.get("log_id")),
+                raw=payload,
+            )
+
+        successful = bool(payload.get("successful", True))
+        return ToolCallResult(
+            provider=PROVIDER_ID,
+            tool_slug=tool_slug,
+            successful=successful,
+            data=payload.get("data"),
+            error=_str_or_none(payload.get("error")),
+            log_id=_str_or_none(payload.get("log_id")),
+            raw=payload,
+        )
+
+
+def _str_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/ax_cli/connectors/providers/composio_catalog.py
+++ b/ax_cli/connectors/providers/composio_catalog.py
@@ -1,0 +1,261 @@
+"""Composio tool catalog listing and intent search (Composio-native filtering)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..filtering import ToolFilterPolicy
+from .base import ConnectorProviderError, ToolCatalogEntry, ToolSearchResult
+from .composio_adapter import ComposioAdapter
+
+_COMPOSIO_SEARCH_TOOL = "COMPOSIO_SEARCH_TOOLS"
+_SLUG_RE = re.compile(r"^[A-Z][A-Z0-9_]+$")
+
+
+def _catalog_entry_from_item(item: dict[str, Any]) -> ToolCatalogEntry | None:
+    slug = str(item.get("slug") or "").strip()
+    if not slug:
+        return None
+    toolkit = item.get("toolkit") if isinstance(item.get("toolkit"), dict) else {}
+    tags_raw = item.get("tags") if isinstance(item.get("tags"), list) else []
+    tags = tuple(str(tag).strip() for tag in tags_raw if str(tag).strip())
+    return ToolCatalogEntry(
+        slug=slug,
+        name=str(item.get("name") or slug).strip(),
+        description=str(item.get("description") or item.get("human_description") or "").strip(),
+        toolkit_slug=str(toolkit.get("slug") or "").strip() or None,
+        toolkit_name=str(toolkit.get("name") or "").strip() or None,
+        version=_str_or_none(item.get("version")),
+        tags=tags,
+    )
+
+
+def _str_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _entries_to_dicts(entries: list[ToolCatalogEntry]) -> list[dict[str, Any]]:
+    return [entry.to_dict() for entry in entries]
+
+
+def list_composio_tools(
+    adapter: ComposioAdapter,
+    policy: ToolFilterPolicy,
+    *,
+    query: str | None = None,
+    toolkit_slug: str | None = None,
+    tool_slugs: list[str] | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """List tools via ``GET /api/v3.1/tools`` and apply Gateway allow/deny policy."""
+    effective_limit = limit if limit is not None else policy.default_limit
+    effective_limit = max(1, min(int(effective_limit), 200))
+
+    if tool_slugs:
+        params: dict[str, Any] = {
+            "tool_slugs": ",".join(str(s).strip() for s in tool_slugs if str(s).strip()),
+            "limit": effective_limit,
+        }
+        payload = adapter.get_tools(params)
+        items = payload.get("items") if isinstance(payload.get("items"), list) else []
+        entries = [_catalog_entry_from_item(item) for item in items if isinstance(item, dict)]
+        entries = [entry for entry in entries if entry is not None]
+        filtered = [entry for entry in entries if _entry_allowed(entry, policy)]
+        return {
+            "tools": _entries_to_dicts(filtered),
+            "count": len(filtered),
+            "total_items": payload.get("total_items"),
+            "next_cursor": payload.get("next_cursor"),
+            "composio_query": params.get("tool_slugs"),
+            "policy_applied": policy.has_allowlist or bool(policy.denied_patterns),
+        }
+
+    toolkits = [toolkit_slug] if toolkit_slug else list(policy.toolkit_slugs)
+    if not toolkits:
+        params = {"limit": effective_limit, "query": str(query).strip() if query else None}
+        if cursor:
+            params["cursor"] = cursor
+        payload = adapter.get_tools({k: v for k, v in params.items() if v is not None})
+        return _page_from_payload(payload, policy)
+
+    merged: list[ToolCatalogEntry] = []
+    seen: set[str] = set()
+    last_payload: dict[str, Any] = {}
+    per_toolkit = max(1, effective_limit // max(len(toolkits), 1))
+    for tk in toolkits:
+        params = {
+            "toolkit_slug": str(tk).strip().lower(),
+            "limit": per_toolkit,
+            "query": str(query).strip() if query else None,
+        }
+        payload = adapter.get_tools({k: v for k, v in params.items() if v is not None})
+        last_payload = payload
+        items = payload.get("items") if isinstance(payload.get("items"), list) else []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            entry = _catalog_entry_from_item(item)
+            if entry is None or entry.slug in seen:
+                continue
+            if not _entry_allowed(entry, policy):
+                continue
+            seen.add(entry.slug)
+            merged.append(entry)
+            if len(merged) >= effective_limit:
+                break
+        if len(merged) >= effective_limit:
+            break
+
+    return {
+        "tools": _entries_to_dicts(merged[:effective_limit]),
+        "count": len(merged[:effective_limit]),
+        "total_items": last_payload.get("total_items"),
+        "next_cursor": last_payload.get("next_cursor"),
+        "toolkit_slugs": list(toolkits),
+        "policy_applied": policy.has_allowlist or bool(policy.denied_patterns),
+    }
+
+
+def _page_from_payload(payload: dict[str, Any], policy: ToolFilterPolicy) -> dict[str, Any]:
+    items = payload.get("items") if isinstance(payload.get("items"), list) else []
+    entries = [_catalog_entry_from_item(item) for item in items if isinstance(item, dict)]
+    entries = [entry for entry in entries if entry is not None]
+    filtered = [entry for entry in entries if _entry_allowed(entry, policy)]
+    return {
+        "tools": _entries_to_dicts(filtered),
+        "count": len(filtered),
+        "total_items": payload.get("total_items"),
+        "next_cursor": payload.get("next_cursor"),
+        "policy_applied": policy.has_allowlist or bool(policy.denied_patterns),
+    }
+
+
+def _entry_allowed(entry: ToolCatalogEntry, policy: ToolFilterPolicy) -> bool:
+    from ..filtering import is_tool_allowed
+
+    return is_tool_allowed(entry.slug, policy)
+
+
+def search_composio_tools_catalog(
+    adapter: ComposioAdapter,
+    policy: ToolFilterPolicy,
+    use_case: str,
+    *,
+    limit: int | None = None,
+) -> ToolSearchResult:
+    """Soft search via Composio catalog ``query`` parameter."""
+    needle = str(use_case or "").strip()
+    if not needle:
+        raise ConnectorProviderError("use_case is required for tool search")
+    page = list_composio_tools(adapter, policy, query=needle, limit=limit)
+    entries = [
+        ToolCatalogEntry(
+            slug=str(row.get("slug") or ""),
+            name=str(row.get("name") or ""),
+            description=str(row.get("description") or ""),
+            toolkit_slug=row.get("toolkit_slug"),
+            toolkit_name=row.get("toolkit_name"),
+            version=row.get("version"),
+            tags=tuple(row.get("tags") or ()),
+        )
+        for row in page.get("tools") or []
+        if isinstance(row, dict) and row.get("slug")
+    ]
+    return ToolSearchResult(
+        mode="catalog_query",
+        use_case=needle,
+        tools=tuple(entries),
+        successful=True,
+        raw=page,
+    )
+
+
+def search_composio_tools_intent(
+    adapter: ComposioAdapter,
+    policy: ToolFilterPolicy,
+    use_case: str,
+    *,
+    known_fields: str | None = None,
+    session_id: str | None = None,
+) -> ToolSearchResult:
+    """Intent search via Composio ``COMPOSIO_SEARCH_TOOLS`` meta tool."""
+    needle = str(use_case or "").strip()
+    if not needle:
+        raise ConnectorProviderError("use_case is required for tool search")
+
+    query: dict[str, Any] = {"use_case": needle}
+    if known_fields:
+        query["known_fields"] = str(known_fields).strip()
+    arguments: dict[str, Any] = {"queries": [query]}
+    if session_id:
+        arguments["session"] = {"id": str(session_id).strip()}
+    else:
+        arguments["session"] = {"generate_id": True}
+
+    result = adapter.execute_tool(_COMPOSIO_SEARCH_TOOL, arguments)
+    parsed_tools, parsed_session = _parse_search_tools_response(result.data)
+    if not parsed_session and isinstance(result.raw, dict):
+        parsed_session = _extract_session_id(result.raw)
+
+    filtered = [tool for tool in parsed_tools if _entry_allowed(tool, policy)]
+    return ToolSearchResult(
+        mode="composio_search_tools",
+        use_case=needle,
+        tools=tuple(filtered),
+        session_id=parsed_session,
+        successful=result.successful,
+        error=result.error,
+        raw=result.raw if isinstance(result.raw, dict) else {"data": result.data},
+    )
+
+
+def _parse_search_tools_response(data: Any) -> tuple[list[ToolCatalogEntry], str | None]:
+    """Best-effort extraction of tool slugs from COMPOSIO_SEARCH_TOOLS output."""
+    session_id = _extract_session_id(data) if isinstance(data, dict) else None
+    slugs: set[str] = set()
+    _collect_slugs(data, slugs)
+    tools = [
+        ToolCatalogEntry(slug=slug, name=slug, description="")
+        for slug in sorted(slugs)
+        if _SLUG_RE.match(slug) and slug != _COMPOSIO_SEARCH_TOOL
+    ]
+    return tools, session_id
+
+
+def _collect_slugs(node: Any, out: set[str]) -> None:
+    if isinstance(node, dict):
+        for key in ("tool_slug", "slug", "primary_tool_slugs", "related_tool_slugs"):
+            val = node.get(key)
+            if isinstance(val, str) and _SLUG_RE.match(val.strip()):
+                out.add(val.strip())
+            elif isinstance(val, list):
+                for item in val:
+                    if isinstance(item, str) and _SLUG_RE.match(item.strip()):
+                        out.add(item.strip())
+        for value in node.values():
+            _collect_slugs(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_slugs(item, out)
+    elif isinstance(node, str) and _SLUG_RE.match(node.strip()) and len(node) > 8:
+        out.add(node.strip())
+
+
+def _extract_session_id(data: Any) -> str | None:
+    if not isinstance(data, dict):
+        return None
+    session = data.get("session")
+    if isinstance(session, dict):
+        sid = session.get("id") or session.get("session_id")
+        if sid:
+            return str(sid).strip()
+    for key in ("session_id", "sessionId"):
+        val = data.get(key)
+        if val:
+            return str(val).strip()
+    return None

--- a/ax_cli/connectors/providers/dispatch.py
+++ b/ax_cli/connectors/providers/dispatch.py
@@ -1,0 +1,50 @@
+"""Resolve a registry connector row and execute a provider tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ax_cli.connectors.registry import find_connector, load_connectors_registry
+
+from .base import ConnectorProviderError, ToolCallResult
+from .registry import get_provider_adapter
+
+
+def adapter_for_connector(connector: dict[str, Any]) -> Any:
+    """Build a provider adapter from a connector registry row."""
+    if not isinstance(connector, dict):
+        raise ConnectorProviderError("connector row must be an object")
+    if not bool(connector.get("enabled", True)):
+        raise ConnectorProviderError(f"connector {connector.get('name')!r} is disabled")
+    provider = str(connector.get("provider") or "").strip().lower()
+    if not provider:
+        raise ConnectorProviderError("connector provider is missing")
+    return get_provider_adapter(provider, connector)
+
+
+def execute_connector_tool(
+    connector_ref: str,
+    tool_slug: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    registry: dict[str, Any] | None = None,
+    version: str | None = None,
+    connected_account_id: str | None = None,
+) -> ToolCallResult:
+    """Load connector by name/id and execute ``tool_slug`` via its provider adapter."""
+    reg = registry if registry is not None else load_connectors_registry()
+    row = find_connector(reg, connector_ref)
+    if not row:
+        raise ConnectorProviderError(f"unknown connector: {connector_ref!r}")
+    adapter = adapter_for_connector(row)
+    cfg = row.get("config") if isinstance(row.get("config"), dict) else {}
+    version_eff = version or (str(cfg.get("tool_version") or cfg.get("version") or "").strip() or None)
+    connected_eff = connected_account_id or (
+        str(cfg.get("connected_account_id") or "").strip() or None
+    )
+    return adapter.execute_tool(
+        tool_slug,
+        arguments,
+        version=version_eff,
+        connected_account_id=connected_eff,
+    )

--- a/ax_cli/connectors/providers/dispatch.py
+++ b/ax_cli/connectors/providers/dispatch.py
@@ -16,12 +16,13 @@ from ax_cli.connectors.filtering import (
 from ax_cli.connectors.registry import find_connector, load_connectors_registry
 
 from .base import ConnectorProviderError, ToolCallResult, ToolSearchResult
-from .composio_adapter import PROVIDER_ID
+from .catalog import PROVIDER_COMPOSIO, PROVIDER_HTTP_MCP
 from .composio_catalog import (
     list_composio_tools,
     search_composio_tools_catalog,
     search_composio_tools_intent,
 )
+from .http_mcp_catalog import list_http_mcp_tools, search_http_mcp_tools_catalog
 from .registry import get_provider_adapter
 
 SearchMode = Literal["catalog", "intent", "auto"]
@@ -52,6 +53,10 @@ def _require_connector_row(
     return row
 
 
+def _provider_id(row: dict[str, Any]) -> str:
+    return str(row.get("provider") or "").strip().lower()
+
+
 def list_connector_tools(
     connector_ref: str,
     *,
@@ -62,22 +67,30 @@ def list_connector_tools(
     limit: int | None = None,
     cursor: str | None = None,
 ) -> dict[str, Any]:
-    """List tools for a connector (Composio catalog API + Gateway policy)."""
+    """List tools for a connector (provider catalog + Gateway policy)."""
     row = _require_connector_row(registry, connector_ref)
-    provider = str(row.get("provider") or "").strip().lower()
-    if provider != PROVIDER_ID:
-        raise ConnectorProviderError(f"tool listing is not implemented for provider {provider!r}")
+    provider = _provider_id(row)
     policy = resolve_tool_filter_policy(row)
     adapter = adapter_for_connector(row)
-    page = list_composio_tools(
-        adapter,
-        policy,
-        query=query,
-        toolkit_slug=toolkit_slug,
-        tool_slugs=tool_slugs,
-        limit=limit,
-        cursor=cursor,
-    )
+    if provider == PROVIDER_COMPOSIO:
+        page = list_composio_tools(
+            adapter,
+            policy,
+            query=query,
+            toolkit_slug=toolkit_slug,
+            tool_slugs=tool_slugs,
+            limit=limit,
+            cursor=cursor,
+        )
+    elif provider == PROVIDER_HTTP_MCP:
+        if toolkit_slug or tool_slugs or cursor:
+            pass  # ignored for MCP tools/list
+        page = list_http_mcp_tools(adapter, policy, query=query, limit=limit)
+    else:
+        raise ConnectorProviderError(
+            f"tool listing is not implemented for provider {provider!r} "
+            f"(supported: {PROVIDER_COMPOSIO}, {PROVIDER_HTTP_MCP})"
+        )
     page["connector_name"] = row.get("name")
     page["provider"] = provider
     return page
@@ -93,13 +106,21 @@ def search_connector_tools(
     session_id: str | None = None,
     limit: int | None = None,
 ) -> ToolSearchResult:
-    """Search tools by natural-language use case (Composio intent or catalog query)."""
+    """Search tools by natural-language use case (intent or catalog query)."""
     row = _require_connector_row(registry, connector_ref)
-    provider = str(row.get("provider") or "").strip().lower()
-    if provider != PROVIDER_ID:
-        raise ConnectorProviderError(f"tool search is not implemented for provider {provider!r}")
+    provider = _provider_id(row)
     policy = resolve_tool_filter_policy(row)
     adapter = adapter_for_connector(row)
+
+    if provider == PROVIDER_HTTP_MCP:
+        return search_http_mcp_tools_catalog(adapter, policy, use_case, limit=limit)
+
+    if provider != PROVIDER_COMPOSIO:
+        raise ConnectorProviderError(
+            f"tool search is not implemented for provider {provider!r} "
+            f"(supported: {PROVIDER_COMPOSIO}, {PROVIDER_HTTP_MCP})"
+        )
+
     cfg = row.get("config") if isinstance(row.get("config"), dict) else {}
     configured_mode = str(cfg.get("search_mode") or "auto").strip().lower()
     effective_mode = mode if mode != "auto" else configured_mode  # type: ignore[assignment]
@@ -117,7 +138,6 @@ def search_connector_tools(
             session_id=session_id,
         )
     else:
-        # Prefer Composio intent search; fall back to catalog query on failure.
         result = search_composio_tools_intent(
             adapter,
             policy,

--- a/ax_cli/connectors/providers/dispatch.py
+++ b/ax_cli/connectors/providers/dispatch.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
+from ax_cli.connectors.activity import (
+    record_connector_tool_finished,
+    record_connector_tool_started,
+)
 from ax_cli.connectors.registry import find_connector, load_connectors_registry
 
 from .base import ConnectorProviderError, ToolCallResult
@@ -30,21 +35,51 @@ def execute_connector_tool(
     registry: dict[str, Any] | None = None,
     version: str | None = None,
     connected_account_id: str | None = None,
+    record_activity: bool = True,
 ) -> ToolCallResult:
     """Load connector by name/id and execute ``tool_slug`` via its provider adapter."""
     reg = registry if registry is not None else load_connectors_registry()
     row = find_connector(reg, connector_ref)
     if not row:
         raise ConnectorProviderError(f"unknown connector: {connector_ref!r}")
-    adapter = adapter_for_connector(row)
+
+    tool_call_id = str(uuid.uuid4())
+    if record_activity:
+        started = record_connector_tool_started(row, tool_slug, tool_call_id=tool_call_id)
+        tool_call_id = str(started.get("tool_call_id") or tool_call_id)
+
     cfg = row.get("config") if isinstance(row.get("config"), dict) else {}
     version_eff = version or (str(cfg.get("tool_version") or cfg.get("version") or "").strip() or None)
     connected_eff = connected_account_id or (
         str(cfg.get("connected_account_id") or "").strip() or None
     )
-    return adapter.execute_tool(
-        tool_slug,
-        arguments,
-        version=version_eff,
-        connected_account_id=connected_eff,
-    )
+
+    try:
+        adapter = adapter_for_connector(row)
+        result = adapter.execute_tool(
+            tool_slug,
+            arguments,
+            version=version_eff,
+            connected_account_id=connected_eff,
+        )
+    except ConnectorProviderError as exc:
+        if record_activity:
+            record_connector_tool_finished(
+                row,
+                tool_slug,
+                tool_call_id=tool_call_id,
+                successful=False,
+                error=str(exc),
+            )
+        raise
+
+    if record_activity:
+        record_connector_tool_finished(
+            row,
+            tool_slug,
+            tool_call_id=tool_call_id,
+            successful=result.successful,
+            error=result.error,
+            log_id=result.log_id,
+        )
+    return result

--- a/ax_cli/connectors/providers/dispatch.py
+++ b/ax_cli/connectors/providers/dispatch.py
@@ -3,16 +3,28 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from ax_cli.connectors.activity import (
     record_connector_tool_finished,
     record_connector_tool_started,
 )
+from ax_cli.connectors.filtering import (
+    assert_tool_allowed,
+    resolve_tool_filter_policy,
+)
 from ax_cli.connectors.registry import find_connector, load_connectors_registry
 
-from .base import ConnectorProviderError, ToolCallResult
+from .base import ConnectorProviderError, ToolCallResult, ToolSearchResult
+from .composio_adapter import PROVIDER_ID
+from .composio_catalog import (
+    list_composio_tools,
+    search_composio_tools_catalog,
+    search_composio_tools_intent,
+)
 from .registry import get_provider_adapter
+
+SearchMode = Literal["catalog", "intent", "auto"]
 
 
 def adapter_for_connector(connector: dict[str, Any]) -> Any:
@@ -27,6 +39,97 @@ def adapter_for_connector(connector: dict[str, Any]) -> Any:
     return get_provider_adapter(provider, connector)
 
 
+def _require_connector_row(
+    registry: dict[str, Any] | None,
+    connector_ref: str,
+) -> dict[str, Any]:
+    reg = registry if registry is not None else load_connectors_registry()
+    row = find_connector(reg, connector_ref)
+    if not row:
+        raise ConnectorProviderError(f"unknown connector: {connector_ref!r}")
+    if not bool(row.get("enabled", True)):
+        raise ConnectorProviderError(f"connector {row.get('name')!r} is disabled")
+    return row
+
+
+def list_connector_tools(
+    connector_ref: str,
+    *,
+    registry: dict[str, Any] | None = None,
+    query: str | None = None,
+    toolkit_slug: str | None = None,
+    tool_slugs: list[str] | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """List tools for a connector (Composio catalog API + Gateway policy)."""
+    row = _require_connector_row(registry, connector_ref)
+    provider = str(row.get("provider") or "").strip().lower()
+    if provider != PROVIDER_ID:
+        raise ConnectorProviderError(f"tool listing is not implemented for provider {provider!r}")
+    policy = resolve_tool_filter_policy(row)
+    adapter = adapter_for_connector(row)
+    page = list_composio_tools(
+        adapter,
+        policy,
+        query=query,
+        toolkit_slug=toolkit_slug,
+        tool_slugs=tool_slugs,
+        limit=limit,
+        cursor=cursor,
+    )
+    page["connector_name"] = row.get("name")
+    page["provider"] = provider
+    return page
+
+
+def search_connector_tools(
+    connector_ref: str,
+    use_case: str,
+    *,
+    registry: dict[str, Any] | None = None,
+    mode: SearchMode = "auto",
+    known_fields: str | None = None,
+    session_id: str | None = None,
+    limit: int | None = None,
+) -> ToolSearchResult:
+    """Search tools by natural-language use case (Composio intent or catalog query)."""
+    row = _require_connector_row(registry, connector_ref)
+    provider = str(row.get("provider") or "").strip().lower()
+    if provider != PROVIDER_ID:
+        raise ConnectorProviderError(f"tool search is not implemented for provider {provider!r}")
+    policy = resolve_tool_filter_policy(row)
+    adapter = adapter_for_connector(row)
+    cfg = row.get("config") if isinstance(row.get("config"), dict) else {}
+    configured_mode = str(cfg.get("search_mode") or "auto").strip().lower()
+    effective_mode = mode if mode != "auto" else configured_mode  # type: ignore[assignment]
+    if effective_mode not in {"catalog", "intent", "auto"}:
+        effective_mode = "auto"
+
+    if effective_mode == "catalog":
+        result = search_composio_tools_catalog(adapter, policy, use_case, limit=limit)
+    elif effective_mode == "intent":
+        result = search_composio_tools_intent(
+            adapter,
+            policy,
+            use_case,
+            known_fields=known_fields,
+            session_id=session_id,
+        )
+    else:
+        # Prefer Composio intent search; fall back to catalog query on failure.
+        result = search_composio_tools_intent(
+            adapter,
+            policy,
+            use_case,
+            known_fields=known_fields,
+            session_id=session_id,
+        )
+        if not result.successful or not result.tools:
+            result = search_composio_tools_catalog(adapter, policy, use_case, limit=limit)
+    return result
+
+
 def execute_connector_tool(
     connector_ref: str,
     tool_slug: str,
@@ -36,12 +139,17 @@ def execute_connector_tool(
     version: str | None = None,
     connected_account_id: str | None = None,
     record_activity: bool = True,
+    skip_policy_check: bool = False,
 ) -> ToolCallResult:
     """Load connector by name/id and execute ``tool_slug`` via its provider adapter."""
     reg = registry if registry is not None else load_connectors_registry()
     row = find_connector(reg, connector_ref)
     if not row:
         raise ConnectorProviderError(f"unknown connector: {connector_ref!r}")
+
+    policy = resolve_tool_filter_policy(row)
+    if not skip_policy_check:
+        assert_tool_allowed(tool_slug, policy, connector_name=str(row.get("name") or ""))
 
     tool_call_id = str(uuid.uuid4())
     if record_activity:

--- a/ax_cli/connectors/providers/http_mcp_adapter.py
+++ b/ax_cli/connectors/providers/http_mcp_adapter.py
@@ -1,0 +1,214 @@
+"""HTTP MCP provider: JSON-RPC tools/list and tools/call against a remote MCP endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from ..auth import load_connector_auth_env
+from .base import ConnectorProviderError, ToolCallResult
+
+PROVIDER_ID = "http_mcp"
+DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+_AUTH_BEARER_KEYS = ("MCP_BEARER_TOKEN", "MCP_TOKEN", "MCP_ACCESS_TOKEN")
+_AUTH_AUTHORIZATION_KEYS = ("MCP_AUTHORIZATION", "AUTHORIZATION")
+_AUTH_API_KEY_KEYS = ("MCP_API_KEY", "API_KEY")
+
+
+def _connector_config(connector: dict[str, Any]) -> dict[str, Any]:
+    cfg = connector.get("config")
+    if isinstance(cfg, dict):
+        return cfg
+    return {}
+
+
+def _first_env(env: dict[str, str], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        val = str(env.get(key) or "").strip()
+        if val:
+            return val
+    return None
+
+
+def resolve_http_mcp_settings(connector: dict[str, Any]) -> dict[str, str]:
+    """Resolve base URL and auth headers from connector config + auth env."""
+    cfg = _connector_config(connector)
+    base_url = str(cfg.get("base_url") or "").strip().rstrip("/")
+    if not base_url:
+        raise ConnectorProviderError(
+            "http_mcp base_url missing. Set config.base_url to the MCP HTTP endpoint URL."
+        )
+    env = load_connector_auth_env(connector)
+    headers: dict[str, str] = {"Content-Type": "application/json", "Accept": "application/json"}
+    bearer = _first_env(env, _AUTH_BEARER_KEYS)
+    if bearer:
+        headers["Authorization"] = bearer if bearer.lower().startswith("bearer ") else f"Bearer {bearer}"
+    else:
+        authorization = _first_env(env, _AUTH_AUTHORIZATION_KEYS)
+        if authorization:
+            headers["Authorization"] = authorization
+    api_key = _first_env(env, _AUTH_API_KEY_KEYS)
+    if api_key:
+        header_name = str(cfg.get("api_key_header") or "X-API-Key").strip() or "X-API-Key"
+        headers[header_name] = api_key
+    return {
+        "base_url": base_url,
+        "protocol_version": str(cfg.get("protocol_version") or DEFAULT_PROTOCOL_VERSION).strip()
+        or DEFAULT_PROTOCOL_VERSION,
+        "skip_initialize": bool(cfg.get("skip_initialize")),
+        "headers": headers,
+    }
+
+
+def build_http_mcp_adapter(connector: dict[str, Any]) -> HttpMcpAdapter:
+    settings = resolve_http_mcp_settings(connector)
+    return HttpMcpAdapter(
+        base_url=settings["base_url"],
+        headers=dict(settings["headers"]),
+        protocol_version=settings["protocol_version"],
+        skip_initialize=bool(settings["skip_initialize"]),
+    )
+
+
+class HttpMcpAdapter:
+    """Minimal MCP JSON-RPC client for tools/list and tools/call."""
+
+    provider_id = PROVIDER_ID
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        headers: dict[str, str],
+        protocol_version: str = DEFAULT_PROTOCOL_VERSION,
+        skip_initialize: bool = False,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._headers = dict(headers)
+        self._protocol_version = protocol_version
+        self._skip_initialize = skip_initialize
+        self._timeout = timeout_seconds
+        self._client = client
+        self._initialized = skip_initialize
+        self._next_id = 1
+
+    def _next_request_id(self) -> int:
+        rid = self._next_id
+        self._next_id += 1
+        return rid
+
+    def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            if self._client is not None:
+                response = self._client.post(
+                    self._base_url,
+                    json=payload,
+                    headers=self._headers,
+                    timeout=self._timeout,
+                )
+            else:
+                with httpx.Client(timeout=self._timeout) as client:
+                    response = client.post(self._base_url, json=payload, headers=self._headers)
+        except httpx.HTTPError as exc:
+            raise ConnectorProviderError(f"MCP HTTP request failed: {exc}") from exc
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise ConnectorProviderError("MCP endpoint returned non-JSON response") from exc
+        if not isinstance(body, dict):
+            raise ConnectorProviderError("MCP endpoint returned unexpected JSON payload")
+        if "error" in body and body["error"] is not None:
+            err = body["error"]
+            if isinstance(err, dict):
+                message = str(err.get("message") or err.get("code") or err)
+            else:
+                message = str(err)
+            raise ConnectorProviderError(f"MCP error: {message}")
+        if response.status_code >= 400:
+            raise ConnectorProviderError(f"MCP HTTP {response.status_code}: {body}")
+        result = body.get("result")
+        if not isinstance(result, dict):
+            return {"result": result}
+        return result
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        init_id = self._next_request_id()
+        self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": init_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": self._protocol_version,
+                    "capabilities": {},
+                    "clientInfo": {"name": "ax-gateway-connector", "version": "1.0"},
+                },
+            }
+        )
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+        self._initialized = True
+
+    def list_tools_raw(self) -> list[dict[str, Any]]:
+        self._ensure_initialized()
+        result = self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": self._next_request_id(),
+                "method": "tools/list",
+                "params": {},
+            }
+        )
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            return []
+        return [tool for tool in tools if isinstance(tool, dict)]
+
+    def execute_tool(
+        self,
+        tool_slug: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        version: str | None = None,
+        connected_account_id: str | None = None,
+    ) -> ToolCallResult:
+        _ = version, connected_account_id
+        name = str(tool_slug or "").strip()
+        if not name:
+            raise ConnectorProviderError("tool_slug is required")
+        self._ensure_initialized()
+        try:
+            result = self._post(
+                {
+                    "jsonrpc": "2.0",
+                    "id": self._next_request_id(),
+                    "method": "tools/call",
+                    "params": {"name": name, "arguments": dict(arguments or {})},
+                }
+            )
+        except ConnectorProviderError as exc:
+            return ToolCallResult(
+                provider=PROVIDER_ID,
+                tool_slug=name,
+                successful=False,
+                error=str(exc),
+                log_id=None,
+                raw={},
+            )
+        is_error = bool(result.get("isError"))
+        content = result.get("content")
+        return ToolCallResult(
+            provider=PROVIDER_ID,
+            tool_slug=name,
+            successful=not is_error,
+            data=content,
+            error="tool returned isError=true" if is_error else None,
+            log_id=None,
+            raw=result if isinstance(result, dict) else {"result": result},
+        )

--- a/ax_cli/connectors/providers/http_mcp_catalog.py
+++ b/ax_cli/connectors/providers/http_mcp_catalog.py
@@ -1,0 +1,97 @@
+"""Tool catalog helpers for HTTP MCP connectors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..filtering import ToolFilterPolicy, is_tool_allowed
+from .base import ToolCatalogEntry, ToolSearchResult
+from .http_mcp_adapter import HttpMcpAdapter
+
+
+def _entry_from_mcp_tool(tool: dict[str, Any]) -> ToolCatalogEntry | None:
+    name = str(tool.get("name") or "").strip()
+    if not name:
+        return None
+    description = str(tool.get("description") or "").strip()
+    return ToolCatalogEntry(
+        slug=name,
+        name=name,
+        description=description,
+        toolkit_slug=None,
+        toolkit_name=None,
+        version=None,
+        tags=(),
+    )
+
+
+def _entries_to_dicts(entries: list[ToolCatalogEntry]) -> list[dict[str, Any]]:
+    return [entry.to_dict() for entry in entries]
+
+
+def list_http_mcp_tools(
+    adapter: HttpMcpAdapter,
+    policy: ToolFilterPolicy,
+    *,
+    query: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """List tools via MCP ``tools/list`` and apply Gateway allow/deny policy."""
+    effective_limit = limit if limit is not None else policy.default_limit
+    effective_limit = max(1, min(int(effective_limit), 200))
+    raw_tools = adapter.list_tools_raw()
+    entries: list[ToolCatalogEntry] = []
+    for item in raw_tools:
+        entry = _entry_from_mcp_tool(item)
+        if entry is None:
+            continue
+        if query:
+            needle = str(query).strip().lower()
+            hay = f"{entry.name} {entry.description} {entry.slug}".lower()
+            if needle not in hay:
+                continue
+        if is_tool_allowed(entry.slug, policy):
+            entries.append(entry)
+        if len(entries) >= effective_limit:
+            break
+    return {
+        "tools": _entries_to_dicts(entries),
+        "count": len(entries),
+        "total_items": len(raw_tools),
+        "next_cursor": None,
+        "policy_applied": policy.has_allowlist or bool(policy.denied_patterns),
+    }
+
+
+def search_http_mcp_tools_catalog(
+    adapter: HttpMcpAdapter,
+    policy: ToolFilterPolicy,
+    use_case: str,
+    *,
+    limit: int | None = None,
+) -> ToolSearchResult:
+    """Text search over MCP tools/list results (no intent API)."""
+    page = list_http_mcp_tools(adapter, policy, query=use_case, limit=limit)
+    tools_raw = page.get("tools") if isinstance(page.get("tools"), list) else []
+    entries = [
+        ToolCatalogEntry(
+            slug=str(row.get("slug") or ""),
+            name=str(row.get("name") or ""),
+            description=str(row.get("description") or ""),
+            toolkit_slug=row.get("toolkit_slug"),
+            toolkit_name=row.get("toolkit_name"),
+            version=row.get("version"),
+            tags=tuple(row.get("tags") or ()),
+        )
+        for row in tools_raw
+        if isinstance(row, dict) and row.get("slug")
+    ]
+    return ToolSearchResult(
+        mode="catalog",
+        use_case=use_case,
+        tools=tuple(entries),
+        session_id=None,
+        successful=True,
+        error=None,
+        raw={"page": page},
+    )

--- a/ax_cli/connectors/providers/registry.py
+++ b/ax_cli/connectors/providers/registry.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from .base import ConnectorProviderError, ProviderAdapter
+from .catalog import SUPPORTED_PROVIDERS
 from .composio_adapter import build_composio_adapter
+from .http_mcp_adapter import build_http_mcp_adapter
 
 ProviderFactory = Callable[[dict[str, Any]], ProviderAdapter]
 
-SUPPORTED_PROVIDERS: frozenset[str] = frozenset({"composio"})
-
 _FACTORIES: dict[str, ProviderFactory] = {
     "composio": build_composio_adapter,
+    "http_mcp": build_http_mcp_adapter,
 }
 
 

--- a/ax_cli/connectors/providers/registry.py
+++ b/ax_cli/connectors/providers/registry.py
@@ -1,0 +1,27 @@
+"""Provider id → adapter factory."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .base import ConnectorProviderError, ProviderAdapter
+from .composio_adapter import build_composio_adapter
+
+ProviderFactory = Callable[[dict[str, Any]], ProviderAdapter]
+
+SUPPORTED_PROVIDERS: frozenset[str] = frozenset({"composio"})
+
+_FACTORIES: dict[str, ProviderFactory] = {
+    "composio": build_composio_adapter,
+}
+
+
+def get_provider_adapter(provider_id: str, connector: dict[str, Any]) -> ProviderAdapter:
+    """Instantiate the adapter for ``provider_id`` using ``connector`` row + auth env."""
+    pid = str(provider_id or "").strip().lower()
+    factory = _FACTORIES.get(pid)
+    if factory is None:
+        raise ConnectorProviderError(
+            f"unsupported connector provider {provider_id!r} (supported: {', '.join(sorted(SUPPORTED_PROVIDERS))})"
+        )
+    return factory(connector)

--- a/ax_cli/connectors/registry.py
+++ b/ax_cli/connectors/registry.py
@@ -1,0 +1,390 @@
+"""Filesystem-backed connector registry for the local Gateway.
+
+Each row describes an outbound integration (e.g. Composio MCP, custom HTTP MCP).
+Secrets must not live inline: use ``auth_ref`` for a path or vault key only.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ax_cli.gateway import gateway_dir
+
+CONNECTORS_SCHEMA_VERSION = 1
+
+# Slug-safe labels for operator UX and future dashboard/API use.
+_LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,63}$", re.IGNORECASE)
+
+_MAX_AUTH_REF_LEN = 2048
+_MAX_ID_LEN = 128
+
+
+class _UnsetType:
+    __slots__ = ()
+
+
+_UNSET: Any = _UnsetType()
+
+
+def connectors_registry_path() -> Path:
+    return gateway_dir() / "connectors.json"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def default_connectors_registry() -> dict[str, Any]:
+    return {"version": CONNECTORS_SCHEMA_VERSION, "connectors": []}
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any], *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            json.dump(payload, tmp, indent=2, sort_keys=True)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        assert tmp_path is not None
+        tmp_path.chmod(mode)
+        tmp_path.replace(path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def _read_raw(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return copy.deepcopy(default_connectors_registry())
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return copy.deepcopy(default_connectors_registry())
+    if not isinstance(raw, dict):
+        return copy.deepcopy(default_connectors_registry())
+    return raw
+
+
+def validate_connector_record(rec: dict[str, Any]) -> None:
+    """Raise ``ValueError`` with a human-readable message if ``rec`` is invalid."""
+    errs: list[str] = []
+    if not isinstance(rec, dict):
+        raise ValueError("connector row must be an object")
+    cid = str(rec.get("id") or "").strip()
+    name = str(rec.get("name") or "").strip()
+    provider = str(rec.get("provider") or "").strip()
+    if not cid:
+        errs.append("id is required")
+    elif len(cid) > _MAX_ID_LEN:
+        errs.append(f"id must be at most {_MAX_ID_LEN} characters")
+    if not name:
+        errs.append("name is required")
+    elif not _LABEL_RE.match(name):
+        errs.append("name must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
+    if not provider:
+        errs.append("provider is required")
+    elif not _LABEL_RE.match(provider):
+        errs.append("provider must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
+    enabled = rec.get("enabled", True)
+    if not isinstance(enabled, bool):
+        errs.append("enabled must be a boolean")
+    auth_ref = rec.get("auth_ref")
+    if auth_ref is not None and auth_ref != "":
+        if not isinstance(auth_ref, str):
+            errs.append("auth_ref must be a string or null")
+        elif len(auth_ref) > _MAX_AUTH_REF_LEN:
+            errs.append(
+                f"auth_ref must be at most {_MAX_AUTH_REF_LEN} characters (use a path or opaque ref, not inline secrets)"
+            )
+    cfg = rec.get("config", {})
+    if cfg is None:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        errs.append("config must be an object")
+    meta = rec.get("metadata", {})
+    if meta is None:
+        meta = {}
+    if not isinstance(meta, dict):
+        errs.append("metadata must be an object")
+    for key in ("created_at", "updated_at"):
+        val = rec.get(key)
+        if val is not None and val != "" and not isinstance(val, str):
+            errs.append(f"{key} must be a string or omitted")
+    if errs:
+        raise ValueError("; ".join(errs))
+
+
+def normalize_connector_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Return a new dict with defaults applied; does not validate beyond coercion."""
+    if not isinstance(rec, dict):
+        raise ValueError("connector row must be an object")
+    cid = str(rec.get("id") or "").strip() or str(uuid.uuid4())
+    name = str(rec.get("name") or "").strip()
+    provider = str(rec.get("provider") or "").strip()
+    enabled = rec.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = bool(enabled)
+    auth_ref_raw = rec.get("auth_ref")
+    if auth_ref_raw is None or auth_ref_raw == "":
+        auth_ref: str | None = None
+    else:
+        auth_ref = str(auth_ref_raw).strip() or None
+    cfg = rec.get("config") or {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    meta = rec.get("metadata") or {}
+    if not isinstance(meta, dict):
+        meta = {}
+    created = rec.get("created_at")
+    updated = rec.get("updated_at")
+    return {
+        "id": cid,
+        "name": name,
+        "provider": provider,
+        "enabled": enabled,
+        "auth_ref": auth_ref,
+        "config": dict(cfg),
+        "metadata": dict(meta),
+        "created_at": str(created) if created else _now_iso(),
+        "updated_at": str(updated) if updated else _now_iso(),
+    }
+
+
+def _connector_rows(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    items = registry.get("connectors")
+    if not isinstance(items, list):
+        return []
+    return [x for x in items if isinstance(x, dict)]
+
+
+def _coerce_registry(raw: dict[str, Any]) -> dict[str, Any]:
+    version = raw.get("version")
+    try:
+        v = int(version) if version is not None else CONNECTORS_SCHEMA_VERSION
+    except (TypeError, ValueError):
+        v = CONNECTORS_SCHEMA_VERSION
+    rows_in = raw.get("connectors")
+    if rows_in is None:
+        rows_in = []
+    if not isinstance(rows_in, list):
+        rows_in = []
+    connectors: list[dict[str, Any]] = []
+    for row in rows_in:
+        if not isinstance(row, dict):
+            continue
+        try:
+            normalized = normalize_connector_record(row)
+            validate_connector_record(normalized)
+        except ValueError:
+            continue
+        connectors.append(normalized)
+    return {"version": v, "connectors": connectors}
+
+
+def list_connectors(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a shallow copy of each connector row (safe for JSON serialization)."""
+    return [dict(x) for x in _connector_rows(registry)]
+
+
+def find_connector(registry: dict[str, Any], ref: str) -> dict[str, Any] | None:
+    """Return the live row dict from ``registry`` (mutations persist), or None."""
+    needle = str(ref or "").strip()
+    if not needle:
+        return None
+    lower = needle.lower()
+    for row in _connector_rows(registry):
+        if str(row.get("id") or "") == needle:
+            return row
+        if str(row.get("name") or "").lower() == lower:
+            return row
+    return None
+
+
+def assert_unique_connector_name(registry: dict[str, Any], name: str, *, exclude_id: str | None = None) -> None:
+    """Raise ``ValueError`` if another connector already uses this name (case-insensitive)."""
+    n = str(name or "").strip()
+    if not n:
+        raise ValueError("name is required")
+    eid = str(exclude_id or "").strip()
+    for row in _connector_rows(registry):
+        rid = str(row.get("id") or "")
+        if eid and rid == eid:
+            continue
+        if str(row.get("name") or "").strip().lower() == n.lower():
+            raise ValueError(f"connector name already in use: {row.get('name')!r}")
+
+
+def load_connectors_registry() -> dict[str, Any]:
+    path = connectors_registry_path()
+    raw = _read_raw(path)
+    coerced = _coerce_registry(raw)
+    coerced["version"] = CONNECTORS_SCHEMA_VERSION
+    return coerced
+
+
+def save_connectors_registry(registry: dict[str, Any]) -> Path:
+    """Validate and atomically persist the registry. Returns the file path."""
+    path = connectors_registry_path()
+    rows = _connector_rows(registry)
+    seen_ids: set[str] = set()
+    for row in rows:
+        validate_connector_record(row)
+        rid = str(row.get("id") or "")
+        if rid in seen_ids:
+            raise ValueError(f"duplicate connector id: {rid!r}")
+        seen_ids.add(rid)
+    names = [str(r.get("name") or "").strip().lower() for r in rows]
+    if len(names) != len(set(names)):
+        raise ValueError("duplicate connector name (case-insensitive)")
+    payload = {"version": CONNECTORS_SCHEMA_VERSION, "connectors": rows}
+    _atomic_write_json(path, payload)
+    return path
+
+
+def add_connector(
+    registry: dict[str, Any],
+    *,
+    name: str,
+    provider: str,
+    enabled: bool = True,
+    auth_ref: str | None = None,
+    config: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    assert_unique_connector_name(registry, name)
+    now = _now_iso()
+    rec = normalize_connector_record(
+        {
+            "id": str(uuid.uuid4()),
+            "name": name.strip(),
+            "provider": provider.strip(),
+            "enabled": enabled,
+            "auth_ref": auth_ref,
+            "config": dict(config or {}),
+            "metadata": dict(metadata or {}),
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    validate_connector_record(rec)
+    if not isinstance(registry.get("connectors"), list):
+        registry["connectors"] = []
+    registry["connectors"].append(rec)
+    return rec
+
+
+def update_connector(
+    registry: dict[str, Any],
+    ref: str,
+    *,
+    name: str | None = None,
+    provider: str | None = None,
+    enabled: bool | None = None,
+    auth_ref: Any = _UNSET,
+    clear_auth_ref: bool = False,
+    config: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Patch a connector. Use ``clear_auth_ref=True`` to drop ``auth_ref``."""
+    target = find_connector(registry, ref)
+    if not target:
+        return None
+    tid = str(target.get("id") or "")
+    changed = False
+    if clear_auth_ref and auth_ref is not _UNSET:
+        raise ValueError("cannot pass both clear_auth_ref and auth_ref")
+    if name is not None:
+        new_name = str(name).strip()
+        assert_unique_connector_name(registry, new_name, exclude_id=tid)
+        if str(target.get("name") or "").strip() != new_name:
+            target["name"] = new_name
+            changed = True
+    if provider is not None:
+        new_p = str(provider).strip()
+        if str(target.get("provider") or "").strip() != new_p:
+            target["provider"] = new_p
+            changed = True
+    if enabled is not None:
+        new_e = bool(enabled)
+        if bool(target.get("enabled", True)) != new_e:
+            changed = True
+        target["enabled"] = new_e
+    if clear_auth_ref:
+        if target.get("auth_ref") is not None:
+            changed = True
+        target["auth_ref"] = None
+    elif auth_ref is not _UNSET:
+        if auth_ref in (None, ""):
+            if target.get("auth_ref") is not None:
+                changed = True
+            target["auth_ref"] = None
+        elif isinstance(auth_ref, str):
+            new_val = auth_ref.strip() or None
+            if target.get("auth_ref") != new_val:
+                changed = True
+            target["auth_ref"] = new_val
+        else:
+            raise ValueError("auth_ref must be a string, empty string, or None")
+    if config is not None:
+        if not isinstance(config, dict):
+            raise ValueError("config must be an object")
+        target["config"] = dict(config)
+        changed = True
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            raise ValueError("metadata must be an object")
+        target["metadata"] = dict(metadata)
+        changed = True
+    if changed:
+        target["updated_at"] = _now_iso()
+    validate_connector_record(target)
+    return target
+
+
+def remove_connector(registry: dict[str, Any], ref: str) -> bool:
+    needle = str(ref or "").strip()
+    if not needle:
+        return False
+    lower = needle.lower()
+    items = registry.setdefault("connectors", [])
+    if not isinstance(items, list):
+        registry["connectors"] = []
+        items = registry["connectors"]
+    new_list: list[dict[str, Any]] = []
+    removed = False
+    for row in items:
+        if not isinstance(row, dict):
+            continue
+        rid = str(row.get("id") or "")
+        rname = str(row.get("name") or "").strip().lower()
+        if rid == needle or rname == lower:
+            removed = True
+            continue
+        new_list.append(row)
+    registry["connectors"] = new_list
+    return removed

--- a/ax_cli/connectors/registry.py
+++ b/ax_cli/connectors/registry.py
@@ -1,178 +1,36 @@
-"""Filesystem-backed connector registry for the local Gateway.
-
-Each row describes an outbound integration (e.g. Composio MCP, custom HTTP MCP).
-Secrets must not live inline: use ``auth_ref`` for a path or vault key only.
-"""
+"""Connector registry: load, save, and CRUD over ``connectors.json``."""
 
 from __future__ import annotations
 
-import copy
-import json
-import os
-import re
-import tempfile
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from ax_cli.gateway import gateway_dir
+from .constants import CONNECTORS_SCHEMA_VERSION, UNSET
+from .paths import connectors_registry_path  # re-exported for backward-compatible imports
+from .storage import atomic_write_json, read_json_object, utc_now_iso
+from .validation import (
+    coerce_connectors_registry,
+    default_connectors_registry,
+    normalize_connector_record,
+    validate_connector_record,
+)
 
-CONNECTORS_SCHEMA_VERSION = 1
-
-# Slug-safe labels for operator UX and future dashboard/API use.
-_LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,63}$", re.IGNORECASE)
-
-_MAX_AUTH_REF_LEN = 2048
-_MAX_ID_LEN = 128
-
-
-class _UnsetType:
-    __slots__ = ()
-
-
-_UNSET: Any = _UnsetType()
-
-
-def connectors_registry_path() -> Path:
-    return gateway_dir() / "connectors.json"
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def default_connectors_registry() -> dict[str, Any]:
-    return {"version": CONNECTORS_SCHEMA_VERSION, "connectors": []}
-
-
-def _atomic_write_json(path: Path, payload: dict[str, Any], *, mode: int = 0o600) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as tmp:
-            tmp_path = Path(tmp.name)
-            json.dump(payload, tmp, indent=2, sort_keys=True)
-            tmp.write("\n")
-            tmp.flush()
-            os.fsync(tmp.fileno())
-        assert tmp_path is not None
-        tmp_path.chmod(mode)
-        tmp_path.replace(path)
-    finally:
-        if tmp_path is not None and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
-    try:
-        path.chmod(mode)
-    except OSError:
-        pass
-
-
-def _read_raw(path: Path) -> dict[str, Any]:
-    if not path.exists():
-        return copy.deepcopy(default_connectors_registry())
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return copy.deepcopy(default_connectors_registry())
-    if not isinstance(raw, dict):
-        return copy.deepcopy(default_connectors_registry())
-    return raw
-
-
-def validate_connector_record(rec: dict[str, Any]) -> None:
-    """Raise ``ValueError`` with a human-readable message if ``rec`` is invalid."""
-    errs: list[str] = []
-    if not isinstance(rec, dict):
-        raise ValueError("connector row must be an object")
-    cid = str(rec.get("id") or "").strip()
-    name = str(rec.get("name") or "").strip()
-    provider = str(rec.get("provider") or "").strip()
-    if not cid:
-        errs.append("id is required")
-    elif len(cid) > _MAX_ID_LEN:
-        errs.append(f"id must be at most {_MAX_ID_LEN} characters")
-    if not name:
-        errs.append("name is required")
-    elif not _LABEL_RE.match(name):
-        errs.append("name must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
-    if not provider:
-        errs.append("provider is required")
-    elif not _LABEL_RE.match(provider):
-        errs.append("provider must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
-    enabled = rec.get("enabled", True)
-    if not isinstance(enabled, bool):
-        errs.append("enabled must be a boolean")
-    auth_ref = rec.get("auth_ref")
-    if auth_ref is not None and auth_ref != "":
-        if not isinstance(auth_ref, str):
-            errs.append("auth_ref must be a string or null")
-        elif len(auth_ref) > _MAX_AUTH_REF_LEN:
-            errs.append(
-                f"auth_ref must be at most {_MAX_AUTH_REF_LEN} characters (use a path or opaque ref, not inline secrets)"
-            )
-    cfg = rec.get("config", {})
-    if cfg is None:
-        cfg = {}
-    if not isinstance(cfg, dict):
-        errs.append("config must be an object")
-    meta = rec.get("metadata", {})
-    if meta is None:
-        meta = {}
-    if not isinstance(meta, dict):
-        errs.append("metadata must be an object")
-    for key in ("created_at", "updated_at"):
-        val = rec.get(key)
-        if val is not None and val != "" and not isinstance(val, str):
-            errs.append(f"{key} must be a string or omitted")
-    if errs:
-        raise ValueError("; ".join(errs))
-
-
-def normalize_connector_record(rec: dict[str, Any]) -> dict[str, Any]:
-    """Return a new dict with defaults applied; does not validate beyond coercion."""
-    if not isinstance(rec, dict):
-        raise ValueError("connector row must be an object")
-    cid = str(rec.get("id") or "").strip() or str(uuid.uuid4())
-    name = str(rec.get("name") or "").strip()
-    provider = str(rec.get("provider") or "").strip()
-    enabled = rec.get("enabled", True)
-    if not isinstance(enabled, bool):
-        enabled = bool(enabled)
-    auth_ref_raw = rec.get("auth_ref")
-    if auth_ref_raw is None or auth_ref_raw == "":
-        auth_ref: str | None = None
-    else:
-        auth_ref = str(auth_ref_raw).strip() or None
-    cfg = rec.get("config") or {}
-    if not isinstance(cfg, dict):
-        cfg = {}
-    meta = rec.get("metadata") or {}
-    if not isinstance(meta, dict):
-        meta = {}
-    created = rec.get("created_at")
-    updated = rec.get("updated_at")
-    return {
-        "id": cid,
-        "name": name,
-        "provider": provider,
-        "enabled": enabled,
-        "auth_ref": auth_ref,
-        "config": dict(cfg),
-        "metadata": dict(meta),
-        "created_at": str(created) if created else _now_iso(),
-        "updated_at": str(updated) if updated else _now_iso(),
-    }
+# Re-export for callers that imported schema version from this module.
+__all__ = [
+    "CONNECTORS_SCHEMA_VERSION",
+    "add_connector",
+    "connectors_registry_path",
+    "default_connectors_registry",
+    "find_connector",
+    "list_connectors",
+    "load_connectors_registry",
+    "normalize_connector_record",
+    "remove_connector",
+    "save_connectors_registry",
+    "update_connector",
+    "validate_connector_record",
+]
 
 
 def _connector_rows(registry: dict[str, Any]) -> list[dict[str, Any]]:
@@ -180,30 +38,6 @@ def _connector_rows(registry: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(items, list):
         return []
     return [x for x in items if isinstance(x, dict)]
-
-
-def _coerce_registry(raw: dict[str, Any]) -> dict[str, Any]:
-    version = raw.get("version")
-    try:
-        v = int(version) if version is not None else CONNECTORS_SCHEMA_VERSION
-    except (TypeError, ValueError):
-        v = CONNECTORS_SCHEMA_VERSION
-    rows_in = raw.get("connectors")
-    if rows_in is None:
-        rows_in = []
-    if not isinstance(rows_in, list):
-        rows_in = []
-    connectors: list[dict[str, Any]] = []
-    for row in rows_in:
-        if not isinstance(row, dict):
-            continue
-        try:
-            normalized = normalize_connector_record(row)
-            validate_connector_record(normalized)
-        except ValueError:
-            continue
-        connectors.append(normalized)
-    return {"version": v, "connectors": connectors}
 
 
 def list_connectors(registry: dict[str, Any]) -> list[dict[str, Any]]:
@@ -241,8 +75,8 @@ def assert_unique_connector_name(registry: dict[str, Any], name: str, *, exclude
 
 def load_connectors_registry() -> dict[str, Any]:
     path = connectors_registry_path()
-    raw = _read_raw(path)
-    coerced = _coerce_registry(raw)
+    raw = read_json_object(path, default=default_connectors_registry())
+    coerced = coerce_connectors_registry(raw)
     coerced["version"] = CONNECTORS_SCHEMA_VERSION
     return coerced
 
@@ -262,7 +96,7 @@ def save_connectors_registry(registry: dict[str, Any]) -> Path:
     if len(names) != len(set(names)):
         raise ValueError("duplicate connector name (case-insensitive)")
     payload = {"version": CONNECTORS_SCHEMA_VERSION, "connectors": rows}
-    _atomic_write_json(path, payload)
+    atomic_write_json(path, payload)
     return path
 
 
@@ -277,7 +111,7 @@ def add_connector(
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     assert_unique_connector_name(registry, name)
-    now = _now_iso()
+    now = utc_now_iso()
     rec = normalize_connector_record(
         {
             "id": str(uuid.uuid4()),
@@ -305,7 +139,7 @@ def update_connector(
     name: str | None = None,
     provider: str | None = None,
     enabled: bool | None = None,
-    auth_ref: Any = _UNSET,
+    auth_ref: Any = UNSET,
     clear_auth_ref: bool = False,
     config: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
@@ -316,7 +150,7 @@ def update_connector(
         return None
     tid = str(target.get("id") or "")
     changed = False
-    if clear_auth_ref and auth_ref is not _UNSET:
+    if clear_auth_ref and auth_ref is not UNSET:
         raise ValueError("cannot pass both clear_auth_ref and auth_ref")
     if name is not None:
         new_name = str(name).strip()
@@ -338,7 +172,7 @@ def update_connector(
         if target.get("auth_ref") is not None:
             changed = True
         target["auth_ref"] = None
-    elif auth_ref is not _UNSET:
+    elif auth_ref is not UNSET:
         if auth_ref in (None, ""):
             if target.get("auth_ref") is not None:
                 changed = True
@@ -361,7 +195,7 @@ def update_connector(
         target["metadata"] = dict(metadata)
         changed = True
     if changed:
-        target["updated_at"] = _now_iso()
+        target["updated_at"] = utc_now_iso()
     validate_connector_record(target)
     return target
 

--- a/ax_cli/connectors/registry.py
+++ b/ax_cli/connectors/registry.py
@@ -116,7 +116,7 @@ def add_connector(
         {
             "id": str(uuid.uuid4()),
             "name": name.strip(),
-            "provider": provider.strip(),
+            "provider": provider.strip().lower(),
             "enabled": enabled,
             "auth_ref": auth_ref,
             "config": dict(config or {}),

--- a/ax_cli/connectors/storage.py
+++ b/ax_cli/connectors/storage.py
@@ -1,0 +1,61 @@
+"""Atomic JSON persistence helpers for connector state."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .constants import FILE_MODE_SECRET
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any], *, mode: int = FILE_MODE_SECRET) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            json.dump(payload, tmp, indent=2, sort_keys=True)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        assert tmp_path is not None
+        tmp_path.chmod(mode)
+        tmp_path.replace(path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def read_json_object(path: Path, *, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return copy.deepcopy(default)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return copy.deepcopy(default)
+    if not isinstance(raw, dict):
+        return copy.deepcopy(default)
+    return raw

--- a/ax_cli/connectors/types.py
+++ b/ax_cli/connectors/types.py
@@ -1,0 +1,24 @@
+"""Typed shapes for connector registry data (documentation and static checking)."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class ConnectorRecord(TypedDict, total=False):
+    """One row in ``connectors.json`` — secrets belong in auth env files, not here."""
+
+    id: str
+    name: str
+    provider: str
+    enabled: bool
+    auth_ref: str | None
+    config: dict[str, Any]
+    metadata: dict[str, Any]
+    created_at: str
+    updated_at: str
+
+
+class ConnectorRegistry(TypedDict):
+    version: int
+    connectors: list[ConnectorRecord]

--- a/ax_cli/connectors/validation.py
+++ b/ax_cli/connectors/validation.py
@@ -1,0 +1,129 @@
+"""Validate and normalize connector registry rows."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from .constants import (
+    CONNECTOR_LABEL_RE,
+    CONNECTORS_SCHEMA_VERSION,
+    MAX_AUTH_REF_LEN,
+    MAX_CONNECTOR_ID_LEN,
+)
+from .storage import utc_now_iso
+
+
+def validate_connector_record(rec: dict[str, Any]) -> None:
+    """Raise ``ValueError`` with a human-readable message if ``rec`` is invalid."""
+    errs: list[str] = []
+    if not isinstance(rec, dict):
+        raise ValueError("connector row must be an object")
+    cid = str(rec.get("id") or "").strip()
+    name = str(rec.get("name") or "").strip()
+    provider = str(rec.get("provider") or "").strip()
+    if not cid:
+        errs.append("id is required")
+    elif len(cid) > MAX_CONNECTOR_ID_LEN:
+        errs.append(f"id must be at most {MAX_CONNECTOR_ID_LEN} characters")
+    if not name:
+        errs.append("name is required")
+    elif not CONNECTOR_LABEL_RE.match(name):
+        errs.append("name must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
+    if not provider:
+        errs.append("provider is required")
+    elif not CONNECTOR_LABEL_RE.match(provider):
+        errs.append("provider must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
+    enabled = rec.get("enabled", True)
+    if not isinstance(enabled, bool):
+        errs.append("enabled must be a boolean")
+    auth_ref = rec.get("auth_ref")
+    if auth_ref is not None and auth_ref != "":
+        if not isinstance(auth_ref, str):
+            errs.append("auth_ref must be a string or null")
+        elif len(auth_ref) > MAX_AUTH_REF_LEN:
+            errs.append(
+                f"auth_ref must be at most {MAX_AUTH_REF_LEN} characters "
+                "(use a path or opaque ref, not inline secrets)"
+            )
+    cfg = rec.get("config", {})
+    if cfg is None:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        errs.append("config must be an object")
+    meta = rec.get("metadata", {})
+    if meta is None:
+        meta = {}
+    if not isinstance(meta, dict):
+        errs.append("metadata must be an object")
+    for key in ("created_at", "updated_at"):
+        val = rec.get(key)
+        if val is not None and val != "" and not isinstance(val, str):
+            errs.append(f"{key} must be a string or omitted")
+    if errs:
+        raise ValueError("; ".join(errs))
+
+
+def normalize_connector_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Return a new dict with defaults applied; does not validate beyond coercion."""
+    if not isinstance(rec, dict):
+        raise ValueError("connector row must be an object")
+    cid = str(rec.get("id") or "").strip() or str(uuid.uuid4())
+    name = str(rec.get("name") or "").strip()
+    provider = str(rec.get("provider") or "").strip()
+    enabled = rec.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = bool(enabled)
+    auth_ref_raw = rec.get("auth_ref")
+    if auth_ref_raw is None or auth_ref_raw == "":
+        auth_ref: str | None = None
+    else:
+        auth_ref = str(auth_ref_raw).strip() or None
+    cfg = rec.get("config") or {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    meta = rec.get("metadata") or {}
+    if not isinstance(meta, dict):
+        meta = {}
+    created = rec.get("created_at")
+    updated = rec.get("updated_at")
+    return {
+        "id": cid,
+        "name": name,
+        "provider": provider,
+        "enabled": enabled,
+        "auth_ref": auth_ref,
+        "config": dict(cfg),
+        "metadata": dict(meta),
+        "created_at": str(created) if created else utc_now_iso(),
+        "updated_at": str(updated) if updated else utc_now_iso(),
+    }
+
+
+def default_connectors_registry() -> dict[str, Any]:
+    return {"version": CONNECTORS_SCHEMA_VERSION, "connectors": []}
+
+
+def coerce_connectors_registry(raw: dict[str, Any]) -> dict[str, Any]:
+    """Parse on-disk JSON into a normalized in-memory registry."""
+    version = raw.get("version")
+    try:
+        v = int(version) if version is not None else CONNECTORS_SCHEMA_VERSION
+    except (TypeError, ValueError):
+        v = CONNECTORS_SCHEMA_VERSION
+    rows_in = raw.get("connectors")
+    if rows_in is None:
+        rows_in = []
+    if not isinstance(rows_in, list):
+        rows_in = []
+    connectors: list[dict[str, Any]] = []
+    for row in rows_in:
+        if not isinstance(row, dict):
+            continue
+        try:
+            normalized = normalize_connector_record(row)
+            validate_connector_record(normalized)
+        except ValueError:
+            continue
+        connectors.append(normalized)
+    return {"version": v, "connectors": connectors}

--- a/ax_cli/connectors/validation.py
+++ b/ax_cli/connectors/validation.py
@@ -11,6 +11,7 @@ from .constants import (
     MAX_AUTH_REF_LEN,
     MAX_CONNECTOR_ID_LEN,
 )
+from .providers.catalog import PROVIDER_HTTP_MCP, is_supported_provider
 from .storage import utc_now_iso
 
 
@@ -21,7 +22,7 @@ def validate_connector_record(rec: dict[str, Any]) -> None:
         raise ValueError("connector row must be an object")
     cid = str(rec.get("id") or "").strip()
     name = str(rec.get("name") or "").strip()
-    provider = str(rec.get("provider") or "").strip()
+    provider = str(rec.get("provider") or "").strip().lower()
     if not cid:
         errs.append("id is required")
     elif len(cid) > MAX_CONNECTOR_ID_LEN:
@@ -34,6 +35,11 @@ def validate_connector_record(rec: dict[str, Any]) -> None:
         errs.append("provider is required")
     elif not CONNECTOR_LABEL_RE.match(provider):
         errs.append("provider must be 1–64 chars: start with alphanumeric, then [a-zA-Z0-9_.-]")
+    elif not is_supported_provider(provider):
+        from .providers.catalog import SUPPORTED_PROVIDERS
+
+        supported = ", ".join(sorted(SUPPORTED_PROVIDERS))
+        errs.append(f"unsupported provider {provider!r} (supported: {supported})")
     enabled = rec.get("enabled", True)
     if not isinstance(enabled, bool):
         errs.append("enabled must be a boolean")
@@ -51,6 +57,10 @@ def validate_connector_record(rec: dict[str, Any]) -> None:
         cfg = {}
     if not isinstance(cfg, dict):
         errs.append("config must be an object")
+    elif provider == PROVIDER_HTTP_MCP:
+        base_url = str(cfg.get("base_url") or "").strip()
+        if not base_url:
+            errs.append("http_mcp requires config.base_url (MCP HTTP endpoint URL)")
     meta = rec.get("metadata", {})
     if meta is None:
         meta = {}

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -249,6 +249,10 @@ GATEWAY_ACTIVITY_EVENTS: dict[str, str] = {
     "tool_started": "tool",
     "tool_call_recorded": "tool",
     "tool_call_record_failed": "tool",
+    # connector outbound toolbelt (Composio, etc.)
+    "connector_tool_started": "tool",
+    "connector_tool_completed": "tool",
+    "connector_tool_failed": "result",
     # reply: agent posted a reply
     "reply_sent": "reply",
     # channel bridge lifecycle

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3931,6 +3931,13 @@ def sanitize_exec_env(prompt: str, entry: dict[str, Any]) -> dict[str, str]:
     hermes_repo_path = str(entry.get("hermes_repo_path") or "").strip()
     if hermes_repo_path:
         env["HERMES_REPO_PATH"] = hermes_repo_path
+    connector_ref = str(entry.get("connector_ref") or "").strip()
+    if not connector_ref:
+        meta = entry.get("metadata")
+        if isinstance(meta, dict):
+            connector_ref = str(meta.get("connector_ref") or "").strip()
+    if connector_ref:
+        env["AX_GATEWAY_CONNECTOR_REF"] = connector_ref
     return env
 
 

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3402,12 +3402,15 @@ def daemon_status() -> dict[str, Any]:
             pid = scanned[0]
             running = True
     registry = load_gateway_registry()
+    from ax_cli.connectors.registry import connectors_registry_path
+
     return {
         "pid": pid,
         "running": running,
         "gateway_dir": str(gateway_dir()),
         "gateway_environment": gateway_environment(),
         "registry_path": str(registry_path()),
+        "connectors_registry_path": str(connectors_registry_path()),
         "session_path": str(session_path()),
         "registry": registry,
     }

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3402,8 +3402,7 @@ def daemon_status() -> dict[str, Any]:
             pid = scanned[0]
             running = True
     registry = load_gateway_registry()
-    from ax_cli.connectors.auth import connectors_auth_env_base
-    from ax_cli.connectors.registry import connectors_registry_path
+    from ax_cli.connectors import connectors_auth_env_base, connectors_registry_path
 
     return {
         "pid": pid,

--- a/ax_cli/gateway.py
+++ b/ax_cli/gateway.py
@@ -3402,6 +3402,7 @@ def daemon_status() -> dict[str, Any]:
             pid = scanned[0]
             running = True
     registry = load_gateway_registry()
+    from ax_cli.connectors.auth import connectors_auth_env_base
     from ax_cli.connectors.registry import connectors_registry_path
 
     return {
@@ -3411,6 +3412,7 @@ def daemon_status() -> dict[str, Any]:
         "gateway_environment": gateway_environment(),
         "registry_path": str(registry_path()),
         "connectors_registry_path": str(connectors_registry_path()),
+        "connectors_auth_env_dir": str(connectors_auth_env_base()),
         "session_path": str(session_path()),
         "registry": registry,
     }

--- a/ax_cli/gateway_runtime_types.py
+++ b/ax_cli/gateway_runtime_types.py
@@ -389,6 +389,42 @@ def agent_template_catalog() -> dict[str, dict[str, Any]]:
                 "supports_command_override": True,
             },
         },
+        "langgraph_composio": {
+            "id": "langgraph_composio",
+            "label": "LangGraph + Composio",
+            "description": "LangGraph bridge that searches and runs tools via Gateway connectors (Composio).",
+            "availability": "ready",
+            "launchable": True,
+            "runtime_type": "exec",
+            "asset_class": "interactive_agent",
+            "intake_model": "launch_on_send",
+            "trigger_sources": ["direct_message"],
+            "return_paths": ["inline_reply"],
+            "telemetry_shape": "basic",
+            "suggested_name": "langgraph-composio-bot",
+            "operator_summary": (
+                "LangGraph round-trip with Composio intent search and optional RUN: tool execution "
+                "through the Gateway connector registry (no secrets in agent config)."
+            ),
+            "recommended_test_message": "List GitHub tools for listing repository stargazers.",
+            "what_you_need": [
+                "Python 3.11+ and a registered Composio connector (`ax gateway connectors add` + auth write).",
+                "Pass `--connector-ref <name>` when adding this agent.",
+                "Optional: `pip install langgraph` for a one-node StateGraph wrapper (same logic without it).",
+            ],
+            "setup_skill": "gateway-agent-setup",
+            "setup_skill_path": str(skill_path),
+            "defaults": {
+                "runtime_type": "exec",
+                "exec_command": "python3 examples/gateway_langgraph_composio/langgraph_composio_bridge.py",
+                "workdir": str(repo_root),
+            },
+            "signals": runtime_signals["exec"],
+            "advanced": {
+                "adapter_label": "Gateway-managed LangGraph + Composio bridge",
+                "supports_command_override": True,
+            },
+        },
         "strands": {
             "id": "strands",
             "label": "Strands",
@@ -638,6 +674,7 @@ def agent_template_list(*, include_advanced: bool = False) -> list[dict[str, Any
         "hermes",
         "ollama",
         "langgraph",
+        "langgraph_composio",
         "strands",
         "echo_test",
         "service_account",

--- a/ax_cli/gateway_runtime_types.py
+++ b/ax_cli/gateway_runtime_types.py
@@ -18,6 +18,10 @@ def _gateway_setup_skill_path() -> Path:
     return _repo_root() / "skills" / "gateway-agent-setup" / "SKILL.md"
 
 
+def _gateway_composio_skill_path() -> Path:
+    return _repo_root() / "skills" / "gateway-composio-connectors" / "SKILL.md"
+
+
 def _shared_signals() -> dict[str, str]:
     return {
         "delivery": "Gateway confirms when a message was queued or claimed.",
@@ -293,6 +297,7 @@ def runtime_type_list() -> list[dict[str, Any]]:
 def agent_template_catalog() -> dict[str, dict[str, Any]]:
     repo_root = _repo_root()
     skill_path = _gateway_setup_skill_path()
+    composio_skill_path = _gateway_composio_skill_path()
     runtime_signals = {
         key: runtime_type_definition(key)["signals"]
         for key in ("echo", "exec", "hermes_plugin", "hermes_sentinel", "sentinel_cli", "claude_code_channel", "inbox")
@@ -412,8 +417,8 @@ def agent_template_catalog() -> dict[str, dict[str, Any]]:
                 "Pass `--connector-ref <name>` when adding this agent.",
                 "Optional: `pip install langgraph` for a one-node StateGraph wrapper (same logic without it).",
             ],
-            "setup_skill": "gateway-agent-setup",
-            "setup_skill_path": str(skill_path),
+            "setup_skill": "gateway-composio-connectors",
+            "setup_skill_path": str(composio_skill_path),
             "defaults": {
                 "runtime_type": "exec",
                 "exec_command": "python3 examples/gateway_langgraph_composio/langgraph_composio_bridge.py",

--- a/docs/composio-integration.md
+++ b/docs/composio-integration.md
@@ -1,0 +1,206 @@
+# Composio integration via Gateway connectors
+
+Gateway connectors are the **outbound toolbelt** for managed agents: Composio (and future providers) run **outside** agent context, with secrets brokered by Gateway and tool exposure controlled by operator policy.
+
+This document is the operator reference for phases 1–7 of the connector stack. For a runnable graph demo, see [`examples/gateway_langgraph_composio/README.md`](../examples/gateway_langgraph_composio/README.md).
+
+## Two trust boundaries
+
+| Layer | Who authenticates | What it owns |
+|-------|-------------------|--------------|
+| **aX / Gateway** | Human bootstrap login + per-agent PATs | Spaces, messages, managed agent identity, connector registry rows |
+| **Composio** | API key + `user_id` (entity) per connector | Connected accounts (GitHub, Slack, …), tool catalog, tool execution |
+
+Rules:
+
+- **Never** put Composio API keys, OAuth tokens, or connected-account secrets in `connectors.json`, agent registry rows, workspace `.ax/config.toml`, chat, or PRs.
+- Store secrets only in Gateway-managed auth files (`gateway:managed`) or operator-chosen external env files referenced by `auth_ref`.
+- Runtime messages and activity rows use **redacted** connector metadata (name, provider, tool slug)—not secret values.
+
+## Connectors vs Claude Code MCP
+
+| Approach | Best for |
+|----------|----------|
+| **`ax gateway connectors`** (this doc) | Gateway-supervised agents, LangGraph bridges, CLI/scripted tool calls, centralized allow/deny policy |
+| **`ax channel setup` + `.mcp.json`** | Live Claude Code Channel sessions talking to remote aX MCP |
+| **Composio hosted MCP** (`https://mcp.composio.dev`) | Direct MCP clients (Cursor, ChatGPT connectors) **without** Gateway policy |
+
+Gateway connectors call Composio’s **HTTP tool API** directly. They do not require the Composio Python SDK at install time. Intent search uses Composio’s `COMPOSIO_SEARCH_TOOLS` plus Gateway filtering—not a full tool dump into the model.
+
+## On-disk layout
+
+Under `AX_GATEWAY_DIR` (default `~/.ax/gateway`, or `~/.ax/gateway/envs/<env>` when `AX_GATEWAY_ENV` is set):
+
+```text
+<connectors.json>              # registry rows (no secrets)
+connectors/auth/<connector-id>.env   # managed secrets (mode 0600) when auth_ref = gateway:managed
+activity.jsonl                 # connector_tool_* events on execute
+```
+
+Inspect paths:
+
+```bash
+ax gateway status --json    # connectors_registry_path, connectors_auth_env_dir
+```
+
+## Golden path setup
+
+### 1. Start Gateway and log in
+
+```bash
+pip install -e .
+ax gateway login
+ax gateway start
+```
+
+### 2. Register a Composio connector
+
+```bash
+ax gateway connectors add my_composio \
+  --provider composio \
+  --managed-auth \
+  --config-json '{
+    "user_id": "your-composio-entity-id",
+    "allowed_tools": ["GITHUB_*", "SLACK_*"],
+    "denied_tools": ["*_DELETE_*"],
+    "toolkits": ["github"],
+    "tools_limit": 25,
+    "search_mode": "auto",
+    "agent_name": "hermes"
+  }'
+```
+
+`user_id` is the Composio entity id for this connector (one human or one automation principal per connector row is recommended).
+
+Optional non-secret config keys:
+
+| Key | Purpose |
+|-----|---------|
+| `base_url` | Composio API base (default `https://backend.composio.dev`) |
+| `tool_version` / `version` | Tool version passed to execute |
+| `connected_account_id` | Execute as a specific connected account |
+| `agent_name` | Link activity rows to a Gateway registry agent name |
+| `allowed_tools` / `allow_tools` | fnmatch allowlist applied **after** Composio returns candidates |
+| `denied_tools` / `deny_tools` | fnmatch denylist |
+| `toolkits` / `toolkit_slug` / `toolkit` | Restrict catalog listing to toolkit slugs |
+| `tools_limit` | Max tools per list/search page (default 50, max 200) |
+| `search_mode` | `auto` \| `intent` \| `catalog` for `tools search` |
+
+### 3. Write auth secrets (managed)
+
+Create a local file **outside git** (example `composio.env`):
+
+```env
+COMPOSIO_API_KEY=your_key_here
+# Optional overrides:
+# COMPOSIO_USER_ID=entity-id
+# COMPOSIO_BASE_URL=https://backend.composio.dev
+```
+
+```bash
+ax gateway connectors auth write my_composio --from-file ./composio.env
+ax gateway connectors auth status my_composio
+```
+
+`auth status` is redacted—it confirms keys are present, not their values.
+
+### 4. Discover and test tools
+
+```bash
+# Intent / catalog search (Composio-native, then Gateway policy)
+ax gateway connectors tools search my_composio \
+  --use-case "list stargazers for a GitHub repo"
+
+# Catalog browse
+ax gateway connectors tools list my_composio --toolkit github --query stargazers
+
+# Execute one tool
+ax gateway connectors call my_composio \
+  --tool GITHUB_LIST_STARGAZERS \
+  --args-json '{"owner":"ComposioHQ","repo":"composio","per_page":5}'
+```
+
+### 5. Observe activity
+
+```bash
+ax gateway activity
+```
+
+On execute, Gateway appends `connector_tool_started`, `connector_tool_completed`, or `connector_tool_failed` with tool name `composio/<TOOL_SLUG>`.
+
+## LangGraph demo agent
+
+Register an agent that searches (and optionally executes) via connectors on each mention:
+
+```bash
+ax gateway agents add composio-graph \
+  --template langgraph_composio \
+  --connector-ref my_composio
+```
+
+Mention examples:
+
+```text
+@composio-graph find GitHub tools for listing repository stargazers
+@composio-graph RUN:GITHUB_LIST_STARGAZERS {"owner":"ComposioHQ","repo":"composio","per_page":3}
+```
+
+The bridge sets `AX_GATEWAY_CONNECTOR_REF` from the agent’s `connector_ref` field. See the example README for manual bridge runs.
+
+Agents setting up connectors should use the companion skill [`skills/gateway-composio-connectors/SKILL.md`](../skills/gateway-composio-connectors/SKILL.md).
+
+## External auth file (advanced)
+
+Instead of `--managed-auth`, reference an existing env file:
+
+```bash
+ax gateway connectors add my_composio \
+  --provider composio \
+  --auth-ref /absolute/path/to/composio.env \
+  --config-json '{"user_id":"entity-id"}'
+```
+
+Gateway does not copy or chmod external files; the operator owns permissions and rotation.
+
+## Security checklist
+
+- [ ] API keys only in managed `connectors/auth/*.env` or approved external paths
+- [ ] `connectors.json` and `gateway/registry.json` contain no secrets
+- [ ] Allow/deny patterns documented for each connector (`allowed_tools`, `denied_tools`)
+- [ ] One Composio `user_id` per automation principal (avoid shared entities across unrelated agents)
+- [ ] Agent runtime uses **agent PAT**, not user bootstrap PAT, for aX calls
+- [ ] PRs and chat never include `composio.env` contents
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|----------------|-----|
+| `Composio API key missing` | Auth file empty or wrong key name | `auth write` with `COMPOSIO_API_KEY`; `auth status` |
+| `user_id missing` | Config and env both empty | Set `config.user_id` or `COMPOSIO_USER_ID` in auth env |
+| `tool … is not allowed` | Gateway allow/deny policy | Adjust `allowed_tools` / `denied_tools`; `tools search` to see filtered set |
+| `unknown connector` | Typo or wrong Gateway dir | `connectors list`; confirm `AX_GATEWAY_DIR` / `AX_GATEWAY_ENV` |
+| `No such command 'connectors'` | Old PyPI `axctl` install | `pip install -e .` from this repo |
+| Bridge: `AX_GATEWAY_CONNECTOR_REF` required | Agent missing `--connector-ref` | `agents update <name> --connector-ref my_composio` |
+| 401 from Composio | Invalid or short API key | Rotate key in Composio dashboard; re-`auth write` |
+
+## CLI reference
+
+| Command | Purpose |
+|---------|---------|
+| `ax gateway connectors list` | Registry rows |
+| `ax gateway connectors show <ref>` | Row + redacted auth status |
+| `ax gateway connectors add` | New row (`--managed-auth`, `--config-json`) |
+| `ax gateway connectors set` | Enable/disable, update config |
+| `ax gateway connectors remove` | Remove row; release managed auth if unused |
+| `ax gateway connectors auth write` | Copy secrets into managed env |
+| `ax gateway connectors auth status` | Redacted key presence |
+| `ax gateway connectors tools list` | Composio catalog + policy |
+| `ax gateway connectors tools search` | Intent/catalog search + policy |
+| `ax gateway connectors call` | Execute tool by slug |
+| `ax gateway connectors providers` | Supported provider ids (`composio`) |
+
+## Related docs
+
+- [Gateway agent runtimes](gateway-agent-runtimes.md) — managed agents and exec bridges
+- [Credential security](credential-security.md) — PAT handling and workspace boundaries
+- [Gateway demo script](gateway-demo-script.md) — broader Gateway walkthrough

--- a/docs/composio-integration.md
+++ b/docs/composio-integration.md
@@ -197,7 +197,30 @@ Gateway does not copy or chmod external files; the operator owns permissions and
 | `ax gateway connectors tools list` | Composio catalog + policy |
 | `ax gateway connectors tools search` | Intent/catalog search + policy |
 | `ax gateway connectors call` | Execute tool by slug |
-| `ax gateway connectors providers` | Supported provider ids (`composio`) |
+| `ax gateway connectors providers` | Provider catalog (capabilities per type) |
+
+## Multi-provider support
+
+Gateway ships two connector provider types:
+
+| Provider | Execute | List tools | Intent search | Auth env keys |
+|----------|---------|------------|---------------|---------------|
+| `composio` | Composio HTTP tool API | Composio catalog API | `COMPOSIO_SEARCH_TOOLS` | `COMPOSIO_API_KEY`, `COMPOSIO_USER_ID`, … |
+| `http_mcp` | MCP `tools/call` | MCP `tools/list` | Catalog text match only | `MCP_BEARER_TOKEN`, `MCP_AUTHORIZATION`, `MCP_API_KEY` |
+
+**`http_mcp`** is for any MCP server exposed over HTTP JSON-RPC (self-hosted, Composio hosted MCP URL, etc.). Registry config must include `config.base_url`. Optional: `protocol_version`, `skip_initialize`, `api_key_header`.
+
+Example registry row (CLI or dashboard):
+
+```bash
+ax gateway connectors add my_mcp --provider http_mcp --managed-auth \
+  --config-json '{"base_url":"https://mcp.example.com/rpc","skip_initialize":true}'
+ax gateway connectors auth write my_mcp --from-file ./mcp.env   # MCP_BEARER_TOKEN=...
+ax gateway connectors tools list my_mcp
+ax gateway connectors call my_mcp echo --args-json '{"message":"hi"}'
+```
+
+Operator UI: provider dropdown is populated from `GET /api/connectors/providers`.
 
 ## Related docs
 

--- a/docs/gateway-agent-runtimes.md
+++ b/docs/gateway-agent-runtimes.md
@@ -64,6 +64,25 @@ Use `hermes_sentinel` for coding sentinel QA. Avoid using a one-shot `exec`
 bridge as proof that `dev_sentinel` is fixed. It can prove Gateway dispatch,
 but not the session continuity that made the old sentinel setup useful.
 
+### Outbound connectors (Composio)
+
+Gateway can register **outbound connectors**—provider toolbelts brokered locally,
+separate from Claude Code `.mcp.json` or remote aX MCP.
+
+- Registry: `connectors.json` under the Gateway dir (no secrets in rows).
+- Auth: managed `connectors/auth/<id>.env` or external env paths via `auth_ref`.
+- CLI: `ax gateway connectors …` (list, auth, `tools search`, `call`).
+- Policy: `allowed_tools` / `denied_tools` fnmatch on catalog, search, and execute.
+- Activity: `connector_tool_*` events in `activity.jsonl` on execute.
+
+The `langgraph_composio` template runs a demo bridge that intent-searches
+Composio per mention and optionally executes `RUN:<TOOL_SLUG> {json}` through
+the connector layer. Operators pass `--connector-ref` when adding the agent.
+
+Full setup, security rules, and troubleshooting:
+[composio-integration.md](composio-integration.md). Agent skill:
+`skills/gateway-composio-connectors/SKILL.md`.
+
 ## Preferred Runtime Patterns
 
 ### Hermes Sentinel

--- a/examples/gateway_langgraph_composio/README.md
+++ b/examples/gateway_langgraph_composio/README.md
@@ -1,8 +1,10 @@
 # gateway_langgraph_composio — LangGraph + Gateway Composio connector demo
 
 Runnable example showing how a Gateway-managed LangGraph agent can use the
-**connector toolbelt** (phases 1–6) instead of dumping thousands of Composio
-tools into context.
+**connector toolbelt** instead of dumping thousands of Composio tools into context.
+
+Operator reference: [`docs/composio-integration.md`](../../docs/composio-integration.md).  
+Agent skill: [`skills/gateway-composio-connectors/SKILL.md`](../../skills/gateway-composio-connectors/SKILL.md).
 
 ## What it proves
 

--- a/examples/gateway_langgraph_composio/README.md
+++ b/examples/gateway_langgraph_composio/README.md
@@ -1,0 +1,64 @@
+# gateway_langgraph_composio — LangGraph + Gateway Composio connector demo
+
+Runnable example showing how a Gateway-managed LangGraph agent can use the
+**connector toolbelt** (phases 1–6) instead of dumping thousands of Composio
+tools into context.
+
+## What it proves
+
+- **Intent search** via `search_connector_tools` (Composio `COMPOSIO_SEARCH_TOOLS` + Gateway allow/deny).
+- **Optional execute** when the operator includes `RUN:<TOOL_SLUG> {"arg": "value"}` in the mention.
+- **Activity**: Gateway records connector execute events; the bridge emits `tool_start` / `tool_result` for search.
+
+## Prerequisites
+
+1. Gateway repo installed editable: `pip install -e .`
+2. A Composio connector registered and authed:
+
+```bash
+ax gateway connectors add my_composio --provider composio --managed-auth \
+  --config-json '{"user_id":"your-composio-user-id","allowed_tools":["GITHUB_*"]}'
+ax gateway connectors auth write my_composio --from-file ./composio.env
+```
+
+3. Optional: `pip install langgraph` (bridge runs without it using the same logic sequentially).
+
+## Register the agent
+
+```bash
+ax gateway agents add composio-graph \
+  --template langgraph_composio \
+  --connector-ref my_composio
+```
+
+Send a mention, for example:
+
+```text
+@composio-graph list stargazers for ComposioHQ/composio
+```
+
+To execute after search:
+
+```text
+@composio-graph RUN:GITHUB_LIST_STARGAZERS {"owner":"ComposioHQ","repo":"composio","per_page":3}
+```
+
+## Manual bridge run
+
+```bash
+export AX_GATEWAY_DIR=~/.ax/gateway   # or your gateway dir
+export AX_GATEWAY_CONNECTOR_REF=my_composio
+python3 examples/gateway_langgraph_composio/langgraph_composio_bridge.py "list github stars tools"
+```
+
+## Architecture
+
+```
+  mention → Gateway exec → langgraph_composio_bridge.py
+                │
+                ├─ search_connector_tools (Gateway + Composio API)
+                ├─ optional execute_connector_tool (RUN: directive)
+                └─ stdout reply + AX_GATEWAY_EVENT tool/status lines
+```
+
+Secrets stay in `connectors/auth/<id>.env` (managed) — never in the agent registry row.

--- a/examples/gateway_langgraph_composio/langgraph_composio_bridge.py
+++ b/examples/gateway_langgraph_composio/langgraph_composio_bridge.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Gateway-managed LangGraph bridge with Composio connector toolbelt.
+
+Designed for ``ax gateway agents add ... --template langgraph_composio
+--connector-ref <name>``.
+
+Per mention the bridge:
+  1. Searches Composio tools via Gateway ``search_connector_tools`` (intent/catalog).
+  2. Optionally executes one tool when the prompt contains ``RUN:<SLUG> {json}``.
+  3. Prints a short operator-facing reply on stdout.
+
+Gateway records connector activity on execute; the bridge emits AX_GATEWAY_EVENT
+tool_start/tool_result lines for search so the monitor shows the round trip.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from typing import Any, Callable
+
+EVENT_PREFIX = "AX_GATEWAY_EVENT "
+_RUN_RE = re.compile(
+    r"(?i)\bRUN:\s*([A-Z][A-Z0-9_]*)\s*(\{.*\})?\s*$",
+    re.MULTILINE,
+)
+
+
+def emit_event(payload: dict[str, Any]) -> None:
+    print(f"{EVENT_PREFIX}{json.dumps(payload, sort_keys=True)}", flush=True)
+
+
+def _read_prompt() -> str:
+    if len(sys.argv) > 1 and sys.argv[-1] != "-":
+        return sys.argv[-1]
+    env_prompt = os.environ.get("AX_MENTION_CONTENT", "").strip()
+    if env_prompt:
+        return env_prompt
+    return sys.stdin.read().strip()
+
+
+def _agent_name() -> str:
+    return (
+        os.environ.get("AX_GATEWAY_AGENT_NAME", "").strip()
+        or os.environ.get("AX_AGENT_NAME", "").strip()
+        or "langgraph-composio-bot"
+    )
+
+
+def _connector_ref() -> str:
+    return os.environ.get("AX_GATEWAY_CONNECTOR_REF", "").strip()
+
+
+def _parse_run_directive(prompt: str) -> tuple[str | None, dict[str, Any]]:
+    match = _RUN_RE.search(prompt)
+    if not match:
+        return None, {}
+    slug = match.group(1).upper()
+    raw_args = (match.group(2) or "").strip()
+    if not raw_args:
+        return slug, {}
+    try:
+        parsed = json.loads(raw_args)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"RUN:{slug} arguments must be valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"RUN:{slug} arguments must be a JSON object")
+    return slug, parsed
+
+
+def _default_search(connector_ref: str, use_case: str) -> Any:
+    from ax_cli.connectors import search_connector_tools
+
+    return search_connector_tools(connector_ref, use_case)
+
+
+def _default_execute(connector_ref: str, tool_slug: str, arguments: dict[str, Any]) -> Any:
+    from ax_cli.connectors import execute_connector_tool
+
+    return execute_connector_tool(connector_ref, tool_slug, arguments)
+
+
+def run_connector_round(
+    prompt: str,
+    connector_ref: str,
+    *,
+    search_tools: Callable[[str, str], Any] | None = None,
+    execute_tool: Callable[[str, str, dict[str, Any]], Any] | None = None,
+) -> str:
+    """Search (and optionally execute) via Gateway connectors; return reply text."""
+    search_fn = search_tools or _default_search
+    execute_fn = execute_tool or _default_execute
+    run_slug, run_args = _parse_run_directive(prompt)
+
+    search_call_id = f"composio-search-{uuid.uuid4()}"
+    emit_event(
+        {
+            "kind": "tool_start",
+            "tool_name": "composio/search_tools",
+            "tool_action": "search",
+            "tool_call_id": search_call_id,
+            "status": "tool_call",
+            "arguments": {"use_case": prompt[:500], "connector_ref": connector_ref},
+            "message": "Searching Composio tools for mention",
+        }
+    )
+    started = time.monotonic()
+    search_result = search_fn(connector_ref, prompt)
+    slugs = [tool.slug for tool in search_result.tools]
+    emit_event(
+        {
+            "kind": "tool_result",
+            "tool_name": "composio/search_tools",
+            "tool_action": "search",
+            "tool_call_id": search_call_id,
+            "status": "tool_complete",
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "initial_data": {
+                "mode": search_result.mode,
+                "successful": search_result.successful,
+                "tool_slugs": slugs,
+                "session_id": search_result.session_id,
+            },
+            "message": f"Composio search returned {len(slugs)} tool(s) after policy",
+        }
+    )
+
+    lines = [
+        f"LangGraph+Composio (@{_agent_name()}) via connector {connector_ref!r}:",
+        f"  search mode = {search_result.mode}, matched = {len(search_result.tools)}",
+    ]
+    if search_result.error:
+        lines.append(f"  search note = {search_result.error}")
+    for tool in search_result.tools[:8]:
+        desc = (tool.description or "").strip()
+        if len(desc) > 72:
+            desc = desc[:69] + "..."
+        lines.append(f"  - {tool.slug}: {tool.name}" + (f" — {desc}" if desc else ""))
+    if len(search_result.tools) > 8:
+        lines.append(f"  … and {len(search_result.tools) - 8} more")
+
+    if run_slug:
+        exec_call_id = f"composio-exec-{uuid.uuid4()}"
+        emit_event(
+            {
+                "kind": "tool_start",
+                "tool_name": f"composio/{run_slug}",
+                "tool_action": "execute",
+                "tool_call_id": exec_call_id,
+                "status": "tool_call",
+                "arguments": run_args,
+                "message": f"Executing {run_slug} via Gateway connector",
+            }
+        )
+        exec_started = time.monotonic()
+        try:
+            call_result = execute_fn(connector_ref, run_slug, run_args)
+        except Exception as exc:
+            emit_event(
+                {
+                    "kind": "tool_result",
+                    "tool_name": f"composio/{run_slug}",
+                    "tool_action": "execute",
+                    "tool_call_id": exec_call_id,
+                    "status": "tool_error",
+                    "duration_ms": int((time.monotonic() - exec_started) * 1000),
+                    "message": str(exc),
+                }
+            )
+            raise
+        emit_event(
+            {
+                "kind": "tool_result",
+                "tool_name": f"composio/{run_slug}",
+                "tool_action": "execute",
+                "tool_call_id": exec_call_id,
+                "status": "tool_complete",
+                "duration_ms": int((time.monotonic() - exec_started) * 1000),
+                "initial_data": call_result.to_dict(),
+                "message": "Composio tool execution finished",
+            }
+        )
+        status = "ok" if call_result.successful else "failed"
+        lines.append(f"  RUN:{run_slug} → {status}")
+        if call_result.error:
+            lines.append(f"    error = {call_result.error}")
+        elif call_result.data is not None:
+            preview = json.dumps(call_result.data, default=str)
+            if len(preview) > 240:
+                preview = preview[:237] + "..."
+            lines.append(f"    data = {preview}")
+    else:
+        lines.append("  Tip: append RUN:<TOOL_SLUG> {\"key\": \"value\"} to execute a matched tool.")
+
+    return "\n".join(lines)
+
+
+def _run_langgraph(prompt: str, connector_ref: str) -> str:
+    try:
+        from langgraph.graph import END, START, StateGraph
+    except ImportError:
+        emit_event(
+            {
+                "kind": "activity",
+                "activity": "langgraph not installed; running connector round sequentially",
+            }
+        )
+        return run_connector_round(prompt, connector_ref)
+
+    emit_event({"kind": "activity", "activity": "building LangGraph connector round-trip"})
+
+    def _search_node(state: dict[str, Any]) -> dict[str, Any]:
+        reply = run_connector_round(str(state.get("prompt") or ""), connector_ref)
+        return {"reply": reply}
+
+    graph = StateGraph(dict)
+    graph.add_node("connector_round", _search_node)
+    graph.add_edge(START, "connector_round")
+    graph.add_edge("connector_round", END)
+    app = graph.compile()
+    result = app.invoke({"prompt": prompt})
+    return str(result.get("reply") or "")
+
+
+def main() -> int:
+    prompt = _read_prompt()
+    if not prompt:
+        print("(no mention content received)", file=sys.stderr)
+        return 1
+
+    connector_ref = _connector_ref()
+    if not connector_ref:
+        print(
+            "LangGraph+Composio bridge requires AX_GATEWAY_CONNECTOR_REF "
+            "(set via `ax gateway agents add --connector-ref <name>`).",
+            file=sys.stderr,
+        )
+        return 1
+
+    started = time.monotonic()
+    emit_event(
+        {
+            "kind": "status",
+            "status": "processing",
+            "message": "Routing mention through LangGraph Composio bridge",
+        }
+    )
+
+    try:
+        reply = _run_langgraph(prompt, connector_ref)
+    except Exception as exc:
+        emit_event({"kind": "status", "status": "error", "error_message": str(exc)})
+        print(f"LangGraph Composio bridge failed: {exc}", file=sys.stderr)
+        return 1
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    emit_event(
+        {
+            "kind": "status",
+            "status": "completed",
+            "message": f"LangGraph Composio bridge completed in {duration_ms}ms",
+            "detail": {"duration_ms": duration_ms, "connector_ref": connector_ref},
+        }
+    )
+    print(reply)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -346,6 +346,14 @@ That flow is for:
 The browser UI is a human-readable view over the same Gateway state, but the
 setup flow itself must stay agent-operable through the CLI and local API.
 
+## Gateway Composio Connectors
+
+When the job is outbound Composio tools (registry, managed auth, intent search,
+policy, execute, or `langgraph_composio` agents), use
+[`gateway-composio-connectors`](gateway-composio-connectors/SKILL.md) and
+`docs/composio-integration.md`. Do not store Composio API keys in connector
+config JSON or agent registry rows.
+
 ## Troubleshooting
 
 | Error | Meaning | Fix |

--- a/skills/gateway-agent-setup/SKILL.md
+++ b/skills/gateway-agent-setup/SKILL.md
@@ -30,6 +30,7 @@ Use this skill when the task is:
    - `echo_test`
    - `ollama`
    - `hermes`
+   - `langgraph` / `langgraph_composio` (exec bridges; Composio variant needs a connector)
    - `claude_code_channel`
    - `pass_through`
 
@@ -74,7 +75,12 @@ uv run ax gateway agents add northstar --template hermes --workdir /absolute/pat
 uv run ax gateway agents add ollama-bot --template ollama
 uv run ax gateway agents add orion --template claude_code_channel --workdir /absolute/path/to/claude-workspace
 uv run ax gateway agents add codex-pass-through --template pass_through
+uv run ax gateway agents add composio-graph --template langgraph_composio --connector-ref my_composio
 ```
+
+For Composio outbound tools (registry, auth, search, execute), use the companion
+skill [`gateway-composio-connectors`](../gateway-composio-connectors/SKILL.md) and
+`docs/composio-integration.md` instead of embedding API keys in agent config.
 
 For Hermes and Claude Code Channel, always choose the directory the agent will
 actually run from. Do not let setup default to the `ax-cli` checkout just

--- a/skills/gateway-composio-connectors/SKILL.md
+++ b/skills/gateway-composio-connectors/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: gateway-composio-connectors
+description: |
+  Register, authenticate, search, filter, and execute Composio tools through
+  the Gateway connector registry. Use when setting up outbound toolbelt access
+  for managed agents, running ax gateway connectors commands, debugging connector
+  auth or policy, or wiring langgraph_composio agents with --connector-ref.
+---
+
+# Gateway Composio Connectors
+
+Use this skill when the task is **outbound SaaS tools via Composio** brokered by
+Gateway—not when configuring Claude Code `.mcp.json` or remote aX MCP (see
+`docs/composio-integration.md` for boundaries).
+
+## Principles
+
+1. **Gateway is the trust boundary for secrets.**
+   - Registry row: name, provider, `auth_ref`, non-secret `config`.
+   - Secrets: `connectors/auth/<id>.env` (`gateway:managed`) or an external env path.
+   - Never copy API keys into `connectors.json`, agent registry, workspace config, or chat.
+
+2. **Filter after Composio, before execute.**
+   - Composio intent search narrows thousands of tools to a small candidate set.
+   - Gateway `allowed_tools` / `denied_tools` (fnmatch) applies on catalog, search, and `call`.
+   - Prefer `tools search` over dumping full catalogs into agent context.
+
+3. **One Composio `user_id` per principal.**
+   - Map each connector row to one automation identity (agent, team bot, or human).
+   - Do not share entities across unrelated agents without an explicit operator decision.
+
+4. **Runtime actions use agent identity on aX.**
+   - User PAT bootstraps Gateway only.
+   - Managed agents use Gateway-minted agent tokens for platform calls.
+
+## First checks
+
+```bash
+uv run ax gateway status --json
+uv run ax gateway connectors list --json
+```
+
+Confirm `connectors_registry_path` and that the target connector row exists and is `enabled`.
+
+## Golden path
+
+### 1. Register connector (managed auth)
+
+```bash
+uv run ax gateway connectors add my_composio \
+  --provider composio \
+  --managed-auth \
+  --config-json '{"user_id":"<composio-entity-id>","allowed_tools":["GITHUB_*"],"search_mode":"auto"}'
+```
+
+### 2. Write secrets offline
+
+Create `composio.env` (never commit):
+
+```env
+COMPOSIO_API_KEY=<key>
+```
+
+```bash
+uv run ax gateway connectors auth write my_composio --from-file ./composio.env
+uv run ax gateway connectors auth status my_composio
+```
+
+### 3. Search before execute
+
+```bash
+uv run ax gateway connectors tools search my_composio \
+  --use-case "list GitHub stargazers for owner/repo" \
+  --json
+
+uv run ax gateway connectors tools list my_composio --toolkit github --limit 10 --json
+```
+
+### 4. Execute one tool
+
+```bash
+uv run ax gateway connectors call my_composio \
+  --tool GITHUB_LIST_STARGAZERS \
+  --args-json '{"owner":"ORG","repo":"REPO","per_page":5}' \
+  --json
+```
+
+### 5. Verify activity
+
+```bash
+uv run ax gateway activity
+```
+
+Expect `connector_tool_started` / `connector_tool_completed` (or `_failed`) with `tool_name` like `composio/GITHUB_LIST_STARGAZERS`.
+
+## LangGraph demo agent
+
+When the operator wants mention-driven search + optional execute:
+
+```bash
+uv run ax gateway agents add composio-graph \
+  --template langgraph_composio \
+  --connector-ref my_composio
+```
+
+Mention patterns:
+
+- Natural language → intent search only.
+- `RUN:<TOOL_SLUG> {"arg": "value"}` → search round + `execute_connector_tool`.
+
+Update connector binding without recreating the agent:
+
+```bash
+uv run ax gateway agents update composio-graph --connector-ref my_composio
+```
+
+## Policy tuning
+
+Edit connector config (non-secret) via `connectors set`:
+
+```bash
+uv run ax gateway connectors set my_composio \
+  --config-json '{"allowed_tools":["GITHUB_*"],"denied_tools":["*_DELETE_*"],"tools_limit":20}'
+```
+
+If `call` fails with “not allowed”, fix patterns before disabling the connector.
+
+## Optional activity linkage
+
+Set `agent_name` in connector config to the Gateway registry name of a managed agent so activity rows include that agent’s identity fields when present.
+
+## Output standard
+
+When finishing connector setup, report:
+
+- Connector name/id and provider
+- Whether auth status shows required keys (redacted)
+- A successful `tools search` or `call` result summary (tool slugs only, no secrets)
+- Any allow/deny patterns in effect
+- Next step (LangGraph agent, Hermes integration, or manual `call` only)
+
+## Anti-patterns
+
+- Putting `COMPOSIO_API_KEY` in `--config-json` or agent registry.
+- Sharing one Composio entity across unrelated agents without documenting it.
+- Executing tools before search when the slug is unknown (wastes context and risks wrong tool).
+- Using user bootstrap token to author agent messages while testing connectors.
+- Assuming PyPI `axctl` has `connectors` without verifying `pip install -e .` from this repo.
+
+## References
+
+- Operator doc: `docs/composio-integration.md`
+- Example bridge: `examples/gateway_langgraph_composio/README.md`
+- General Gateway agents: `skills/gateway-agent-setup/SKILL.md`

--- a/tests/test_composio_integration_docs.py
+++ b/tests/test_composio_integration_docs.py
@@ -1,0 +1,34 @@
+"""Phase 8: composio integration docs and operator skill are present and wired."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ax_cli.gateway_runtime_types import agent_template_definition
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOC_PATH = REPO_ROOT / "docs" / "composio-integration.md"
+SKILL_PATH = REPO_ROOT / "skills" / "gateway-composio-connectors" / "SKILL.md"
+
+
+def test_composio_integration_doc_exists() -> None:
+    assert DOC_PATH.is_file(), f"missing operator doc at {DOC_PATH}"
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert "ax gateway connectors" in text
+    assert "gateway:managed" in text or "managed-auth" in text
+    assert "allowed_tools" in text
+
+
+def test_gateway_composio_skill_exists() -> None:
+    assert SKILL_PATH.is_file(), f"missing skill at {SKILL_PATH}"
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    assert "name: gateway-composio-connectors" in text
+    assert "tools search" in text
+    assert "Never" in text or "never" in text
+
+
+def test_langgraph_composio_template_points_at_composio_skill() -> None:
+    template = agent_template_definition("langgraph_composio")
+    assert template["setup_skill"] == "gateway-composio-connectors"
+    skill_path = Path(str(template["setup_skill_path"]))
+    assert skill_path == SKILL_PATH

--- a/tests/test_connectors_activity.py
+++ b/tests/test_connectors_activity.py
@@ -1,0 +1,116 @@
+"""Tests for connector Gateway activity attribution."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from ax_cli.connectors.activity import (
+    connector_activity_fields,
+    record_connector_tool_finished,
+    record_connector_tool_started,
+)
+from ax_cli.connectors.auth import AUTH_REF_MANAGED, ensure_managed_auth_file
+from ax_cli.connectors.providers.base import ConnectorProviderError
+from ax_cli.connectors.providers.composio_adapter import ComposioAdapter, resolve_composio_settings
+from ax_cli.connectors.providers.dispatch import execute_connector_tool
+from ax_cli.connectors.registry import add_connector, load_connectors_registry, save_connectors_registry
+from ax_cli.gateway import activity_log_path, load_recent_gateway_activity
+
+
+def test_connector_activity_fields_redacted():
+    row = {
+        "id": "cid",
+        "name": "my_conn",
+        "provider": "composio",
+        "config": {"user_id": "u1", "agent_name": "hermes"},
+    }
+    fields = connector_activity_fields(row)
+    assert fields["connector_name"] == "my_conn"
+    assert fields["linked_agent_name"] == "hermes"
+    assert "user_id" not in fields
+
+
+def test_record_connector_tool_started_writes_activity(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    row = {"id": "1", "name": "c", "provider": "composio"}
+    rec = record_connector_tool_started(row, "GITHUB_LIST_STARGAZERS", tool_call_id="call-1")
+    assert rec["event"] == "connector_tool_started"
+    assert rec["phase"] == "tool"
+    assert rec["tool_call_id"] == "call-1"
+    assert rec["connector_name"] == "c"
+    path = activity_log_path()
+    assert path.exists()
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    payload = json.loads(lines[-1])
+    assert payload["event"] == "connector_tool_started"
+
+
+def test_execute_connector_tool_records_start_and_finish(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    rec = add_connector(
+        reg,
+        name="act_test",
+        provider="composio",
+        auth_ref=AUTH_REF_MANAGED,
+        config={"user_id": "u"},
+    )
+    save_connectors_registry(reg)
+    ensure_managed_auth_file(str(rec["id"]))
+    (tmp_path / "connectors" / "auth" / f"{rec['id']}.env").write_text("COMPOSIO_API_KEY=k\n", encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"successful": True, "data": {"n": 1}, "error": None, "log_id": "log_x"})
+
+    transport = httpx.MockTransport(handler)
+    mock_client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+
+    def _factory(connector: dict) -> ComposioAdapter:
+        settings = resolve_composio_settings(connector)
+        return ComposioAdapter(
+            api_key=settings["api_key"],
+            user_id=settings["user_id"],
+            base_url=settings["base_url"],
+            client=mock_client,
+        )
+
+    from ax_cli.connectors.providers import registry as provider_registry
+
+    monkeypatch.setitem(provider_registry._FACTORIES, "composio", _factory)
+
+    result = execute_connector_tool("act_test", "SOME_TOOL", {"a": 1})
+    assert result.successful is True
+
+    events = [item["event"] for item in load_recent_gateway_activity(limit=10)]
+    assert "connector_tool_started" in events
+    assert "connector_tool_completed" in events
+
+
+def test_execute_connector_tool_records_failure_on_provider_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    add_connector(reg, name="bad", provider="composio", auth_ref=AUTH_REF_MANAGED, config={})
+    save_connectors_registry(reg)
+    with pytest.raises(ConnectorProviderError):
+        execute_connector_tool("bad", "TOOL", {})
+    events = [item["event"] for item in load_recent_gateway_activity(limit=10)]
+    assert "connector_tool_started" in events
+    assert "connector_tool_failed" in events
+
+
+def test_record_connector_tool_finished_failed_phase(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    row = {"id": "1", "name": "c", "provider": "composio"}
+    rec = record_connector_tool_finished(
+        row,
+        "TOOL",
+        tool_call_id="call-2",
+        successful=False,
+        error="rate limited",
+    )
+    assert rec["event"] == "connector_tool_failed"
+    assert rec["phase"] == "result"
+    assert rec["successful"] is False

--- a/tests/test_connectors_auth.py
+++ b/tests/test_connectors_auth.py
@@ -103,7 +103,7 @@ def test_resolve_external_path(tmp_path, monkeypatch):
 def test_remove_connector_deletes_managed_file(tmp_path, monkeypatch):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
     reg = load_connectors_registry()
-    rec = add_connector(reg, name="m", provider="p", auth_ref=AUTH_REF_MANAGED)
+    rec = add_connector(reg, name="m", provider="composio", auth_ref=AUTH_REF_MANAGED)
     save_connectors_registry(reg)
     cid = str(rec["id"])
     ensure_managed_auth_file(cid)
@@ -119,7 +119,7 @@ def test_remove_connector_deletes_managed_file(tmp_path, monkeypatch):
 def test_update_clear_auth_releases_managed(tmp_path, monkeypatch):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
     reg = load_connectors_registry()
-    rec = add_connector(reg, name="u", provider="p", auth_ref=AUTH_REF_MANAGED)
+    rec = add_connector(reg, name="u", provider="composio", auth_ref=AUTH_REF_MANAGED)
     save_connectors_registry(reg)
     cid = str(rec["id"])
     ensure_managed_auth_file(cid)

--- a/tests/test_connectors_auth.py
+++ b/tests/test_connectors_auth.py
@@ -1,0 +1,135 @@
+"""Tests for ax_cli.connectors.auth."""
+
+from __future__ import annotations
+
+import json
+
+from ax_cli.connectors.auth import (
+    AUTH_REF_MANAGED,
+    connectors_auth_env_base,
+    delete_managed_auth_file,
+    ensure_managed_auth_file,
+    load_connector_auth_env,
+    parse_dotenv,
+    public_auth_status,
+    release_managed_auth_if_unused,
+    resolve_auth_env_path,
+    uses_managed_auth,
+    write_managed_auth_from_file,
+)
+from ax_cli.connectors.registry import (
+    add_connector,
+    find_connector,
+    load_connectors_registry,
+    remove_connector,
+    save_connectors_registry,
+    update_connector,
+)
+
+
+def test_parse_dotenv_basic():
+    text = """
+# c
+export FOO=bar
+BAZ='quoted'
+"""
+    d = parse_dotenv(text)
+    assert d["FOO"] == "bar"
+    assert d["BAZ"] == "quoted"
+
+
+def test_managed_path_and_load(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    cid = "test-connector-id-001"
+    p = ensure_managed_auth_file(cid)
+    assert p.parent == connectors_auth_env_base()
+    assert p.name == f"{cid}.env"
+    p.write_text("API_KEY=secret-value\n", encoding="utf-8")
+    row = {"id": cid, "auth_ref": AUTH_REF_MANAGED}
+    env = load_connector_auth_env(row)
+    assert env.get("API_KEY") == "secret-value"
+
+
+def test_public_auth_status_never_contains_values(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    cid = "uuid-here-0000"
+    ensure_managed_auth_file(cid)
+    env_path = connectors_auth_env_base() / f"{cid}.env"
+    env_path.write_text("TOKEN=supersecret\n", encoding="utf-8")
+    st = public_auth_status({"id": cid, "auth_ref": AUTH_REF_MANAGED})
+    dumped = json.dumps(st)
+    assert "supersecret" not in dumped
+    assert "TOKEN" in st.get("env_keys", [])
+
+
+def test_release_managed_auth_if_unused(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    cid = "rel-001"
+    ensure_managed_auth_file(cid)
+    env_path = connectors_auth_env_base() / f"{cid}.env"
+    assert env_path.is_file()
+    release_managed_auth_if_unused({"id": cid, "auth_ref": AUTH_REF_MANAGED}, auth_ref_after=None)
+    assert not env_path.is_file()
+
+
+def test_release_keeps_file_when_still_managed(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    cid = "rel-002"
+    ensure_managed_auth_file(cid)
+    env_path = connectors_auth_env_base() / f"{cid}.env"
+    release_managed_auth_if_unused({"id": cid, "auth_ref": AUTH_REF_MANAGED}, auth_ref_after=AUTH_REF_MANAGED)
+    assert env_path.is_file()
+
+
+def test_write_managed_auth_from_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    src = tmp_path / "src.env"
+    src.write_text("X=1\n", encoding="utf-8")
+    cid = "write-001"
+    dest = write_managed_auth_from_file(cid, src)
+    assert dest.is_file()
+    assert load_connector_auth_env({"id": cid, "auth_ref": AUTH_REF_MANAGED})["X"] == "1"
+
+
+def test_resolve_external_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    ext = tmp_path / "external.env"
+    ext.write_text("Y=2\n", encoding="utf-8")
+    row = {"id": "x", "auth_ref": str(ext)}
+    assert resolve_auth_env_path(row) == ext.resolve()
+    assert load_connector_auth_env(row)["Y"] == "2"
+
+
+def test_remove_connector_deletes_managed_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    rec = add_connector(reg, name="m", provider="p", auth_ref=AUTH_REF_MANAGED)
+    save_connectors_registry(reg)
+    cid = str(rec["id"])
+    ensure_managed_auth_file(cid)
+    env_path = connectors_auth_env_base() / f"{cid}.env"
+    assert env_path.is_file()
+    assert remove_connector(reg, "m") is True
+    save_connectors_registry(reg)
+    if uses_managed_auth({"id": cid, "auth_ref": AUTH_REF_MANAGED}):
+        delete_managed_auth_file(cid)
+    assert not env_path.is_file()
+
+
+def test_update_clear_auth_releases_managed(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    rec = add_connector(reg, name="u", provider="p", auth_ref=AUTH_REF_MANAGED)
+    save_connectors_registry(reg)
+    cid = str(rec["id"])
+    ensure_managed_auth_file(cid)
+    env_path = connectors_auth_env_base() / f"{cid}.env"
+    row = find_connector(reg, "u")
+    assert row is not None
+    snap = {"id": cid, "auth_ref": row.get("auth_ref")}
+    update_connector(reg, "u", clear_auth_ref=True)
+    save_connectors_registry(reg)
+    row2 = find_connector(reg, "u")
+    assert row2 is not None
+    release_managed_auth_if_unused(snap, auth_ref_after=str(row2.get("auth_ref") or "").strip() or None)
+    assert not env_path.is_file()

--- a/tests/test_connectors_composio_adapter.py
+++ b/tests/test_connectors_composio_adapter.py
@@ -1,0 +1,170 @@
+"""Tests for Composio provider adapter and connector tool dispatch."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from ax_cli.connectors.auth import AUTH_REF_MANAGED, ensure_managed_auth_file
+from ax_cli.connectors.providers.base import ConnectorProviderError
+from ax_cli.connectors.providers.composio_adapter import (
+    ComposioAdapter,
+    build_composio_adapter,
+    resolve_composio_settings,
+)
+from ax_cli.connectors.providers.dispatch import adapter_for_connector, execute_connector_tool
+from ax_cli.connectors.registry import add_connector, load_connectors_registry, save_connectors_registry
+
+
+def test_resolve_composio_settings_from_config_and_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    connector = {
+        "id": "cid-1",
+        "name": "c",
+        "provider": "composio",
+        "enabled": True,
+        "auth_ref": AUTH_REF_MANAGED,
+        "config": {"user_id": "user-abc", "base_url": "https://example.test"},
+    }
+    ensure_managed_auth_file("cid-1")
+    env_path = tmp_path / "connectors" / "auth" / "cid-1.env"
+    env_path.write_text("COMPOSIO_API_KEY=sk-test\n", encoding="utf-8")
+    settings = resolve_composio_settings(connector)
+    assert settings["api_key"] == "sk-test"
+    assert settings["user_id"] == "user-abc"
+    assert settings["base_url"] == "https://example.test"
+
+
+def test_resolve_composio_settings_missing_api_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    connector = {
+        "id": "cid-2",
+        "name": "c",
+        "provider": "composio",
+        "enabled": True,
+        "auth_ref": AUTH_REF_MANAGED,
+        "config": {"user_id": "u"},
+    }
+    ensure_managed_auth_file("cid-2")
+    with pytest.raises(ConnectorProviderError, match="API key"):
+        resolve_composio_settings(connector)
+
+
+def test_composio_adapter_execute_success():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/api/v3/tools/execute/GITHUB_LIST_STARGAZERS"
+        assert request.headers["x-api-key"] == "sk-test"
+        body = json.loads(request.content.decode())
+        assert body["user_id"] == "user-1"
+        assert body["arguments"]["owner"] == "ComposioHQ"
+        return httpx.Response(
+            200,
+            json={"successful": True, "data": {"items": []}, "error": None, "log_id": "log_1"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+    adapter = ComposioAdapter(
+        api_key="sk-test",
+        user_id="user-1",
+        base_url="https://backend.composio.dev",
+        client=client,
+    )
+    result = adapter.execute_tool(
+        "GITHUB_LIST_STARGAZERS",
+        {"owner": "ComposioHQ", "repo": "composio"},
+    )
+    assert result.successful is True
+    assert result.data == {"items": []}
+    assert result.log_id == "log_1"
+    assert result.error is None
+
+
+def test_composio_adapter_execute_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "invalid api key", "successful": False})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+    adapter = ComposioAdapter(
+        api_key="bad",
+        user_id="user-1",
+        base_url="https://backend.composio.dev",
+        client=client,
+    )
+    result = adapter.execute_tool("SOME_TOOL", {})
+    assert result.successful is False
+    assert "invalid api key" in (result.error or "")
+
+
+def test_execute_connector_tool_end_to_end(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    rec = add_connector(
+        reg,
+        name="my_composio",
+        provider="composio",
+        auth_ref=AUTH_REF_MANAGED,
+        config={"user_id": "gateway-agent-1"},
+    )
+    save_connectors_registry(reg)
+    ensure_managed_auth_file(str(rec["id"]))
+    env_path = tmp_path / "connectors" / "auth" / f"{rec['id']}.env"
+    env_path.write_text("COMPOSIO_API_KEY=sk-e2e\n", encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"successful": True, "data": {"ok": True}, "error": None},
+        )
+
+    transport = httpx.MockTransport(handler)
+    mock_client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+
+    def _factory(connector: dict) -> ComposioAdapter:
+        settings = resolve_composio_settings(connector)
+        return ComposioAdapter(
+            api_key=settings["api_key"],
+            user_id=settings["user_id"],
+            base_url=settings["base_url"],
+            client=mock_client,
+        )
+
+    from ax_cli.connectors.providers import registry as provider_registry
+
+    monkeypatch.setitem(provider_registry._FACTORIES, "composio", _factory)
+    result = execute_connector_tool("my_composio", "ECHO_TOOL", {"x": 1})
+    assert result.successful is True
+    assert result.data == {"ok": True}
+
+
+def test_adapter_for_connector_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    connector = {
+        "id": "x",
+        "name": "off",
+        "provider": "composio",
+        "enabled": False,
+        "config": {"user_id": "u"},
+    }
+    with pytest.raises(ConnectorProviderError, match="disabled"):
+        adapter_for_connector(connector)
+
+
+def test_build_composio_adapter(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    connector = {
+        "id": "b1",
+        "name": "c",
+        "provider": "composio",
+        "enabled": True,
+        "auth_ref": AUTH_REF_MANAGED,
+        "config": {"user_id": "u1"},
+    }
+    ensure_managed_auth_file("b1")
+    (tmp_path / "connectors" / "auth" / "b1.env").write_text("COMPOSIO_API_KEY=k\n", encoding="utf-8")
+    adapter = build_composio_adapter(connector)
+    assert adapter.provider_id == "composio"

--- a/tests/test_connectors_filtering.py
+++ b/tests/test_connectors_filtering.py
@@ -1,0 +1,166 @@
+"""Tests for connector tool filtering policy and Composio catalog APIs."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from ax_cli.connectors.auth import AUTH_REF_MANAGED
+from ax_cli.connectors.errors import ConnectorProviderError
+from ax_cli.connectors.filtering import is_tool_allowed, resolve_tool_filter_policy
+from ax_cli.connectors.providers.composio_adapter import ComposioAdapter
+from ax_cli.connectors.providers.composio_catalog import list_composio_tools, search_composio_tools_intent
+from ax_cli.connectors.providers.dispatch import execute_connector_tool, list_connector_tools
+from ax_cli.connectors.registry import add_connector, load_connectors_registry, save_connectors_registry
+
+
+def test_policy_allow_deny_patterns():
+    policy = resolve_tool_filter_policy(
+        {
+            "config": {
+                "allowed_tools": ["GITHUB_*"],
+                "denied_tools": ["*_DELETE_*"],
+            }
+        }
+    )
+    assert is_tool_allowed("GITHUB_LIST_ISSUES", policy)
+    assert not is_tool_allowed("SLACK_SEND_MESSAGE", policy)
+    assert not is_tool_allowed("GITHUB_DELETE_ISSUE", policy)
+
+
+def test_list_composio_tools_with_query():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert "/api/v3.1/tools" in request.url.path
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "slug": "GITHUB_LIST_STARGAZERS",
+                        "name": "List Stargazers",
+                        "description": "List stargazers",
+                        "toolkit": {"slug": "github", "name": "GitHub"},
+                        "version": "latest",
+                        "tags": [],
+                    },
+                    {
+                        "slug": "SLACK_SEND_MESSAGE",
+                        "name": "Send",
+                        "description": "Send slack",
+                        "toolkit": {"slug": "slack", "name": "Slack"},
+                        "version": "latest",
+                        "tags": [],
+                    },
+                ],
+                "total_items": 2,
+                "next_cursor": None,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+    adapter = ComposioAdapter(api_key="k", user_id="u", base_url="https://backend.composio.dev", client=client)
+    policy = resolve_tool_filter_policy({"config": {"allowed_tools": ["GITHUB_*"]}})
+    page = list_composio_tools(adapter, policy, query="stars")
+    assert page["count"] == 1
+    assert page["tools"][0]["slug"] == "GITHUB_LIST_STARGAZERS"
+
+
+def test_search_composio_tools_intent_parses_slugs():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json={"items": []})
+        body = json.loads(request.content.decode())
+        assert body["arguments"]["queries"][0]["use_case"] == "send github stars list"
+        return httpx.Response(
+            200,
+            json={
+                "successful": True,
+                "data": {
+                    "session": {"id": "sess-abc"},
+                    "tools": [{"tool_slug": "GITHUB_LIST_STARGAZERS"}, {"tool_slug": "SLACK_SEND_MESSAGE"}],
+                },
+                "error": None,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+    adapter = ComposioAdapter(api_key="k", user_id="u", base_url="https://backend.composio.dev", client=client)
+    policy = resolve_tool_filter_policy({"config": {"allowed_tools": ["GITHUB_*"]}})
+    result = search_composio_tools_intent(adapter, policy, "send github stars list")
+    assert result.successful is True
+    assert result.session_id == "sess-abc"
+    assert len(result.tools) == 1
+    assert result.tools[0].slug == "GITHUB_LIST_STARGAZERS"
+
+
+def test_execute_blocked_by_allowlist(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    add_connector(
+        reg,
+        name="filt",
+        provider="composio",
+        auth_ref=AUTH_REF_MANAGED,
+        config={"user_id": "u", "allowed_tools": ["GITHUB_*"]},
+    )
+    save_connectors_registry(reg)
+    with pytest.raises(ConnectorProviderError, match="not allowed"):
+        execute_connector_tool("filt", "SLACK_SEND_MESSAGE", {}, record_activity=False)
+
+
+def test_list_connector_tools_integration(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    rec = add_connector(
+        reg,
+        name="list_me",
+        provider="composio",
+        auth_ref=AUTH_REF_MANAGED,
+        config={"user_id": "u", "toolkits": ["github"]},
+    )
+    save_connectors_registry(reg)
+    (tmp_path / "connectors" / "auth").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "connectors" / "auth" / f"{rec['id']}.env").write_text("COMPOSIO_API_KEY=k\n", encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "slug": "GITHUB_LIST_STARGAZERS",
+                        "name": "List",
+                        "description": "d",
+                        "toolkit": {"slug": "github", "name": "GitHub"},
+                        "version": "v1",
+                        "tags": [],
+                    }
+                ],
+                "total_items": 1,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    mock_client = httpx.Client(transport=transport, base_url="https://backend.composio.dev")
+
+    def _factory(connector: dict) -> ComposioAdapter:
+        from ax_cli.connectors.providers.composio_adapter import resolve_composio_settings
+
+        settings = resolve_composio_settings(connector)
+        return ComposioAdapter(
+            api_key=settings["api_key"],
+            user_id=settings["user_id"],
+            base_url=settings["base_url"],
+            client=mock_client,
+        )
+
+    from ax_cli.connectors.providers import registry as provider_registry
+
+    monkeypatch.setitem(provider_registry._FACTORIES, "composio", _factory)
+    page = list_connector_tools("list_me", query="stars")
+    assert page["count"] == 1

--- a/tests/test_connectors_package.py
+++ b/tests/test_connectors_package.py
@@ -24,6 +24,7 @@ def test_public_api_matches_submodules():
     assert connectors.uses_managed_auth is auth_mod.uses_managed_auth
     assert connectors.execute_connector_tool is providers_mod.execute_connector_tool
     assert "composio" in connectors.SUPPORTED_PROVIDERS
+    assert "http_mcp" in connectors.SUPPORTED_PROVIDERS
 
 
 def test_package_exports_documented_symbols():

--- a/tests/test_connectors_package.py
+++ b/tests/test_connectors_package.py
@@ -13,6 +13,8 @@ import ax_cli.connectors.validation as validation_mod
 
 
 def test_public_api_matches_submodules():
+    import ax_cli.connectors.providers as providers_mod
+
     assert connectors.AUTH_REF_MANAGED is constants_mod.AUTH_REF_MANAGED
     assert connectors.CONNECTORS_SCHEMA_VERSION is constants_mod.CONNECTORS_SCHEMA_VERSION
     assert connectors.connectors_registry_path is paths_mod.connectors_registry_path
@@ -20,6 +22,8 @@ def test_public_api_matches_submodules():
     assert connectors.load_connectors_registry is registry_mod.load_connectors_registry
     assert connectors.parse_dotenv is envfile_mod.parse_dotenv
     assert connectors.uses_managed_auth is auth_mod.uses_managed_auth
+    assert connectors.execute_connector_tool is providers_mod.execute_connector_tool
+    assert "composio" in connectors.SUPPORTED_PROVIDERS
 
 
 def test_package_exports_documented_symbols():

--- a/tests/test_connectors_package.py
+++ b/tests/test_connectors_package.py
@@ -1,0 +1,49 @@
+"""Smoke tests for ax_cli.connectors package layout (phase 3)."""
+
+from __future__ import annotations
+
+import ax_cli.connectors as connectors
+import ax_cli.connectors.auth as auth_mod
+import ax_cli.connectors.constants as constants_mod
+import ax_cli.connectors.envfile as envfile_mod
+import ax_cli.connectors.paths as paths_mod
+import ax_cli.connectors.registry as registry_mod
+import ax_cli.connectors.storage as storage_mod
+import ax_cli.connectors.validation as validation_mod
+
+
+def test_public_api_matches_submodules():
+    assert connectors.AUTH_REF_MANAGED is constants_mod.AUTH_REF_MANAGED
+    assert connectors.CONNECTORS_SCHEMA_VERSION is constants_mod.CONNECTORS_SCHEMA_VERSION
+    assert connectors.connectors_registry_path is paths_mod.connectors_registry_path
+    assert connectors.connectors_auth_env_base is paths_mod.connectors_auth_env_base
+    assert connectors.load_connectors_registry is registry_mod.load_connectors_registry
+    assert connectors.parse_dotenv is envfile_mod.parse_dotenv
+    assert connectors.uses_managed_auth is auth_mod.uses_managed_auth
+
+
+def test_package_exports_documented_symbols():
+    expected = {
+        "AUTH_REF_MANAGED",
+        "CONNECTORS_SCHEMA_VERSION",
+        "ConnectorRecord",
+        "ConnectorRegistry",
+        "add_connector",
+        "connectors_auth_env_base",
+        "connectors_registry_path",
+        "load_connectors_registry",
+        "save_connectors_registry",
+    }
+    assert expected.issubset(set(connectors.__all__))
+
+
+def test_constants_single_source_of_truth():
+    assert constants_mod.AUTH_REF_MANAGED == "gateway:managed"
+    assert constants_mod.CONNECTORS_SCHEMA_VERSION == 1
+
+
+def test_validation_delegates_to_constants(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = validation_mod.default_connectors_registry()
+    assert reg["version"] == constants_mod.CONNECTORS_SCHEMA_VERSION
+    assert storage_mod.utc_now_iso().endswith("+00:00") or "T" in storage_mod.utc_now_iso()

--- a/tests/test_connectors_registry.py
+++ b/tests/test_connectors_registry.py
@@ -42,18 +42,18 @@ def test_add_list_save_load(tmp_path, monkeypatch):
 def test_duplicate_name_in_memory_raises(tmp_path, monkeypatch):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
     reg = cr.load_connectors_registry()
-    cr.add_connector(reg, name="alpha", provider="p1")
+    cr.add_connector(reg, name="alpha", provider="composio")
     with pytest.raises(ValueError, match="already in use"):
-        cr.add_connector(reg, name="ALPHA", provider="p2")
+        cr.add_connector(reg, name="ALPHA", provider="composio")
 
 
 def test_save_rejects_duplicate_ids(tmp_path, monkeypatch):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
     reg = cr.load_connectors_registry()
     reg.setdefault("connectors", []).append(
-        cr.normalize_connector_record({"id": "same", "name": "n1", "provider": "a"})
+        cr.normalize_connector_record({"id": "same", "name": "n1", "provider": "composio"})
     )
-    reg["connectors"].append(cr.normalize_connector_record({"id": "same", "name": "n2", "provider": "b"}))
+    reg["connectors"].append(cr.normalize_connector_record({"id": "same", "name": "n2", "provider": "composio"}))
     with pytest.raises(ValueError, match="duplicate connector id"):
         cr.save_connectors_registry(reg)
 
@@ -61,7 +61,7 @@ def test_save_rejects_duplicate_ids(tmp_path, monkeypatch):
 def test_find_and_remove(tmp_path, monkeypatch):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
     reg = cr.load_connectors_registry()
-    rec = cr.add_connector(reg, name="x", provider="y")
+    rec = cr.add_connector(reg, name="x", provider="composio")
     cid = str(rec["id"])
     assert cr.find_connector(reg, "x") is rec
     assert cr.find_connector(reg, cid) is rec
@@ -105,6 +105,6 @@ def test_validate_rejects_bad_name():
 def test_clear_auth_ref(tmp_path, monkeypatch):
     monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
     reg = cr.load_connectors_registry()
-    cr.add_connector(reg, name="c", provider="p", auth_ref="/tmp/x.env")
+    cr.add_connector(reg, name="c", provider="composio", auth_ref="/tmp/x.env")
     cr.update_connector(reg, "c", clear_auth_ref=True)
     assert cr.find_connector(reg, "c")["auth_ref"] is None

--- a/tests/test_connectors_registry.py
+++ b/tests/test_connectors_registry.py
@@ -1,0 +1,110 @@
+"""Tests for ax_cli.connectors.registry."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ax_cli.connectors import registry as cr
+
+
+def test_connectors_registry_path_respects_ax_gateway_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    p = cr.connectors_registry_path()
+    assert p == tmp_path / "connectors.json"
+
+
+def test_add_list_save_load(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = cr.load_connectors_registry()
+    cr.add_connector(
+        reg,
+        name="demo",
+        provider="composio",
+        auth_ref=str(tmp_path / "composio.env"),
+        config={"mcp_server_id": "srv_1"},
+    )
+    path = cr.save_connectors_registry(reg)
+    assert path == tmp_path / "connectors.json"
+    assert path.exists()
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["version"] == cr.CONNECTORS_SCHEMA_VERSION
+    assert len(raw["connectors"]) == 1
+    reg2 = cr.load_connectors_registry()
+    rows = cr.list_connectors(reg2)
+    assert len(rows) == 1
+    assert rows[0]["name"] == "demo"
+    assert rows[0]["provider"] == "composio"
+    assert rows[0]["config"]["mcp_server_id"] == "srv_1"
+
+
+def test_duplicate_name_in_memory_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = cr.load_connectors_registry()
+    cr.add_connector(reg, name="alpha", provider="p1")
+    with pytest.raises(ValueError, match="already in use"):
+        cr.add_connector(reg, name="ALPHA", provider="p2")
+
+
+def test_save_rejects_duplicate_ids(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = cr.load_connectors_registry()
+    reg.setdefault("connectors", []).append(
+        cr.normalize_connector_record({"id": "same", "name": "n1", "provider": "a"})
+    )
+    reg["connectors"].append(cr.normalize_connector_record({"id": "same", "name": "n2", "provider": "b"}))
+    with pytest.raises(ValueError, match="duplicate connector id"):
+        cr.save_connectors_registry(reg)
+
+
+def test_find_and_remove(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = cr.load_connectors_registry()
+    rec = cr.add_connector(reg, name="x", provider="y")
+    cid = str(rec["id"])
+    assert cr.find_connector(reg, "x") is rec
+    assert cr.find_connector(reg, cid) is rec
+    assert cr.remove_connector(reg, cid) is True
+    cr.save_connectors_registry(reg)
+    reg3 = cr.load_connectors_registry()
+    assert cr.list_connectors(reg3) == []
+
+
+def test_update_rename_and_disable(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = cr.load_connectors_registry()
+    cr.add_connector(reg, name="orig", provider="composio")
+    cr.save_connectors_registry(reg)
+    reg = cr.load_connectors_registry()
+    row = cr.find_connector(reg, "orig")
+    assert row is not None
+    cr.update_connector(reg, "orig", name="renamed", enabled=False)
+    cr.save_connectors_registry(reg)
+    reg2 = cr.load_connectors_registry()
+    assert cr.find_connector(reg2, "orig") is None
+    r2 = cr.find_connector(reg2, "renamed")
+    assert r2 is not None
+    assert r2["enabled"] is False
+
+
+def test_validate_rejects_bad_name():
+    with pytest.raises(ValueError, match="name"):
+        cr.validate_connector_record(
+            {
+                "id": "id1",
+                "name": "bad name!",
+                "provider": "p",
+                "enabled": True,
+                "config": {},
+                "metadata": {},
+            }
+        )
+
+
+def test_clear_auth_ref(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = cr.load_connectors_registry()
+    cr.add_connector(reg, name="c", provider="p", auth_ref="/tmp/x.env")
+    cr.update_connector(reg, "c", clear_auth_ref=True)
+    assert cr.find_connector(reg, "c")["auth_ref"] is None

--- a/tests/test_gateway_commands.py
+++ b/tests/test_gateway_commands.py
@@ -3409,6 +3409,8 @@ def test_render_gateway_ui_page_contains_local_dashboard_shell():
     assert "/api/status" in page
     assert "/api/templates" in page
     assert "/api/agents/&lt;name&gt;" in page
+    assert "/api/connectors" in page
+    assert "Outbound Connectors" in page
     assert "refreshMs = 2000" in page
     assert "Gateway Agent Setup" in page
     assert "gateway-agent-setup" in page
@@ -3424,10 +3426,11 @@ def test_gateway_templates_command_json():
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     ids = [item["id"] for item in payload["templates"]]
-    assert ids[:9] == [
+    assert ids[:10] == [
         "hermes",
         "ollama",
         "langgraph",
+        "langgraph_composio",
         "strands",
         "echo_test",
         "service_account",
@@ -3436,14 +3439,15 @@ def test_gateway_templates_command_json():
         "claude_code_channel",
     ]
     assert "inbox" not in ids
-    assert payload["count"] == 9
+    assert payload["count"] == 10
     ollama = next(item for item in payload["templates"] if item["id"] == "ollama")
     assert ollama["runtime_type"] == "exec"
     assert ollama["launchable"] is True
     assert ollama["asset_type_label"] == "On-Demand Agent"
     assert ollama["output_label"] == "Reply"
     assert ollama["setup_skill"] == "gateway-agent-setup"
-    assert ollama["setup_skill_path"].endswith("skills/gateway-agent-setup/SKILL.md")
+    assert Path(ollama["setup_skill_path"]).name == "SKILL.md"
+    assert "gateway-agent-setup" in ollama["setup_skill_path"]
     pass_through = next(item for item in payload["templates"] if item["id"] == "pass_through")
     assert pass_through["runtime_type"] == "inbox"
     assert pass_through["requires_approval"] is True
@@ -3579,7 +3583,8 @@ def test_gateway_ui_handler_serves_status_and_agent_detail(monkeypatch, tmp_path
             template_payload = templates.json()
             assert template_payload["templates"][0]["id"] == "hermes"
             assert template_payload["templates"][2]["id"] == "langgraph"
-            assert template_payload["templates"][3]["id"] == "strands"
+            assert template_payload["templates"][3]["id"] == "langgraph_composio"
+            assert template_payload["templates"][4]["id"] == "strands"
             assert template_payload["templates"][5]["id"] == "service_account"
             channel_template = next(
                 item for item in template_payload["templates"] if item["id"] == "claude_code_channel"

--- a/tests/test_gateway_langgraph_composio_demo.py
+++ b/tests/test_gateway_langgraph_composio_demo.py
@@ -1,0 +1,160 @@
+"""Regression: LangGraph + Composio connector demo template and bridge."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ax_cli import gateway as gateway_core
+from ax_cli.gateway_runtime_types import (
+    agent_template_catalog,
+    agent_template_definition,
+    agent_template_list,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BRIDGE_PATH = REPO_ROOT / "examples" / "gateway_langgraph_composio" / "langgraph_composio_bridge.py"
+
+
+def test_langgraph_composio_template_registered() -> None:
+    catalog = agent_template_catalog()
+    assert "langgraph_composio" in catalog
+    template = agent_template_definition("langgraph_composio")
+    assert template["runtime_type"] == "exec"
+    assert "langgraph_composio_bridge.py" in str((template.get("defaults") or {}).get("exec_command") or "")
+
+
+def test_langgraph_composio_listed_in_default_ordering() -> None:
+    listed_ids = [item["id"] for item in agent_template_list()]
+    assert "langgraph_composio" in listed_ids
+
+
+def test_sanitize_exec_env_passes_connector_ref() -> None:
+    env = gateway_core.sanitize_exec_env(
+        "hello",
+        {"name": "lgc", "agent_id": "a1", "runtime_type": "exec", "connector_ref": "my_composio"},
+    )
+    assert env["AX_GATEWAY_CONNECTOR_REF"] == "my_composio"
+
+
+def test_run_connector_round_search_only(monkeypatch) -> None:
+    sys.path.insert(0, str(BRIDGE_PATH.parent))
+    try:
+        import langgraph_composio_bridge as bridge
+    finally:
+        sys.path.pop(0)
+
+    tool = SimpleNamespace(slug="GITHUB_LIST_STARGAZERS", name="List Stargazers", description="stars")
+    search_result = SimpleNamespace(
+        mode="intent",
+        successful=True,
+        tools=[tool],
+        session_id="sess-1",
+        error=None,
+    )
+
+    def _search(_ref: str, _use_case: str) -> SimpleNamespace:
+        return search_result
+
+    reply = bridge.run_connector_round("list stargazers", "my_composio", search_tools=_search)
+    assert "GITHUB_LIST_STARGAZERS" in reply
+    assert "RUN:" in reply
+
+
+def test_run_connector_round_executes_run_directive() -> None:
+    sys.path.insert(0, str(BRIDGE_PATH.parent))
+    try:
+        import langgraph_composio_bridge as bridge
+    finally:
+        sys.path.pop(0)
+
+    search_result = SimpleNamespace(mode="catalog", successful=True, tools=[], session_id=None, error=None)
+    call_result = SimpleNamespace(
+        successful=True,
+        error=None,
+        data={"count": 3},
+        to_dict=lambda: {"successful": True, "data": {"count": 3}},
+    )
+
+    executed: list[tuple[str, str, dict]] = []
+
+    def _search(_ref: str, _use_case: str) -> SimpleNamespace:
+        return search_result
+
+    def _execute(ref: str, slug: str, args: dict) -> SimpleNamespace:
+        executed.append((ref, slug, args))
+        return call_result
+
+    prompt = 'RUN:GITHUB_LIST_STARGAZERS {"owner":"ComposioHQ","repo":"composio"}'
+    reply = bridge.run_connector_round(
+        prompt,
+        "my_composio",
+        search_tools=_search,
+        execute_tool=_execute,
+    )
+    assert executed == [("my_composio", "GITHUB_LIST_STARGAZERS", {"owner": "ComposioHQ", "repo": "composio"})]
+    assert "RUN:GITHUB_LIST_STARGAZERS" in reply
+
+
+def test_bridge_main_requires_connector_ref(monkeypatch, capsys) -> None:
+    sys.path.insert(0, str(BRIDGE_PATH.parent))
+    try:
+        import langgraph_composio_bridge as bridge
+    finally:
+        sys.path.pop(0)
+
+    monkeypatch.delenv("AX_GATEWAY_CONNECTOR_REF", raising=False)
+    monkeypatch.setattr(sys, "argv", ["langgraph_composio_bridge.py", "hello"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    rc = bridge.main()
+    assert rc == 1
+    assert "AX_GATEWAY_CONNECTOR_REF" in capsys.readouterr().err
+
+
+def test_bridge_main_emits_lifecycle_with_mocked_round(monkeypatch, capsys) -> None:
+    sys.path.insert(0, str(BRIDGE_PATH.parent))
+    try:
+        import langgraph_composio_bridge as bridge
+    finally:
+        sys.path.pop(0)
+
+    monkeypatch.setenv("AX_GATEWAY_CONNECTOR_REF", "demo")
+    monkeypatch.setattr(sys, "argv", ["langgraph_composio_bridge.py", "find github tools"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(
+        bridge,
+        "run_connector_round",
+        lambda prompt, ref, **kw: f"ok:{ref}:{prompt}",
+    )
+
+    rc = bridge.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+
+    statuses = []
+    for line in captured.out.splitlines():
+        if not line.startswith(bridge.EVENT_PREFIX):
+            continue
+        payload = json.loads(line[len(bridge.EVENT_PREFIX) :])
+        if payload.get("kind") == "status":
+            statuses.append(payload.get("status"))
+    assert "processing" in statuses
+    assert "completed" in statuses
+    assert "ok:demo:find github tools" in captured.out
+
+
+def test_register_langgraph_composio_requires_connector_ref(tmp_path, monkeypatch) -> None:
+    from ax_cli.commands import gateway as gateway_cmd
+
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    with pytest.raises(ValueError, match="connector-ref"):
+        gateway_cmd._register_managed_agent(
+            name="lgc",
+            template_id="langgraph_composio",
+            connector_ref=None,
+        )

--- a/tests/test_gateway_ui_connectors.py
+++ b/tests/test_gateway_ui_connectors.py
@@ -1,0 +1,115 @@
+"""Gateway operator UI: connectors API and dashboard shell."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from contextlib import closing
+
+import httpx
+
+from ax_cli import gateway as gateway_core
+from ax_cli.commands import gateway as gateway_cmd
+from ax_cli.connectors import AUTH_REF_MANAGED, add_connector, load_connectors_registry, save_connectors_registry
+
+
+def test_render_gateway_ui_page_includes_connectors_panel():
+    page = gateway_cmd._render_gateway_ui_page(refresh_ms=2000)
+    assert "Outbound Connectors" in page
+    assert "/api/connectors" in page
+    assert "connector-rows" in page
+    assert "add-connector-form" in page
+    assert "renderConnectors" in page
+
+
+def test_connectors_list_payload_redacts_secrets(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    add_connector(
+        reg,
+        name="ui_conn",
+        provider="composio",
+        auth_ref=AUTH_REF_MANAGED,
+        config={"user_id": "ent-1", "allowed_tools": ["GITHUB_*"]},
+    )
+    save_connectors_registry(reg)
+    (tmp_path / "connectors" / "auth").mkdir(parents=True, exist_ok=True)
+    row = reg["connectors"][0]
+    (tmp_path / "connectors" / "auth" / f"{row['id']}.env").write_text(
+        "COMPOSIO_API_KEY=secret-value\n",
+        encoding="utf-8",
+    )
+    payload = gateway_cmd._connectors_list_payload()
+    assert payload["count"] == 1
+    summary = payload["connectors"][0]
+    assert summary["name"] == "ui_conn"
+    assert "secret" not in json.dumps(payload)
+    assert summary["auth_env_keys"] == ["COMPOSIO_API_KEY"]
+
+
+def test_gateway_ui_connectors_api_crud(monkeypatch, tmp_path):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    monkeypatch.setattr(gateway_core, "_scan_gateway_process_pids", lambda: [])
+    monkeypatch.setattr(gateway_core, "_scan_gateway_ui_process_pids", lambda: [])
+
+    handler = gateway_cmd._build_gateway_ui_handler(activity_limit=5, refresh_ms=1500)
+    with closing(socket.socket()) as probe:
+        probe.bind(("127.0.0.1", 0))
+        host, port = probe.getsockname()
+    server = gateway_cmd._GatewayUiServer((host, port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with httpx.Client(base_url=f"http://{host}:{port}", timeout=2.0) as client:
+            created = client.post(
+                "/api/connectors",
+                json={
+                    "name": "dash_composio",
+                    "provider": "composio",
+                    "managed_auth": True,
+                    "config": {"user_id": "u1", "allowed_tools": ["GITHUB_*"]},
+                },
+            )
+            assert created.status_code == 201
+            assert created.json()["connector"]["name"] == "dash_composio"
+            assert "secret" not in created.text
+
+            listing = client.get("/api/connectors")
+            assert listing.status_code == 200
+            assert listing.json()["count"] == 1
+
+            status = client.get("/api/status")
+            assert status.status_code == 200
+            body = status.json()
+            assert body["summary"]["connectors"] == 1
+            assert len(body["connectors"]) == 1
+
+            updated = client.put(
+                "/api/connectors/dash_composio",
+                json={"enabled": False},
+            )
+            assert updated.status_code == 200
+            assert updated.json()["summary"]["enabled"] is False
+
+            removed = client.delete("/api/connectors/dash_composio")
+            assert removed.status_code == 200
+            assert client.get("/api/connectors").json()["count"] == 0
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def test_status_payload_includes_connectors_summary(monkeypatch, tmp_path):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    reg = load_connectors_registry()
+    add_connector(reg, name="c1", provider="composio", enabled=True)
+    save_connectors_registry(reg)
+    gateway_core.save_gateway_registry({"agents": [], "gateway": {"gateway_id": "gw-test"}})
+    monkeypatch.setattr(gateway_cmd, "daemon_status", lambda: {"running": False, "pid": None, "registry": {"agents": [], "gateway": {}}})
+    monkeypatch.setattr(gateway_cmd, "ui_status", lambda: {"running": False, "pid": None, "host": "127.0.0.1", "port": 8765, "url": "", "log_path": ""})
+    monkeypatch.setattr(gateway_cmd, "load_gateway_session", lambda: None)
+    payload = gateway_cmd._status_payload()
+    assert payload["summary"]["connectors"] == 1
+    assert payload["connectors_summary"]["total"] == 1

--- a/tests/test_gateway_ui_connectors.py
+++ b/tests/test_gateway_ui_connectors.py
@@ -21,6 +21,22 @@ def test_render_gateway_ui_page_includes_connectors_panel():
     assert "connector-rows" in page
     assert "add-connector-form" in page
     assert "renderConnectors" in page
+    assert "populateConnectorProviderSelect" in page
+    assert "connector-base-url" in page
+
+
+def test_connectors_providers_api_payload():
+    payload = gateway_cmd.providers_payload()
+    ids = {row["id"] for row in payload["providers"]}
+    assert "composio" in ids
+    assert "http_mcp" in ids
+
+
+def test_connectors_list_payload_includes_provider_catalog(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    payload = gateway_cmd._connectors_list_payload()
+    catalog = payload.get("provider_catalog") or []
+    assert any(row.get("id") == "http_mcp" for row in catalog)
 
 
 def test_connectors_list_payload_redacts_secrets(tmp_path, monkeypatch):
@@ -84,6 +100,10 @@ def test_gateway_ui_connectors_api_crud(monkeypatch, tmp_path):
             body = status.json()
             assert body["summary"]["connectors"] == 1
             assert len(body["connectors"]) == 1
+            providers = client.get("/api/connectors/providers")
+            assert providers.status_code == 200
+            provider_ids = {row["id"] for row in providers.json().get("providers", [])}
+            assert "http_mcp" in provider_ids
 
             updated = client.put(
                 "/api/connectors/dash_composio",
@@ -113,3 +133,4 @@ def test_status_payload_includes_connectors_summary(monkeypatch, tmp_path):
     payload = gateway_cmd._status_payload()
     assert payload["summary"]["connectors"] == 1
     assert payload["connectors_summary"]["total"] == 1
+    assert any(row.get("id") == "composio" for row in payload.get("connector_providers") or [])

--- a/tests/test_http_mcp_adapter.py
+++ b/tests/test_http_mcp_adapter.py
@@ -1,0 +1,205 @@
+"""Tests for HTTP MCP provider adapter and multi-provider dispatch."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from ax_cli.connectors.auth import AUTH_REF_MANAGED, ensure_managed_auth_file
+from ax_cli.connectors.providers.base import ConnectorProviderError
+from ax_cli.connectors.providers.catalog import SUPPORTED_PROVIDERS, providers_payload
+from ax_cli.connectors.providers.dispatch import (
+    adapter_for_connector,
+    execute_connector_tool,
+    list_connector_tools,
+    search_connector_tools,
+)
+from ax_cli.connectors.providers.http_mcp_adapter import (
+    HttpMcpAdapter,
+    build_http_mcp_adapter,
+    resolve_http_mcp_settings,
+)
+from ax_cli.connectors.registry import add_connector, load_connectors_registry, save_connectors_registry
+from ax_cli.connectors.validation import validate_connector_record
+
+
+def test_providers_payload_includes_composio_and_http_mcp():
+    payload = providers_payload()
+    ids = {row["id"] for row in payload["providers"]}
+    assert ids == set(SUPPORTED_PROVIDERS)
+    composio = next(row for row in payload["providers"] if row["id"] == "composio")
+    http_mcp = next(row for row in payload["providers"] if row["id"] == "http_mcp")
+    assert composio["supports_intent_search"] is True
+    assert http_mcp["supports_intent_search"] is False
+    assert http_mcp["supports_list_tools"] is True
+
+
+def test_validate_rejects_unsupported_provider():
+    with pytest.raises(ValueError, match="unsupported provider"):
+        validate_connector_record(
+            {
+                "id": "id1",
+                "name": "demo",
+                "provider": "unknown_vendor",
+                "enabled": True,
+                "config": {},
+                "metadata": {},
+            }
+        )
+
+
+def test_validate_http_mcp_requires_base_url():
+    with pytest.raises(ValueError, match="base_url"):
+        validate_connector_record(
+            {
+                "id": "id1",
+                "name": "mcp_demo",
+                "provider": "http_mcp",
+                "enabled": True,
+                "config": {},
+                "metadata": {},
+            }
+        )
+
+
+def test_resolve_http_mcp_settings_from_config_and_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    connector = {
+        "id": "mcp-1",
+        "name": "mcp",
+        "provider": "http_mcp",
+        "enabled": True,
+        "auth_ref": AUTH_REF_MANAGED,
+        "config": {"base_url": "https://mcp.example.com/rpc"},
+    }
+    ensure_managed_auth_file("mcp-1")
+    env_path = tmp_path / "connectors" / "auth" / "mcp-1.env"
+    env_path.write_text("MCP_BEARER_TOKEN=secret-token\n", encoding="utf-8")
+    settings = resolve_http_mcp_settings(connector)
+    assert settings["base_url"] == "https://mcp.example.com/rpc"
+    adapter = build_http_mcp_adapter(connector)
+    assert "Bearer secret-token" in adapter._headers.get("Authorization", "")
+
+
+def test_http_mcp_adapter_list_and_execute():
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        calls.append(body)
+        method = body.get("method")
+        if method == "initialize":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": body["id"], "result": {}})
+        if method == "notifications/initialized":
+            return httpx.Response(200, json={})
+        if method == "tools/list":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "echo",
+                                "description": "Echo input",
+                                "inputSchema": {"type": "object"},
+                            }
+                        ]
+                    },
+                },
+            )
+        if method == "tools/call":
+            assert body["params"]["name"] == "echo"
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {"content": [{"type": "text", "text": "ok"}], "isError": False},
+                },
+            )
+        return httpx.Response(400, json={"error": "unexpected"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://mcp.example.com")
+    adapter = HttpMcpAdapter(
+        base_url="https://mcp.example.com/rpc",
+        headers={"Content-Type": "application/json"},
+        skip_initialize=False,
+        client=client,
+    )
+    tools = adapter.list_tools_raw()
+    assert len(tools) == 1
+    assert tools[0]["name"] == "echo"
+    result = adapter.execute_tool("echo", {"message": "hi"})
+    assert result.successful is True
+    assert any(c.get("method") == "tools/call" for c in calls)
+
+
+def test_dispatch_list_and_search_http_mcp(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        method = body.get("method")
+        if method == "initialize":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": body["id"], "result": {}})
+        if method == "notifications/initialized":
+            return httpx.Response(200, json={})
+        if method == "tools/list":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {"tools": [{"name": "ping", "description": "Ping tool"}]},
+                },
+            )
+        return httpx.Response(400, json={})
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def client_factory(*args, **kwargs):
+        return real_client(transport=transport, base_url="https://mcp.test")
+
+    monkeypatch.setattr(
+        "ax_cli.connectors.providers.http_mcp_adapter.httpx.Client",
+        client_factory,
+    )
+
+    reg = load_connectors_registry()
+    rec = add_connector(
+        reg,
+        name="local_mcp",
+        provider="http_mcp",
+        auth_ref=AUTH_REF_MANAGED,
+        config={"base_url": "https://mcp.test/rpc", "skip_initialize": True},
+    )
+    save_connectors_registry(reg)
+    ensure_managed_auth_file(str(rec["id"]))
+
+    page = list_connector_tools("local_mcp")
+    assert page["provider"] == "http_mcp"
+    assert page["count"] == 1
+    assert page["tools"][0]["slug"] == "ping"
+
+    search = search_connector_tools("local_mcp", "ping")
+    assert search.mode == "catalog"
+    assert len(search.tools) == 1
+
+
+def test_adapter_for_connector_rejects_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("AX_GATEWAY_DIR", str(tmp_path))
+    connector = {
+        "id": "x",
+        "name": "x",
+        "provider": "http_mcp",
+        "enabled": False,
+        "config": {"base_url": "https://mcp.test"},
+    }
+    with pytest.raises(ConnectorProviderError, match="disabled"):
+        adapter_for_connector(connector)


### PR DESCRIPTION
## Summary

This PR delivers the full Gateway **outbound connectors** stack (phases 1-10): a versioned connector registry, Gateway-brokered secrets, Composio and HTTP MCP provider adapters, operator tool policy, CLI and dashboard surfaces, activity attribution, a LangGraph demonstration agent, and operator documentation.

### Problem

Managed agents need third-party tools (Composio, MCP servers) without embedding API keys in agent config, registry rows, chat, or logs. Operators need a single place to register connectors, enforce which tools can run, observe executions, and wire demos, while keeping aX user/agent PAT flows separate from provider credentials.

### Solution overview

Gateway becomes the **trust boundary for outbound tools**:

- **Registry** (`connectors.json`) holds connector metadata only, no secrets.
- **Auth** lives in `connectors/auth/<connector-id>.env` (`gateway:managed`) or operator-chosen external env files (`auth_ref`).
- **Providers** execute and discover tools via HTTP (Composio REST API; HTTP MCP JSON-RPC).
- **Policy** filters tool slugs after the provider returns candidates and again at execute time.
- **Activity** records `connector_tool_*` events in `activity.jsonl` with redacted metadata.
- **Agents** receive `AX_GATEWAY_CONNECTOR_REF`, not provider API keys.

---

### Phase 1 - Connector registry and CLI

- Versioned `connectors.json` under `AX_GATEWAY_DIR` (default `~/.ax/gateway`, or env-scoped when `AX_GATEWAY_ENV` is set).
- Validated rows: `id`, `name`, `provider`, `enabled`, `auth_ref`, `config`, `metadata`.
- Atomic read/write via `ax_cli/connectors/storage.py`.
- CLI: `ax gateway connectors list|show|add|remove|set`.
- `ax gateway status --json` includes `connectors_registry_path`.

### Phase 2 - Managed auth

- `auth_ref = gateway:managed` maps secrets to `<gateway_dir>/connectors/auth/<connector_id>.env` with restrictive directory/file permissions.
- External `auth_ref` may point to an absolute env file path (operator-owned permissions).
- CLI: `ax gateway connectors auth bind-managed|status|write`.
- `--managed-auth` on `add`; cleanup on `remove` / clear auth ref.
- `show` and API list payloads expose **redacted** auth status (key names present, never values).

### Phase 3 - Package structure

- `ax_cli/connectors/` split into focused modules:
  - `constants`, `paths`, `storage`, `types`, `validation`
  - `registry`, `auth`, `envfile`, `errors`
  - `filtering`, `activity`
  - `providers/` (base, catalog, dispatch, composio, http_mcp)
- Public API exported from `ax_cli.connectors` for Gateway commands and tests.

### Phase 4 - Composio provider and `connectors call`

- HTTP Composio adapter (`composio_adapter.py`). **No Composio Python SDK** required at install time.
- Resolves settings from connector `config` + auth env (`COMPOSIO_API_KEY`, `user_id`, optional `base_url`).
- `ax gateway connectors call <ref> --tool <SLUG> --args-json '{...}'` with optional `--version`, `--connected-account-id`.
- Provider dispatch layer (`dispatch.py`, `registry.py`) resolves connector row, then adapter, then execute.
- `ax gateway connectors providers` lists supported provider types and capabilities.

### Phase 5 - Activity attribution

- On each `execute_connector_tool`:
  - `connector_tool_started` maps to activity phase `tool`
  - `connector_tool_completed` maps to `tool`
  - `connector_tool_failed` maps to `result`
- Payload includes redacted connector fields (`connector_name`, `connector_id`, `provider`, `tool_name` as `provider/SLUG`).
- Optional `agent_name` (or `linked_agent`) in connector `config` links rows to a Gateway registry agent when that agent exists.
- Visible via `ax gateway activity`.

### Phase 6 - Tool policy and discovery

- `ToolFilterPolicy` with fnmatch `allowed_tools` / `denied_tools`, toolkit filters, and `tools_limit` (default 50, max 200).
- Policy applied to Composio catalog listing, `COMPOSIO_SEARCH_TOOLS` intent results, and **blocked at execute** via `assert_tool_allowed`.
- CLI:
  - `ax gateway connectors tools list <ref> [--query] [--toolkit] [--limit]`
  - `ax gateway connectors tools search <ref> --use-case "..." [--mode auto|intent|catalog]`
- `ConnectorProviderError` moved to `errors.py` to avoid circular imports.

### Phase 7 - LangGraph + Composio demo

- New agent template `langgraph_composio` in `gateway_runtime_types.py`.
- `--connector-ref` on `agents add` / `agents update` (required for this template).
- Exec env sets `AX_GATEWAY_CONNECTOR_REF` from the agent registry row.
- Example bridge: `examples/gateway_langgraph_composio/langgraph_composio_bridge.py`
  - Intent search via `search_connector_tools`
  - Optional execute when mention includes `RUN:<TOOL_SLUG> {"arg": "value"}`
  - Emits Gateway event lines for search phases.

### Phase 8 - Operator docs and skills

- `docs/composio-integration.md`: golden-path setup, config keys, security checklist, troubleshooting.
- `skills/gateway-composio-connectors/SKILL.md`: agent-oriented connector setup guidance.
- Cross-links in `docs/gateway-agent-runtimes.md`, `skills/gateway-agent-setup/SKILL.md`, root `skills/SKILL.md`.
- Doc wiring tests in `tests/test_composio_integration_docs.py`.

### Phase 9 - Gateway dashboard UI and API

- Operator dashboard **Outbound Connectors** panel (HTML/JS in `ax_cli/commands/gateway.py`).
- REST API:
  - `GET/POST /api/connectors`
  - `GET/PATCH/DELETE /api/connectors/<ref>`
  - `GET /api/connectors/providers`
  - Tool list/search sub-routes with redacted payloads
- `/api/status` includes connector summary metrics.
- Agent setup UI: `connector_ref` field (required hint for `langgraph_composio`).
- Tests: `tests/test_gateway_ui_connectors.py` (CRUD, redaction, provider catalog).

### Phase 10 - HTTP MCP provider and multi-provider catalog

- Provider catalog (`providers/catalog.py`): `composio`, `http_mcp` with capability flags (`execute`, `list_tools`, `intent_search`).
- `http_mcp` adapter: JSON-RPC over HTTP for tool list and execute when `base_url` (and auth) configured.
- Provider-aware dispatch for list/search/execute across CLI and dashboard.
- Tests: `tests/test_http_mcp_adapter.py`.

---

### Files touched (high level)

| Area | Paths |
|------|--------|
| Core package | `ax_cli/connectors/**` |
| CLI + UI | `ax_cli/commands/gateway.py` (+connector typer apps, dashboard, APIs) |
| Gateway core | `ax_cli/gateway.py` (status paths, activity event types, `AX_GATEWAY_CONNECTOR_REF`) |
| Templates | `ax_cli/gateway_runtime_types.py` |
| Example | `examples/gateway_langgraph_composio/**` |
| Docs / skills | `docs/composio-integration.md`, `skills/gateway-composio-connectors/**` |
| Tests | `tests/test_connectors_*.py`, `tests/test_gateway_*_composio*.py`, `tests/test_gateway_ui_connectors.py`, `tests/test_http_mcp_adapter.py` |

~42 files, ~5.6k lines added (including dashboard UI/JS).

---

### What this does **not** change

- User login PAT flow (`~/.ax/user.toml`) and agent runtime PAT minting are unchanged.
- Composio keys are **connector** credentials, not aX agent tokens.
- This is not Claude Code Channel MCP (`ax channel setup`); connectors call provider HTTP APIs directly with Gateway policy.

## Validation

- [ ] `uv run pytest tests/test_connectors_registry.py tests/test_connectors_auth.py tests/test_connectors_package.py -v --tb=short`
- [ ] `uv run pytest tests/test_connectors_composio_adapter.py tests/test_connectors_activity.py tests/test_connectors_filtering.py -v --tb=short`
- [ ] `uv run pytest tests/test_gateway_langgraph_composio_demo.py tests/test_composio_integration_docs.py -v --tb=short`
- [ ] `uv run pytest tests/test_gateway_ui_connectors.py tests/test_http_mcp_adapter.py -v --tb=short`
- [ ] `uv run pytest tests/test_gateway_commands.py -v --tb=short` (if connector-ref / template assertions apply)
- [ ] `uv run ruff check ax_cli/`
- [ ] `uv run ruff format --check ax_cli/`
- [ ] `python -m build && twine check dist/*`
- [ ] `pip install -e .` then `ax gateway login && ax gateway start`
- [ ] Register Composio connector: `add --managed-auth`, `auth write`, `auth status` (redacted)
- [ ] `ax gateway connectors tools search` and `tools list` with `allowed_tools` / `denied_tools`
- [ ] `ax gateway connectors call` against a known tool slug (mocked in CI; real key optional locally)
- [ ] `ax gateway agents add ... --template langgraph_composio --connector-ref ...` and mention search / `RUN:` execute
- [ ] Gateway dashboard: connectors CRUD, no secret values in JSON responses, tool search works
- [ ] Optional: `http_mcp` connector register + list tools
- [ ] `axctl auth doctor` reviewed for the target env/space, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior
- [ ] `axctl qa preflight` passed for the target env/space before MCP Jam, widget, or Playwright validation
- [ ] `axctl qa matrix` passed before promotion or cross-env/release validation
- [ ] Live aX smoke test, if this changes auth, messages, uploads, listeners, MCP, UI validation, or release behavior

## Release Notes

- [x] This should appear in the changelog (`feat:`, `fix:`, or breaking change)
- [ ] This is internal/docs/test-only and does not need a package release

**Proposed changelog entry:**

`feat(gateway): outbound connectors - Composio and http_mcp providers, managed auth, tool policy, CLI, dashboard, and LangGraph demo`

## Credential / Auth Impact

- [ ] No token, profile, PAT, JWT, or agent identity behavior changed
- [x] Auth behavior changed and the docs/tests were updated

**Details:**

| Surface | Change |
|---------|--------|
| User / agent aX PATs | Unchanged |
| Connector secrets | **New**: Gateway-managed `.env` under `connectors/auth/` or external `auth_ref` paths |
| Agent runtime | Receives `AX_GATEWAY_CONNECTOR_REF` only; no Composio/MCP keys in exec env |
| Registry / activity / API | Redacted; never includes secret values |
| Dashboard | Lists auth **key names** only; values never returned |

Operator docs: `docs/composio-integration.md`. Security checklist and troubleshooting table included there.